### PR TITLE
Fix small py3 related build warning

### DIFF
--- a/src/PyDataSet.cpp
+++ b/src/PyDataSet.cpp
@@ -261,7 +261,7 @@ struct DataSetWrapper : public nix::DataSet, public boost::python::wrapper<nix::
      }
 };
 
-NIXPY_DO_EXPORT_RETVAL PyDataSet::do_export() {
+NIXPY_DO_EXPORT_RETTYPE PyDataSet::do_export() {
     using namespace boost::python;
 
     // For numpy to work
@@ -282,6 +282,8 @@ NIXPY_DO_EXPORT_RETVAL PyDataSet::do_export() {
     class_<nix::DataView, bases<nix::DataSet>>("DataView", boost::python::no_init);
 
     dtype_transmogrify::register_from_python();
+    
+    return NIXPY_DO_EXPORT_RETVAL;
 }
 
 } // nixpy::

--- a/src/PyEntity.hpp
+++ b/src/PyEntity.hpp
@@ -113,9 +113,11 @@ struct PyEntityWithSources {
 };
 
 #if PY_VERSION_HEX >= 0x03000000
-#define NIXPY_DO_EXPORT_RETVAL void *
+#define NIXPY_DO_EXPORT_RETTYPE void *
+#define NIXPY_DO_EXPORT_RETVAL  nullptr
 #else
-#define NIXPY_DO_EXPORT_RETVAL void
+#define NIXPY_DO_EXPORT_RETTYPE void
+#define NIXPY_DO_EXPORT_RETVAL
 #endif
 
 struct PyResult {
@@ -151,7 +153,7 @@ struct PyDataArray {
 };
 
 struct PyDataSet {
-    static NIXPY_DO_EXPORT_RETVAL do_export();
+    static NIXPY_DO_EXPORT_RETTYPE do_export();
 };
 
 struct PyDimensions {


### PR DESCRIPTION
As @jgrewe detected in pr #124 there is a small build warning
since we don't actually return a value in PyDataSet::do_export
for py3.