### PR TITLE
Exceptions wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.pyo
 *.egg
 *.egg-info
+docs
 dist
 build
 eggs

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,10 @@
 *.pyo
 *.egg
 *.egg-info
-docs
+docs/source/*.html
+docs/source/*.h5
+docs/source/images
+docs/source/_*
 dist
 build
 eggs

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ else:
 nixpy_sources = [
     'src/core.cc',
     'src/docstrings.cpp',
+    'src/PyExceptions.cpp',
     'src/PyBlock.cpp',
     'src/PyFile.cpp',
     'src/PySection.cpp',

--- a/src/PyEntity.hpp
+++ b/src/PyEntity.hpp
@@ -164,6 +164,9 @@ struct PyMultiTag {
     static void do_export();
 };
 
+struct PyException {
+    static void do_export();
+};
 }
 
 #endif

--- a/src/PyExceptions.cpp
+++ b/src/PyExceptions.cpp
@@ -25,20 +25,28 @@ using namespace boost::python;
 namespace nixpy {
 
 static bool emptyMessage(const char* message) {
-  return std::strlen(message) == 0;
+    return std::strlen(message) == 0;
 }
 
 static void translateOutOfBounds(const nix::OutOfBounds &e) {
-    PyErr_SetString(PyExc_RuntimeError, e.what());
+    if (emptyMessage(e.what())) {
+        PyErr_SetString(PyExc_IndexError, "Attempt to access data with an index that is out of bounds!");
+    } else {
+        PyErr_SetString(PyExc_IndexError, e.what());
+    }
 }
 
 static void translateDuplicateName(const nix::DuplicateName &e) {
-    PyErr_SetString(PyExc_RuntimeError, e.what());
+    if (emptyMessage(e.what())) {
+        PyErr_SetString(PyExc_RuntimeError, "Duplicate name given - names have to be unique for a given entity type & parent.");
+    } else {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+    }
 }
 
 void PyException::do_export() {
-  register_exception_translator<nix::OutOfBounds>(&translateOutOfBounds);
-  register_exception_translator<nix::DuplicateName>(&translateDuplicateName);
+    register_exception_translator<nix::OutOfBounds>(&translateOutOfBounds);
+    register_exception_translator<nix::DuplicateName>(&translateDuplicateName);
 }
 
 }

--- a/src/PyExceptions.cpp
+++ b/src/PyExceptions.cpp
@@ -44,9 +44,81 @@ static void translateDuplicateName(const nix::DuplicateName &e) {
     }
 }
 
+static void translateInvalidName(const nix::InvalidName &e) {
+    if (emptyMessage(e.what())) {
+        PyErr_SetString(PyExc_NameError, "Invalid name given - names have to be sanitized using util function.");
+    } else {
+        PyErr_SetString(PyExc_NameError, e.what());
+    }
+}
+
+static void translateEmptyString(const nix::EmptyString &e) {
+    if (emptyMessage(e.what())) {
+        PyErr_SetString(PyExc_NameError, "Empty string given - not a valid value for this field.");
+    } else {
+        PyErr_SetString(PyExc_NameError, e.what());
+    }
+}
+
+static void translateMissingAttr(const nix::MissingAttr &e) {
+    if (emptyMessage(e.what())) {
+        PyErr_SetString(PyExc_AttributeError, "Obligatory attribute is not set!");
+    } else {
+        PyErr_SetString(PyExc_AttributeError, e.what());
+    }
+}
+
+static void translateUninitializedEntity(const nix::UninitializedEntity &e) {
+    if (emptyMessage(e.what())) {
+        PyErr_SetString(PyExc_RuntimeError, "The Entity being accessed is uninitialized.");
+    } else {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+    }
+}
+
+static void translateUnsortedTicks(const nix::UnsortedTicks &e) {
+    if (emptyMessage(e.what())) {
+        PyErr_SetString(PyExc_ValueError, "Ticks are not given in a ascending order.");
+    } else {
+        PyErr_SetString(PyExc_ValueError, e.what());
+    }
+}
+
+static void translateIncompatibleDimensions(const nix::IncompatibleDimensions &e) {
+    if (emptyMessage(e.what())) {
+        PyErr_SetString(PyExc_ValueError, "The dimension descriptor is not compatible with the one stored int the dataArray!");
+    } else {
+        PyErr_SetString(PyExc_ValueError, e.what());
+    }
+}
+
+static void translateInvalidDimension(const nix::InvalidDimension &e) {
+    if (emptyMessage(e.what())) {
+        PyErr_SetString(PyExc_ValueError, "The provided dimension descriptor is invalid in this context!");
+    } else {
+        PyErr_SetString(PyExc_ValueError, e.what());
+    }
+}
+
+static void translateInvalidRank(const nix::InvalidRank &e) {
+    if (emptyMessage(e.what())) {
+        PyErr_SetString(PyExc_IndexError, "Invalid rank!");
+    } else {
+        PyErr_SetString(PyExc_IndexError, e.what());
+    }
+}
+
 void PyException::do_export() {
     register_exception_translator<nix::OutOfBounds>(&translateOutOfBounds);
     register_exception_translator<nix::DuplicateName>(&translateDuplicateName);
+    register_exception_translator<nix::InvalidName>(&translateInvalidName);
+    register_exception_translator<nix::EmptyString>(&translateEmptyString);
+    register_exception_translator<nix::InvalidRank>(&translateInvalidRank);
+    register_exception_translator<nix::InvalidDimension>(&translateInvalidDimension);
+    register_exception_translator<nix::IncompatibleDimensions>(&translateIncompatibleDimensions);
+    register_exception_translator<nix::UnsortedTicks>(&translateUnsortedTicks);
+    register_exception_translator<nix::UninitializedEntity>(&translateUninitializedEntity);
+    register_exception_translator<nix::MissingAttr>(&translateMissingAttr);
 }
 
 }

--- a/src/PyExceptions.cpp
+++ b/src/PyExceptions.cpp
@@ -24,6 +24,10 @@ using namespace boost::python;
 
 namespace nixpy {
 
+static bool emptyMessage(const char* message) {
+  return std::strlen(message) == 0;
+}
+
 static void translateOutOfBounds(const nix::OutOfBounds &e) {
     PyErr_SetString(PyExc_RuntimeError, e.what());
 }

--- a/src/PyExceptions.cpp
+++ b/src/PyExceptions.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2014, German Neuroinformatics Node (G-Node)
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted under the terms of the BSD License. See
+// LICENSE source in the root of the Project.
+
+#include <boost/python.hpp>
+#include <boost/optional.hpp>
+#include <boost/python/module.hpp>
+#include <boost/python/def.hpp>
+#include <boost/python/exception_translator.hpp>
+
+#include <nix.hpp>
+
+#include <accessors.hpp>
+#include <transmorgify.hpp>
+
+#include <PyEntity.hpp>
+
+using namespace nix;
+using namespace boost::python;
+
+namespace nixpy {
+
+static void translateOutOfBounds(const nix::OutOfBounds &e) {
+    PyErr_SetString(PyExc_RuntimeError, e.what());
+}
+
+static void translateDuplicateName(const nix::DuplicateName &e) {
+    PyErr_SetString(PyExc_RuntimeError, e.what());
+}
+
+void PyException::do_export() {
+  register_exception_translator<nix::OutOfBounds>(&translateOutOfBounds);
+  register_exception_translator<nix::DuplicateName>(&translateDuplicateName);
+}
+
+}

--- a/src/core.cc
+++ b/src/core.cc
@@ -37,6 +37,8 @@ BOOST_PYTHON_MODULE(core)
     PyTag::do_export();
     PyMultiTag::do_export();
 
+    PyException::do_export();
+
     to_python_converter<boost::optional<std::string>, option_transmogrify<std::string>>();
     option_transmogrify<std::string>::register_from_python();
 


### PR DESCRIPTION
Related by Ajays bug report #114: On the nix side the exceptions are correctly thrown, with correct messages etc. On the nixpy side they sometimes loose the messages. 

I explicitly wrapped the nix exceptions to python exceptions checking for empty messages and, in these instances, giving "standard" error messages.  
It is kind of ugly but works.