### PR TITLE
Backend selection and tests

### DIFF
--- a/nixio/file.py
+++ b/nixio/file.py
@@ -11,7 +11,8 @@ from __future__ import (absolute_import, division, print_function, unicode_liter
 import sys
 
 import nixio.util.find as finders
-from nixio.core import File
+from nixio.core import File as CPPFile
+from nixio.pycore import File as PyFile
 from nixio.util.inject import inject
 from nixio.util.proxy_list import ProxyList
 
@@ -35,7 +36,14 @@ class SectionProxyList(ProxyList):
                                                "_get_section_by_pos", "_delete_section_by_id")
 
 
-class FileMixin(File):
+class FileMixin(CPPFile, PyFile):
+
+    @staticmethod
+    def open(path, mode, backend="hdf5"):
+        if backend == "hdf5":
+            return CPPFile._open(path, mode)
+        elif backend == "h5py":
+            return PyFile._open(path, mode)
 
     @property
     def blocks(self):
@@ -87,4 +95,4 @@ class FileMixin(File):
         return self._sections
 
 
-inject((File,), dict(FileMixin.__dict__))
+inject((CPPFile, PyFile), dict(FileMixin.__dict__))

--- a/nixio/pycore/__init__.py
+++ b/nixio/pycore/__init__.py
@@ -1,0 +1,1 @@
+from .file import File

--- a/nixio/pycore/file.py
+++ b/nixio/pycore/file.py
@@ -1,0 +1,11 @@
+class File(object):
+
+    def __init__(self, path, mode=None):
+        pass
+
+    @classmethod
+    def _open(cls, path, mode=None):
+        return cls(path, mode)
+
+    def close(self):
+        pass

--- a/nixio/test/test_file.py
+++ b/nixio/test/test_file.py
@@ -13,10 +13,10 @@ import unittest
 from nixio import *
 
 
-class TestFile(unittest.TestCase):
+class _FileTest(unittest.TestCase):
 
     def setUp(self):
-        self.file  = File.open("unittest.h5", FileMode.Overwrite)
+        self.file = File.open("unittest.h5", FileMode.Overwrite, backend="hdf5")
 
     def tearDown(self):
         self.file.close()
@@ -81,3 +81,30 @@ class TestFile(unittest.TestCase):
         assert(len(self.file.find_sections(limit=1)) == 2)
         assert(len(self.file.find_sections(filtr=lambda x : "level2-p1-s" in x.name)) == 2)
         assert(len(self.file.find_sections(filtr=lambda x : "level2-p1-s" in x.name, limit=1)) == 0)
+
+
+class FileTestCPP(_FileTest):
+
+    def setUp(self):
+        self.file = File.open("unittest.h5", FileMode.Overwrite, backend="hdf5")
+
+
+class FileTestPy(_FileTest):
+
+    def setUp(self):
+        self.file = File.open("unittest.h5", FileMode.Overwrite, backend="h5py")
+
+    def test_file_format(self):
+        pass
+
+    def test_file_timestamps(self):
+        pass
+
+    def test_file_blocks(self):
+        pass
+
+    def test_file_sections(self):
+        pass
+
+    def test_file_find_sections(self):
+        pass

--- a/nixio/test/test_property.py
+++ b/nixio/test/test_property.py
@@ -12,14 +12,8 @@ import unittest
 
 from nixio import *
 
-class TestProperty(unittest.TestCase):
 
-    def setUp(self):
-        self.file    = File.open("unittest.h5", FileMode.Overwrite)
-        self.section = self.file.create_section("test section", "recordingsession")
-        self.prop    = self.section.create_property("test property", Value(0))
-        self.prop_s  = self.section.create_property("test str", DataType.String)
-        self.other   = self.section.create_property("other property", DataType.Int64)
+class _TestProperty(unittest.TestCase):
 
     def tearDown(self):
         del self.file.sections[self.section.id]
@@ -121,7 +115,6 @@ class TestValue(unittest.TestCase):
         assert(value == 66.6)
         assert(value.value == 66.6)
 
-
     def test_value_bool(self):
         value = Value(True)
         other = Value(False)
@@ -171,3 +164,52 @@ class TestValue(unittest.TestCase):
 
         value.uncertainty = 0.5
         assert(value.uncertainty == 0.5)
+
+
+class TestPropertyCPP(_TestProperty):
+
+    def setUp(self):
+        self.file    = File.open("unittest.h5", FileMode.Overwrite,
+                                 backend="hdf5")
+        self.section = self.file.create_section("test section",
+                                                "recordingsession")
+        self.prop    = self.section.create_property("test property", Value(0))
+        self.prop_s  = self.section.create_property("test str",
+                                                    DataType.String)
+        self.other   = self.section.create_property("other property",
+                                                    DataType.Int64)
+
+
+class TestPropertyPy(_TestProperty):
+
+    def setUp(self):
+        self.file    = File.open("unittest.h5", FileMode.Overwrite,
+                                 backend="h5py")
+        # self.section = self.file.create_section("test section",
+        #                                         "recordingsession")
+        # self.prop    = self.section.create_property("test property", Value(0))
+        # self.prop_s  = self.section.create_property("test str", DataType.String)
+        # self.other   = self.section.create_property("other property",
+        #                                             DataType.Int64)
+
+    def tearDown(self):
+        pass
+
+    def test_property_eq(self):
+        pass
+
+    def test_property_id(self):
+        pass
+
+    def test_property_name(self):
+        pass
+
+    def test_property_definition(self):
+        pass
+
+    def test_property_mapping(self):
+        pass
+
+    def test_property_values(self):
+        pass
+

--- a/nixio/test/test_section.py
+++ b/nixio/test/test_section.py
@@ -14,12 +14,7 @@ from nixio import *
 import nixio
 
 
-class TestSection(unittest.TestCase):
-
-    def setUp(self):
-        self.file    = File.open("unittest.h5", FileMode.Overwrite)
-        self.section = self.file.create_section("test section", "recordingsession")
-        self.other   = self.file.create_section("other section", "recordingsession")
+class _TestSection(unittest.TestCase):
 
     def tearDown(self):
         del self.file.sections[self.section.id]
@@ -173,3 +168,51 @@ class TestSection(unittest.TestCase):
             del self.section[x]
 
         assert(len(self.section) == 0)
+
+
+class TestSectionCPP(_TestSection):
+
+    def setUp(self):
+        self.file    = File.open("unittest.h5", FileMode.Overwrite,
+                                 backend="hdf5")
+        self.section = self.file.create_section("test section", "recordingsession")
+        self.other   = self.file.create_section("other section", "recordingsession")
+
+
+class TestSectionPy(_TestSection):
+
+    def setUp(self):
+        self.file = File.open("unittest.h5", FileMode.Overwrite, backend="h5py")
+
+    def tearDown(self):
+        pass
+
+    def test_section_eq(self):
+        pass
+
+    def test_section_id(self):
+        pass
+
+    def test_section_name(self):
+        pass
+
+    def test_section_type(self):
+        pass
+
+    def test_section_definition(self):
+        pass
+
+    def test_section_mapping(self):
+        pass
+
+    def test_section_repository(self):
+        pass
+
+    def test_section_sections(self):
+        pass
+
+    def test_section_find_sections(self):
+        pass
+
+    def test_section_properties(self):
+        pass

--- a/nixio/test/test_source.py
+++ b/nixio/test/test_source.py
@@ -12,15 +12,8 @@ import unittest
 
 from nixio import *
 
-class TestSource(unittest.TestCase):
 
-    def setUp(self):
-        self.file   = File.open("unittest.h5", FileMode.Overwrite)
-        self.block  = self.file.create_block("test block", "recordingsession")
-        self.source = self.block.create_source("test source", "recordingchannel")
-        self.other  = self.block.create_source("other source", "sometype")
-        self.third  = self.block.create_source("third source", "sometype")
-        self.array  = self.block.create_data_array("test array", "test type", dtype=DataType.Double, shape=(1,1))
+class _TestSource(unittest.TestCase):
 
     def tearDown(self):
         del self.file.blocks[self.block.id]
@@ -101,3 +94,56 @@ class TestSource(unittest.TestCase):
         assert(len(self.array.sources) == 2)
         self.array.sources.extend(self.third)
         assert(len(self.array.sources) == 3)
+
+
+class TestSourceCPP(_TestSource):
+
+    def setUp(self):
+        self.file   = File.open("unittest.h5", FileMode.Overwrite,
+                                backend="hdf5")
+        self.block  = self.file.create_block("test block", "recordingsession")
+        self.source = self.block.create_source("test source",
+                                               "recordingchannel")
+        self.other  = self.block.create_source("other source", "sometype")
+        self.third  = self.block.create_source("third source", "sometype")
+        self.array  = self.block.create_data_array("test array", "test type",
+                                                   dtype=DataType.Double,
+                                                   shape=(1, 1))
+
+
+class TestSourcePy(_TestSource):
+
+    def setUp(self):
+        self.file = File.open("unittest.h5", FileMode.Overwrite,
+                              backend="h5py")
+
+    def tearDown(self):
+        pass
+
+    def test_source_eq(self):
+        pass
+
+    def test_source_id(self):
+        pass
+
+    def test_source_name(self):
+        pass
+
+    def test_source_type(self):
+        pass
+
+    def test_source_definition(self):
+        pass
+
+    def test_source_timestamps(self):
+        pass
+
+    def test_source_sources(self):
+        pass
+
+    def test_source_find_sources(self):
+        pass
+
+    def test_sources_extend(self):
+        pass
+

--- a/nixio/test/test_tag.py
+++ b/nixio/test/test_tag.py
@@ -13,24 +13,8 @@ import numpy as np
 from nixio import *
 
 
-class TestTag(unittest.TestCase):
+class _TestTag(unittest.TestCase):
 
-    def setUp(self):
-        self.file     = File.open("unittest.h5", FileMode.Overwrite)
-        self.block    = self.file.create_block("test block", "recordingsession")
-
-        self.my_array = self.block.create_data_array("my array", "test", DataType.Int16, (1, ))
-        self.my_tag   = self.block.create_tag(
-            "my tag", "tag", [0]
-        )
-        self.my_tag.references.append(self.my_array)
-
-        self.your_array = self.block.create_data_array("your array", "test", DataType.Int16, (1, ))
-        self.your_tag = self.block.create_tag(
-            "your tag", "tag", [0]
-        )
-        self.your_tag.references.append(self.your_array)
-       
     def tearDown(self):
         del self.file.blocks[self.block.id]
         self.file.close()
@@ -174,4 +158,69 @@ class TestTag(unittest.TestCase):
         assert(data1.size == 1) 
         assert(data2.size == 2) 
         assert(data3.size == len(ramp_data))
-        
+
+
+class TestTagCPP(_TestTag):
+
+    def setUp(self):
+        self.file     = File.open("unittest.h5", FileMode.Overwrite,
+                                  backend="hdf5")
+        self.block    = self.file.create_block("test block", "recordingsession")
+
+        self.my_array = self.block.create_data_array("my array", "test", DataType.Int16, (1, ))
+        self.my_tag   = self.block.create_tag(
+            "my tag", "tag", [0]
+        )
+        self.my_tag.references.append(self.my_array)
+
+        self.your_array = self.block.create_data_array("your array", "test", DataType.Int16, (1, ))
+        self.your_tag = self.block.create_tag(
+            "your tag", "tag", [0]
+        )
+        self.your_tag.references.append(self.your_array)
+
+
+class TestTagPy(_TestTag):
+
+    def setUp(self):
+        self.file = File.open("unittest.h5", FileMode.Overwrite,
+                              backend="h5py")
+
+    def tearDown(self):
+        pass
+
+    def test_tag_eq(self):
+        pass
+
+    def test_tag_id(self):
+        pass
+
+    def test_tag_name(self):
+        pass
+
+    def test_tag_type(self):
+        pass
+
+    def test_tag_definition(self):
+        pass
+
+    def test_tag_timestamps(self):
+        pass
+
+    def test_tag_units(self):
+        pass
+
+    def test_tag_position(self):
+        pass
+
+    def test_tag_extent(self):
+        pass
+
+    def test_tag_references(self):
+        pass
+
+    def test_tag_features(self):
+        pass
+
+    def test_tag_retrieve_feature_data(self):
+        pass

--- a/src/PyFile.cpp
+++ b/src/PyFile.cpp
@@ -87,8 +87,8 @@ void PyFile::do_export() {
         // Open and close
         .def("is_open", &File::isOpen, doc::file_is_open)
         .def("close", &File::close, doc::file_close)
-        .def("open", open, open_overloads())
-        .staticmethod("open")
+        .def("_open", open, open_overloads())
+        .staticmethod("_open")
         // Other
         .def("validate", &File::validate)
         .def(self == other<File>())


### PR DESCRIPTION
Backend argument to `File.open` for selecting between C++ bindings to NIX/HDF5 and Python (h5py) core.

Subclassing all appropriate tests to run with both backends. H5py backend tests skipped.