### PR TITLE
Python3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Getting Started (Windows)
 
 **Windows Installer**
 
-You can get a windows installer for both, 32- and 64-bit: [nixpy - Beta 1](https://github.com/G-Node/nixpy/releases)
+You can get a [windows installer](https://github.com/G-Node/nixpy/releases) for both, 32- and 64-bit.
 
 **Build NIXPY under Windows**
 

--- a/nix/__init__.py
+++ b/nix/__init__.py
@@ -21,7 +21,7 @@ from nix.data_array import DataSetMixin
 from nix.data_array import DataArrayMixin
 from nix.tag import TagMixin
 from nix.multi_tag import MultiTagMixin
-from nix.entity_with_sources import DataArrySourcesMixin, MultiTagSourcesMixin, \
+from nix.entity_with_sources import DataArraySourcesMixin, MultiTagSourcesMixin, \
     TagSourcesMixin
 
 from nix.section import S
@@ -32,6 +32,6 @@ __all__ = ("File", "FileMode", "Block", "DataType", "Section", "Property",
            "Tag", "MultiTag")
 
 del BlockMixin, FileMixin, SectionMixin, PropertyMixin, ValueMixin, SourceMixin, DataArrayMixin, TagMixin
-del MultiTagMixin, DataArrySourcesMixin, MultiTagSourcesMixin, TagSourcesMixin
+del MultiTagMixin, DataArraySourcesMixin, MultiTagSourcesMixin, TagSourcesMixin
 
 __author__ = 'Christian Kellner, Adrian Stoewer, Andrey Sobolev, Jan Grewe, Balint Morvai'

--- a/nix/block.py
+++ b/nix/block.py
@@ -12,9 +12,14 @@ import sys
 
 import nix.util.find as finders
 from nix.core import Block
-from nix.util.inject import Inject
+from nix.util.inject import inject
 from nix.util.proxy_list import ProxyList
 import numpy as np
+
+try:
+    from sys import maxint
+except:
+    from sys import maxsize as maxint
 
 
 class SourceProxyList(ProxyList):
@@ -46,10 +51,6 @@ class TagProxyList(ProxyList):
 
 
 class BlockMixin(Block):
-
-    class __metaclass__(Inject, Block.__class__):
-        # this injects all members and the doc into nix.core.Block
-        pass
 
     def create_data_array(self, name, array_type, dtype=None, shape=None, data=None):
         """
@@ -91,7 +92,7 @@ class BlockMixin(Block):
             da.data.write_direct(data)
         return da
 
-    def find_sources(self, filtr=lambda _ : True, limit=sys.maxint):
+    def find_sources(self, filtr=lambda _ : True, limit=maxint):
         """
         Get all sources in this block recursively.
 
@@ -178,3 +179,6 @@ class BlockMixin(Block):
         hash has to be either explicitly inherited from parent class, implemented or escaped
         """
         return hash(self.id)
+
+
+inject((Block,), dict(BlockMixin.__dict__))

--- a/nix/data_array.py
+++ b/nix/data_array.py
@@ -293,6 +293,11 @@ class DataSetMixin(DataSet):
         if pos > -1:
             index = index[:pos] + fill_none(shape, index) + index[pos+1:]
 
+        # in python3 map does not work with None therefore if
+        # len(shape) != len(index) we wont get the expected
+        # result. We therefore need to fill up the missing values
+        index = index + fill_none(shape, index, to_replace=0)
+
         completed = list(map(self.__complete_slices, shape, index))
         combined = list(map(lambda s: (s.start, s.stop), completed))
         count = tuple(x[1] - x[0] for x in combined)

--- a/nix/data_array.py
+++ b/nix/data_array.py
@@ -270,8 +270,8 @@ class DataSetMixin(DataSet):
         return index
 
     @staticmethod
-    def __fill_none(shape, index):
-        size = len(shape) - len(index) + 1
+    def __fill_none(shape, index, to_replace=1):
+        size = len(shape) - len(index) + to_replace
         return tuple([None] * size)
 
     def __tuple_to_count_offset_shape(self, index):

--- a/nix/data_array.py
+++ b/nix/data_array.py
@@ -115,9 +115,10 @@ class DataSetMixin(DataSet):
             return np.array(self)
         # if we got to here we have a tuple with len >= 1
         count, offset, shape = self.__tuple_to_count_offset_shape(index)
-
         raw = np.empty(shape, dtype=self.dtype)
+
         self._read_data(raw, count, offset)
+
         return raw
 
     def __setitem__(self, index, value):
@@ -292,17 +293,17 @@ class DataSetMixin(DataSet):
         if pos > -1:
             index = index[:pos] + fill_none(shape, index) + index[pos+1:]
 
-        completed = map(self.__complete_slices, shape, index)
-        combined = map(lambda s: (s.start, s.stop), completed)
+        completed = list(map(self.__complete_slices, shape, index))
+        combined = list(map(lambda s: (s.start, s.stop), completed))
         count = tuple(x[1] - x[0] for x in combined)
-        offset = zip(*combined)[0]
+        offset = [x for x in zip(*combined)][0]
 
         # drop all indices from count that came from single ints
         # NB: special case when we only have ints, e.g. (int, ) then
         # we get back the empty tuple and this is what we want,
         # because it indicates a scalar result
         squeezed = map(lambda i, c: c if type(i) != int else None, index, count)
-        shape = filter(lambda x: x is not None, squeezed)
+        shape = list(filter(lambda x: x is not None, squeezed))
 
         return count, offset, shape
 

--- a/nix/data_array.py
+++ b/nix/data_array.py
@@ -12,14 +12,11 @@ import sys
 
 from nix.core import DataArray
 from nix.core import DataSet
-from nix.util.inject import Inject
+from nix.util.inject import inject
 
 import numpy as np
 
 class DataArrayMixin(DataArray):
-
-    class __metaclass__(Inject, DataArray.__class__):
-        pass
 
     @property
     def data(self):
@@ -106,9 +103,6 @@ class DataSetMixin(DataSet):
     """
     Data IO object for DataArray.
     """
-
-    class __metaclass__(Inject, DataSet.__class__):
-        pass
 
     def __array__(self):
         raw = np.empty(self.shape, dtype=self.dtype)
@@ -311,3 +305,7 @@ class DataSetMixin(DataSet):
         shape = filter(lambda x: x is not None, squeezed)
 
         return count, offset, shape
+
+
+inject((DataArray,), dict(DataArrayMixin.__dict__))
+inject((DataSet,), dict(DataSetMixin.__dict__))

--- a/nix/entity_with_sources.py
+++ b/nix/entity_with_sources.py
@@ -9,8 +9,9 @@
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 from nix.core import DataArray, MultiTag, Tag
-from nix.util.inject import Inject
+from nix.util.inject import inject
 from nix.util.proxy_list import RefProxyList
+
 
 class RefSourceProxyList(RefProxyList):
 
@@ -27,24 +28,22 @@ def _get_sources(self):
         setattr(self, "_sources", RefSourceProxyList(self))
     return self._sources
 
-class DataArrySourcesMixin(DataArray):
 
-    class __metaclass__(Inject, DataArray.__class__):
-        pass
+class DataArraySourcesMixin(DataArray):
 
     sources = property(_get_sources, None, None, _sources_doc)
 
 
 class MultiTagSourcesMixin(MultiTag):
 
-    class __metaclass__(Inject, MultiTag.__class__):
-        pass
-
     sources = property(_get_sources, None, None, _sources_doc)
+
 
 class TagSourcesMixin(Tag):
 
-    class __metaclass__(Inject, Tag.__class__):
-        pass
-
     sources = property(_get_sources, None, None, _sources_doc)
+
+
+inject((DataArray,), dict(DataArraySourcesMixin.__dict__))
+inject((MultiTag,), dict(MultiTagSourcesMixin.__dict__))
+inject((Tag,), dict(TagSourcesMixin.__dict__))

--- a/nix/file.py
+++ b/nix/file.py
@@ -12,8 +12,14 @@ import sys
 
 import nix.util.find as finders
 from nix.core import File
-from nix.util.inject import Inject
+from nix.util.inject import inject
 from nix.util.proxy_list import ProxyList
+
+try:
+    from sys import maxint
+except:
+    from sys import maxsize as maxint
+
 
 class BlockProxyList(ProxyList):
 
@@ -31,9 +37,6 @@ class SectionProxyList(ProxyList):
 
 class FileMixin(File):
 
-    class __metaclass__(Inject, File.__class__):
-        pass
-
     @property
     def blocks(self):
         """
@@ -48,7 +51,7 @@ class FileMixin(File):
             setattr(self, "_blocks", BlockProxyList(self))
         return self._blocks
 
-    def find_sections(self, filtr=lambda _ : True, limit=sys.maxint):
+    def find_sections(self, filtr=lambda _ : True, limit=maxint):
         """
         Get all sections and their child sections recursively.
 
@@ -82,3 +85,6 @@ class FileMixin(File):
         if not hasattr(self, "_sections"):
             setattr(self, "_sections", SectionProxyList(self))
         return self._sections
+
+
+inject((File,), dict(FileMixin.__dict__))

--- a/nix/multi_tag.py
+++ b/nix/multi_tag.py
@@ -9,14 +9,11 @@
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 from nix.core import MultiTag
-from nix.util.inject import Inject
+from nix.util.inject import inject
 from nix.tag import ReferenceProxyList, FeatureProxyList
 
 
 class MultiTagMixin(MultiTag):
-
-    class __metaclass__(Inject, MultiTag.__class__):
-        pass
 
     @property
     def references(self):
@@ -46,3 +43,6 @@ class MultiTagMixin(MultiTag):
         if not hasattr(self, "_features"):
             setattr(self, "_features", FeatureProxyList(self))
         return self._features
+
+
+inject((MultiTag,), dict(MultiTagMixin.__dict__))

--- a/nix/property.py
+++ b/nix/property.py
@@ -9,12 +9,10 @@
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 from nix.core import Property, Value
-from nix.util.inject import Inject
+from nix.util.inject import inject
+
 
 class PropertyMixin(Property):
-
-    class __metaclass__(Inject, Property.__class__):
-        pass
 
     def __eq__(self, other):
         if hasattr(other, "id"):
@@ -32,9 +30,6 @@ class PropertyMixin(Property):
 
 class ValueMixin(Value):
 
-    class __metaclass__(Inject, Value.__class__):
-        pass
-
     def __eq__(self, other):
         if hasattr(other, "value"):
             return self.value == other.value
@@ -47,3 +42,7 @@ class ValueMixin(Value):
         hash has to be either explicitly inherited from parent class, implemented or escaped
         """
         return hash(self.id)
+
+
+inject((Property,), dict(PropertyMixin.__dict__))
+inject((Value,), dict(ValueMixin.__dict__))

--- a/nix/section.py
+++ b/nix/section.py
@@ -12,7 +12,7 @@ import sys
 
 import nix.util.find as finders
 from nix.core import Section
-from nix.util.inject import Inject
+from nix.util.inject import inject
 from nix.util.proxy_list import ProxyList
 from nix.property import Value
 
@@ -20,6 +20,11 @@ from nix.file import SectionProxyList
 
 from operator import attrgetter
 import collections
+
+try:
+    from sys import maxint
+except:
+    from sys import maxsize as maxint
 
 
 class S(object):
@@ -51,10 +56,7 @@ class PropertyProxyList(ProxyList):
 
 class SectionMixin(Section):
 
-    class __metaclass__(Inject, Section.__class__):
-        pass
-
-    def find_sections(self, filtr=lambda _ : True, limit=sys.maxint):
+    def find_sections(self, filtr=lambda _ : True, limit=maxint):
         """
         Get all child sections recursively.
 
@@ -195,3 +197,6 @@ class SectionMixin(Section):
         if p is None and self.has_property_by_name(ident):
             p = self.get_property_by_name(ident)
         return p
+
+
+inject((Section,), dict(SectionMixin.__dict__))

--- a/nix/section.py
+++ b/nix/section.py
@@ -9,6 +9,7 @@
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 import sys
+import functools
 
 import nix.util.find as finders
 from nix.core import Section
@@ -135,7 +136,7 @@ class SectionMixin(Section):
             return self.sections[key]
 
         prop = self.props[key]
-        values = map(attrgetter('value'), prop.values)
+        values = list(map(attrgetter('value'), prop.values))
         if len(values) == 1:
             values = values[0]
         return values
@@ -152,8 +153,8 @@ class SectionMixin(Section):
         if not isinstance(data, list):
             data = [data]
 
-        val = map(lambda x: x if isinstance(x, Value) else Value(x), data)
-        dtypes = reduce(lambda x, y: x if y.data_type in x else x + [y.data_type], val, [val[0].data_type])
+        val = list(map(lambda x: x if isinstance(x, Value) else Value(x), data))
+        dtypes = functools.reduce(lambda x, y: x if y.data_type in x else x + [y.data_type], val, [val[0].data_type])
         if len(dtypes) > 1:
             raise ValueError('Not all input values are of the same type')
 

--- a/nix/source.py
+++ b/nix/source.py
@@ -12,17 +12,20 @@ import sys
 
 import nix.util.find as finders
 from nix.core import Source
-from nix.util.inject import Inject
+from nix.util.inject import inject
 from nix.util.proxy_list import ProxyList
 
 from nix.block import SourceProxyList
 
+try:
+    from sys import maxint
+except:
+    from sys import maxsize as maxint
+
+
 class SourceMixin(Source):
 
-    class __metaclass__(Inject, Source.__class__):
-        pass
-
-    def find_sources(self, filtr=lambda _ : True, limit=sys.maxint):
+    def find_sources(self, filtr=lambda _ : True, limit=maxint):
         """
         Get all child sources of this source recursively.
 
@@ -60,3 +63,6 @@ class SourceMixin(Source):
         hash has to be either explicitly inherited from parent class, implemented or escaped
         """
         return hash(self.id)
+
+
+inject((Source,), dict(SourceMixin.__dict__))

--- a/nix/tag.py
+++ b/nix/tag.py
@@ -9,7 +9,7 @@
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 from nix.core import Tag
-from nix.util.inject import Inject
+from nix.util.inject import inject
 from nix.util.proxy_list import ProxyList, RefProxyList
 
 
@@ -33,9 +33,6 @@ class FeatureProxyList(ProxyList):
 
 
 class TagMixin(Tag):
-
-    class __metaclass__(Inject, Tag.__class__):
-        pass
 
     @property
     def references(self):
@@ -65,3 +62,6 @@ class TagMixin(Tag):
         if not hasattr(self, "_features"):
             setattr(self, "_features", FeatureProxyList(self))
         return self._features
+
+
+inject((Tag,), dict(TagMixin.__dict__))

--- a/nix/test/test_data_array.py
+++ b/nix/test/test_data_array.py
@@ -14,6 +14,12 @@ import numpy as np
 
 from nix import *
 
+try:
+    basestring = basestring
+except NameError:  # 'basestring' is undefined, must be Python 3
+    basestring = (str,bytes)
+
+
 class TestDataArray(unittest.TestCase):
 
     def setUp(self):

--- a/nix/test/test_data_array.py
+++ b/nix/test/test_data_array.py
@@ -258,7 +258,11 @@ class TestDataArray(unittest.TestCase):
         da = self.block.create_data_array('dtype_int_from_data', 'b', data=test_data)
         assert(da.dtype == test_data.dtype)
 
-        void_data = np.array(['1', '2', '3', '4', '5', '6', '7', '8', '9', '0'], dtype='V1')
+        bdata = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0']
+        if sys.version_info[0] == 3:
+            bdata = [bytes(x, 'UTF-8') for x in bdata]
+
+        void_data = np.array(bdata, dtype='V1')
         da = self.block.create_data_array('dtype_opaque', 'b', data=void_data)
         assert(da.dtype == np.dtype('V1'))
         assert(np.array_equal(void_data, da[:]))

--- a/nix/test/test_proxy_list.py
+++ b/nix/test/test_proxy_list.py
@@ -13,6 +13,12 @@ import unittest
 from nix import *
 from nix.util.proxy_list import ProxyList
 
+try:
+    basestring = basestring
+except NameError:  # 'basestring' is undefined, must be Python 3
+    basestring = (str,bytes)
+
+
 class WithIdMock(object):
 
     def __init__(self, id):

--- a/nix/util/inject.py
+++ b/nix/util/inject.py
@@ -1,29 +1,15 @@
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
-class Inject(type):
-    """
-    Class that can be used as a metaclass in order to ease monkey patching.
 
-    Using Inject as metaclass has the effect, that all methods from the
-    class where it was uses will be added (monkey patched) to its base classes.
+excludes = ("__module__", "__metaclass__")
 
-    Usage:
+""" 
+Does monkey patching to the classes in 'bases' by adding
+methods from the given dict 'dct'.
+"""
+def inject(bases, dct):
+    for base in bases:
+        for k,v in dct.items():
+            if k not in excludes:
+                setattr(base,k,v)
 
-    >>> class Foo(Bar):
-    >>>     class __metaclass__(Inject):
-    >>>          pass
-
-    The above code will inject all methods from Foo into Bar as soon as
-    Foo is imported.
-    """
-
-    def __init__(self, name, bases, dct):
-        excludes = ("__module__", "__metaclass__")
-
-        for b in bases:
-            if type(b) not in (self, type):
-                for k,v in dct.items():
-                    if k not in excludes:
-                        setattr(b,k,v)
-
-        super(Inject, self).__init__(name, bases, dct)

--- a/nix/util/proxy_list.py
+++ b/nix/util/proxy_list.py
@@ -8,6 +8,12 @@
 
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
+try:
+    basestring = basestring
+except NameError:  # 'basestring' is undefined, must be Python 3
+    basestring = (str,bytes)
+
+
 class ProxyList(object):
     """
     Object that turns getters, setters etc of a NIX entity into
@@ -102,6 +108,6 @@ class RefProxyList(ProxyList):
 
     def extend(self, keys):
         if hasattr(keys, '__iter__'):
-            map(self.append, keys)
+            [self.append(key) for key in keys]
         else:
             self.append(keys)

--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,7 @@ classifiers   = [
                     'Programming Language :: Python',
                     'Programming Language :: Python :: 2.6',
                     'Programming Language :: Python :: 2.7',
+                    'Programming Language :: Python :: 3.4',
                     'Topic :: Scientific/Engineering'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ import os
 import re
 import fnmatch
 import distutils
+import platform
 
 def find(pattern, path):
     result = []
@@ -107,9 +108,18 @@ nixpy_sources = [
 
 boost_inc_dir = os.getenv('BOOST_INCDIR', '/usr/local/include')
 boost_lib_dir = os.getenv('BOOST_LIBDIR', '/usr/local/lib')
+
 if os.name != 'nt':
     boost_lnk_arg = ['-lboost_python']
-else:
+
+    if sys.version_info[0] == 3:  # python 3
+        if platform.system().lower() == 'linux':
+            boost_lnk_arg = ['-lboost_python-py34']
+
+        elif platform.system().lower() == 'darwin':
+            boost_lnk_arg = ['-lboost_python3']
+
+else:  # windows
     boostlib = find('libboost_python*.lib', boost_lib_dir)
     boost_lnk_arg = ['/LIBPATH:'+boost_lib_dir, '/DEFAULTLIB:'+boostlib[0]]
 

--- a/src/PyDataSet.cpp
+++ b/src/PyDataSet.cpp
@@ -261,7 +261,7 @@ struct DataSetWrapper : public nix::DataSet, public boost::python::wrapper<nix::
      }
 };
 
-void PyDataSet::do_export() {
+NIXPY_DO_EXPORT_RETVAL PyDataSet::do_export() {
     using namespace boost::python;
 
     // For numpy to work

--- a/src/PyEntity.hpp
+++ b/src/PyEntity.hpp
@@ -112,6 +112,12 @@ struct PyEntityWithSources {
     }
 };
 
+#if PY_VERSION_HEX >= 0x03000000
+#define NIXPY_DO_EXPORT_RETVAL void *
+#else
+#define NIXPY_DO_EXPORT_RETVAL void
+#endif
+
 struct PyResult {
     static void do_export();
 };
@@ -145,7 +151,7 @@ struct PyDataArray {
 };
 
 struct PyDataSet {
-    static void do_export();
+    static NIXPY_DO_EXPORT_RETVAL do_export();
 };
 
 struct PyDimensions {

--- a/src/PyValue.cpp
+++ b/src/PyValue.cpp
@@ -28,13 +28,21 @@ boost::shared_ptr<Value> create(PyObject* value) {
     if (PyBool_Check(value)) {
         bool conv = extract<bool>(value);
         created->set(conv);
+#if PY_MAJOR_VERSION >= 3
+    } else if (PyLong_Check(value)) {
+#else
     } else if (PyInt_Check(value)) {
+#endif
         int64_t conv = extract<int64_t>(value);
         created->set(conv);
     } else if (PyFloat_Check(value)) {
         double conv = extract<double>(value);
         created->set(conv);
+#if PY_MAJOR_VERSION >= 3
+    } else if (PyUnicode_Check(value)) {
+#else
     } else if (PyString_Check(value)) {
+#endif
         std::string conv = extract<std::string>(value);
         created->set(conv);
     } else {
@@ -51,13 +59,21 @@ void set(Value& ref, PyObject* value) {
     } else if (PyBool_Check(value)) {
         bool conv = extract<bool>(value);
         ref.set(conv);
+#if PY_MAJOR_VERSION >= 3
+    } else if (PyLong_Check(value)) {
+#else
     } else if (PyInt_Check(value)) {
+#endif
         int64_t conv = extract<int64_t>(value);
         ref.set(conv);
     } else if (PyFloat_Check(value)) {
         double conv = extract<double>(value);
         ref.set(conv);
+#if PY_MAJOR_VERSION >= 3
+    } else if (PyUnicode_Check(value)) {
+#else
     } else if (PyString_Check(value)) {
+#endif
         std::string conv = extract<std::string>(value);
         ref.set(conv);
     } else {

--- a/src/transmorgify.hpp
+++ b/src/transmorgify.hpp
@@ -117,7 +117,11 @@ PyObject* transmorgify_integer(const U value, const U max_val)
     //of boost::none, so we can call it with just value
     const bool can_downgrade = max_val < std::numeric_limits<T>::max();
     if (can_downgrade) {
+#if PY_MAJOR_VERSION >= 3
+        return PyLong_FromLong(static_cast<T>(value));
+#else
         return PyInt_FromLong(static_cast<T>(value));
+#endif
     } else if (std::numeric_limits<U>::is_signed) {
         return PyLong_FromLongLong(value);
     } else {


### PR DESCRIPTION
Here are a few changes needed to make nixpy work with python3.

One major change - we cannot use metaprogramming to inject methods as elegant as before (see "The Metaclass Hook in Python 3" here http://python-3-patterns-idioms-test.readthedocs.org/en/latest/Metaprogramming.html). So I used the easy solution and monkey patch classes directly (could be easily changed later if you'd like).

All tests run fine EXCEPT 2 TESTS in data set. Something is wrong with indexing ("selection+offset not within extent"). It would be nice if someone who developed DataSet could take a look and fix these.

Other than that it should be fine.

