### PR TITLE
RefProxyList got an extend method much like lists have 

### DIFF
--- a/nix/test/test_source.py
+++ b/nix/test/test_source.py
@@ -19,6 +19,8 @@ class TestSource(unittest.TestCase):
         self.block  = self.file.create_block("test block", "recordingsession")
         self.source = self.block.create_source("test source", "recordingchannel")
         self.other  = self.block.create_source("other source", "sometype")
+        self.third  = self.block.create_source("third source", "sometype")
+        self.array  = self.block.create_data_array("test array", "test type", dtype=DataType.Double, shape=(1,1))
 
     def tearDown(self):
         del self.file.blocks[self.block.id]
@@ -92,3 +94,10 @@ class TestSource(unittest.TestCase):
         assert(len(self.source.find_sources(limit=1)) == 3)
         assert(len(self.source.find_sources(filtr=lambda x : "level2-p1-s" in x.name)) == 2)
         assert(len(self.source.find_sources(filtr=lambda x : "level2-p1-s" in x.name, limit=1)) == 0)
+
+    def test_sources_extend(self):
+        assert(len(self.array.sources) == 0)
+        self.array.sources.extend([self.source, self.other])
+        assert(len(self.array.sources) == 2)
+        self.array.sources.extend(self.third)
+        assert(len(self.array.sources) == 3)

--- a/nix/util/proxy_list.py
+++ b/nix/util/proxy_list.py
@@ -99,3 +99,9 @@ class RefProxyList(ProxyList):
             self.__appender(key)
         else:
             raise TypeError("The only id strings or entities can be appended")
+
+    def extend(self, keys):
+        if hasattr(keys, '__iter__'):
+            map(self.append, keys)
+        else:
+            self.append(keys)


### PR DESCRIPTION
to avoid code like this

````
  array.sources.append(source1)
  array.sources.append(source2)
````

RefProxyList got an extend method that appends a list of elements

````
  array.sources.extend([source1, source2])
````

Regarding the test case: I put it into the TestSources, probably not the perfect place. so let me know where you would prefer it.