### PR TITLE
Util::split_compound fix and doc strings

### DIFF
--- a/nix/test/test_util.py
+++ b/nix/test/test_util.py
@@ -64,7 +64,7 @@ class TestUtil(unittest.TestCase):
         atomics = units.split_compound(unit_1)
         assert(len(atomics) == 2)
         # FIXME the following is not entirely correct should be Hz^-1, needs to be fixed in nix!
-        assert(atomics[0] == "mV^2" and atomics[1] == "Hz")
+        assert(atomics[0] == "mV^2" and atomics[1] == "Hz^-1")
 
         atomics = units.split_compound(unit_2)
         assert(len(atomics) == 2)

--- a/src/PyUtil.cpp
+++ b/src/PyUtil.cpp
@@ -14,6 +14,7 @@
 
 #include <accessors.hpp>
 #include <transmorgify.hpp>
+#include <docstrings.hpp>
 
 #include <PyUtil.hpp>
 
@@ -49,14 +50,14 @@ struct NameWrap {};
 
 void PyUtil::do_export() {
   class_<UnitWrap> ("units")
-  .def("sanitizer", util::unitSanitizer).staticmethod("sanitizer")
-  .def("is_si", util::isSIUnit).staticmethod("is_si")
-  .def("is_atomic", util::isAtomicSIUnit).staticmethod("is_atomic")
-  .def("is_compound", util::isCompoundSIUnit).staticmethod("is_compound")
-  .def("scalable", &isScalableMultiUnits).staticmethod("scalable")
-  .def("scaling", util::getSIScaling).staticmethod("scaling")
-  .def("split", &splitUnit).staticmethod("split")
-  .def("split_compound", &splitCompound).staticmethod("split_compound")
+  .def("sanitizer", util::unitSanitizer, doc::unit_sanitizer).staticmethod("sanitizer")
+  .def("is_si", util::isSIUnit, doc::unit_is_si).staticmethod("is_si")
+  .def("is_atomic", util::isAtomicSIUnit, doc::unit_is_atomic).staticmethod("is_atomic")
+  .def("is_compound", util::isCompoundSIUnit, doc::unit_is_compound).staticmethod("is_compound")
+  .def("scalable", &isScalableMultiUnits, doc::unit_scalable).staticmethod("scalable")
+  .def("scaling", util::getSIScaling, doc::unit_scaling).staticmethod("scaling")
+  .def("split", &splitUnit, doc::unit_split).staticmethod("split")
+  .def("split_compound", &splitCompound, doc::unit_compound_split).staticmethod("split_compound")
   ;
 
   class_<NameWrap> ("names")

--- a/src/PyUtil.cpp
+++ b/src/PyUtil.cpp
@@ -61,9 +61,9 @@ void PyUtil::do_export() {
   ;
 
   class_<NameWrap> ("names")
-  .def("sanitizer", util::nameSanitizer).staticmethod("sanitizer")
-  .def("check", util::nameCheck).staticmethod("check")
-  .def("create_id", util::createId).staticmethod("create_id")
+  .def("sanitizer", util::nameSanitizer, doc::name_sanitizer).staticmethod("sanitizer")
+  .def("check", util::nameCheck, doc::name_check).staticmethod("check")
+  .def("create_id", util::createId, doc::create_id).staticmethod("create_id")
   ;
 }
 

--- a/src/docstrings.cpp
+++ b/src/docstrings.cpp
@@ -640,6 +640,31 @@ const char* unit_scaling = R"(
     :rtype: double
     )";
 
+const char* name_sanitizer = R"(
+    Sanitizes a string supposed to be an entity name. That is,
+    invalid characters like slashes are substituted with underscores.
+
+    :param name: A string representing the name.
+
+    :returns: The sanitized name.
+    :rtype: str
+    )";
+
+const char* name_check = R"(
+    Checks a string whether is needs to be sanitized.
+
+    :param name: The name.
+
+    :returns: True if the name is valid, false otherwise.
+    :rtype: bool
+    )";
+
+const char* create_id = R"(
+    Creates an ID as used for nix entities.
+
+    :returns: The ID.
+    :rtype: str
+    )";
 
 }
 }

--- a/src/docstrings.cpp
+++ b/src/docstrings.cpp
@@ -561,6 +561,85 @@ const char* result_has_errors = R"(
     :rtype: bool
     )";
 
+// PyUtil
+
+const char* unit_is_si = R"(
+    Determines whether a unit is a recognized SI unit.
+
+    :param unit: The unit that needs to be checked.
+
+    :returns: True if the unit is an SI unit, false otherwise.
+    :rtype: bool
+    )";
+
+const char* unit_sanitizer = R"(
+    Sanitizes a unit string. That is, it is de-blanked, and mu and µ symbols are changed
+    to u for micro.
+
+    :param unit: The unit that needs to be sanitized.
+
+    :returns: the sanitized unit.
+    :rtype: str
+    )";
+
+const char* unit_is_atomic = R"(
+    Checked whether a unit string represents an atomic si unit, i.e. not a
+    combination.
+
+    :param unit: The unit to be checked.
+
+    :returns: True if unit is atomic, False otherwise.
+    :rtype: bool
+    )";
+
+const char* unit_is_compound = R"(
+    Checks whether a unit string represents a combination of SI units.
+
+    :param unit: The unit string.
+
+    :returns: True if the unit string represents a combination of SI units, False otherwise.
+    :rtype: bool
+    )";
+
+const char* unit_split = R"(
+    Splits a unit string into magnitude prefix, the base unit, and the power.
+
+    :param unit: The unit string.
+
+    :returns: A tuple of prefix, base unit, and power.
+    :rtype: tuple
+    )";
+
+const char* unit_compound_split = R"(
+    Splits a compound unit (like mV/Hz) into the atomic units.
+
+    :param unit: The unit string.
+
+    :returns: A tuple containing the atomic units.
+    :rtype: tuple
+    )";
+
+const char* unit_scalable = R"(
+    Checks whether units are scalable versions of the same SI unit. Method works on two lists and
+    compares the corresponding units in both lists.
+
+    :param units_1: List of unit strings.
+    :param units_2: List of unit strings.
+
+    :returns: True if all corresponding units are scalable.
+    :rtype: bool
+    )";
+
+const char* unit_scaling = R"(
+    Returns the scaling factor to convert from unit_1 to unit_2.
+
+    :param unit_1: The unit string.
+    :param unit_2: The unit string.
+
+    :returns: The scaling factor.
+    :rtype: double
+    )";
+
 
 }
 }

--- a/src/docstrings.hpp
+++ b/src/docstrings.hpp
@@ -175,6 +175,13 @@ extern const char* unit_compound_split;
 extern const char* unit_scalable;
 
 extern const char* unit_scaling;
+
+extern const char* name_sanitizer;
+
+extern const char* name_check;
+
+extern const char* create_id;
+
 }
 }
 

--- a/src/docstrings.hpp
+++ b/src/docstrings.hpp
@@ -158,6 +158,23 @@ extern const char* result_has_warnings;
 
 extern const char* result_has_errors;
 
+// PyUtil
+
+extern const char* unit_sanitizer;
+
+extern const char* unit_is_si;
+
+extern const char* unit_is_atomic;
+
+extern const char* unit_is_compound;
+
+extern const char* unit_split;
+
+extern const char* unit_compound_split;
+
+extern const char* unit_scalable;
+
+extern const char* unit_scaling;
 }
 }
 


### PR DESCRIPTION
adapt test for split_compound_unit to the fix in the nix lib.

Add docstrings for util methods 