### PR TITLE
transmorgify.hpp: vector to tuple instead of list

### DIFF
--- a/nix/test/test_data_array.py
+++ b/nix/test/test_data_array.py
@@ -97,20 +97,20 @@ class TestDataArray(unittest.TestCase):
         assert(self.array.expansion_origin is None)
 
     def test_data_array_coefficients(self):
-        assert(self.array.polynom_coefficients == [])
+        assert(self.array.polynom_coefficients == ())
 
-        self.array.polynom_coefficients = [1.1, 2.2]
-        assert(self.array.polynom_coefficients == [1.1, 2.2])
+        self.array.polynom_coefficients = (1.1, 2.2)
+        assert(self.array.polynom_coefficients == (1.1, 2.2))
 
         # TODO delete does not work
 
     def test_data_array_data(self):
         import numpy as np
 
-        assert(self.array.polynom_coefficients == [])
+        assert(self.array.polynom_coefficients == ())
         assert(not self.array.has_data())
 
-        data = [float(i) for i in range(100)]
+        data = tuple([float(i) for i in range(100)])
         self.array.data = data
         assert(self.array.has_data())
         assert(self.array.data == data)

--- a/nix/test/test_dimensions.py
+++ b/nix/test/test_dimensions.py
@@ -10,10 +10,10 @@ import unittest
 
 from nix import *
 
-test_range  = [float(i) for i in range(10)]
+test_range  = tuple([float(i) for i in range(10)])
 test_sampl  = 0.1
 test_label  = "test label"
-test_labels = [str(i) + "_label" for i in range(10)]
+test_labels = tuple([str(i) + "_label" for i in range(10)])
 
 class TestDimensions(unittest.TestCase):
 
@@ -34,7 +34,7 @@ class TestDimensions(unittest.TestCase):
         assert(self.set_dim.index == 1)
         assert(self.set_dim.dimension_type == DimensionType.Set)
 
-        assert(self.set_dim.labels == [])
+        assert(self.set_dim.labels == ())
         self.set_dim.labels = test_labels
         assert(self.set_dim.labels == test_labels)
 
@@ -81,7 +81,7 @@ class TestDimensions(unittest.TestCase):
         assert(self.range_dim.unit is None)
 
         assert(self.range_dim.ticks == test_range)
-        other = [i*3.14 for i in range(10)]
+        other = tuple([i*3.14 for i in range(10)])
         self.range_dim.ticks = other
         assert(self.range_dim.ticks == other)
 

--- a/nix/test/test_simple_tag.py
+++ b/nix/test/test_simple_tag.py
@@ -79,37 +79,37 @@ class TestSimpleTag(unittest.TestCase):
         assert(self.my_tag.created_at == 1403530068)
 
     def test_simple_tag_units(self):
-        assert(self.my_tag.units == [])
+        assert(self.my_tag.units == ())
 
         self.my_tag.units = ["mV", "ms"]
-        assert(self.my_tag.units == ["mV", "ms"])
+        assert(self.my_tag.units == ("mV", "ms"))
 
         # TODO append / remove does not work, make tuple?
 
         self.my_tag.units = []
-        assert(self.my_tag.units == [])
+        assert(self.my_tag.units == ())
 
     def test_simple_tag_position(self):
-        assert(self.my_tag.position == [])
+        assert(self.my_tag.position == ())
 
-        self.my_tag.position = [1.0, 2.0, 3.0]
-        assert(self.my_tag.position == [1.0, 2.0, 3.0])
+        self.my_tag.position = (1.0, 2.0, 3.0)
+        assert(self.my_tag.position == (1.0, 2.0, 3.0))
 
         # TODO append / remove does not work, make tuple?
 
         self.my_tag.position = []
-        assert(self.my_tag.position == [])
+        assert(self.my_tag.position == ())
 
     def test_simple_tag_extent(self):
-        assert(self.my_tag.extent == [])
+        assert(self.my_tag.extent == ())
 
-        self.my_tag.extent = [1.0, 2.0, 3.0]
-        assert(self.my_tag.extent == [1.0, 2.0, 3.0])
+        self.my_tag.extent = (1.0, 2.0, 3.0)
+        assert(self.my_tag.extent == (1.0, 2.0, 3.0))
 
         # TODO append / remove does not work, make tuple?
 
         self.my_tag.extent = []
-        assert(self.my_tag.extent == [])
+        assert(self.my_tag.extent == ())
 
     def test_simple_tag_references(self):
         assert(len(self.my_tag.references) == 1)

--- a/src/transmorgify.hpp
+++ b/src/transmorgify.hpp
@@ -22,13 +22,15 @@ namespace nixpy {
 template<typename T>
 struct vector_transmogrify {
     static PyObject* convert(const std::vector<T>& vec) {
-        boost::python::list l = boost::python::list();
+        namespace bp = boost::python;
+
+        bp::list l = bp::list();
 
         for(auto& item : vec) {
             l.append(item);
         }
 
-        return boost::python::incref(l.ptr());
+        return bp::incref(bp::tuple(l).ptr());
     }
 
     typedef boost::python::converter::rvalue_from_python_stage1_data py_s1_data;


### PR DESCRIPTION
std::vector is now converted to tuple instead of list
but it is still possible to convert every python sequence to
std::vector

fixes issue #24
