### PR TITLE
[PyCore] Bug fixes

### DIFF
--- a/nixio/pycore/block.py
+++ b/nixio/pycore/block.py
@@ -32,7 +32,7 @@ class Block(EntityWithMetadata, BlockMixin):
     # DataArray
     def _create_data_array(self, name, type_, data_type, shape):
         util.check_entity_name_and_type(name, type_)
-        data_arrays = self._h5group.open_group("data_arrays", True)
+        data_arrays = self._h5group.open_group("data_arrays")
         if name in data_arrays:
             raise exceptions.DuplicateName("create_data_array")
         da = DataArray._create_new(data_arrays, name, type_, data_type, shape)
@@ -60,7 +60,7 @@ class Block(EntityWithMetadata, BlockMixin):
         util.check_entity_input(positions)
         if not isinstance(positions, DataArray):
             raise TypeError("DataArray expected for 'positions'")
-        multi_tags = self._h5group.open_group("multi_tags", True)
+        multi_tags = self._h5group.open_group("multi_tags")
         if name in multi_tags:
             raise exceptions.DuplicateName("create_multi_tag")
         mtag = MultiTag._create_new(multi_tags, name, type_, positions)

--- a/nixio/pycore/block.py
+++ b/nixio/pycore/block.py
@@ -46,9 +46,9 @@ class Block(EntityWithMetadata, BlockMixin):
         data_arrays = self._h5group.open_group("data_arrays")
         return DataArray(data_arrays.get_by_pos(pos))
 
-    def _delete_data_array_by_id(self, id_or_name):
+    def _delete_data_array_by_id(self, id_):
         data_arrays = self._h5group.open_group("data_arrays")
-        data_arrays.delete(id_or_name)
+        data_arrays.delete(id_)
 
     def _data_array_count(self):
         data_arrays = self._h5group.open_group("data_arrays")
@@ -74,9 +74,9 @@ class Block(EntityWithMetadata, BlockMixin):
         multi_tags = self._h5group.open_group("multi_tags")
         return MultiTag(multi_tags.get_by_pos(pos))
 
-    def _delete_multi_tag_by_id(self, id_or_name):
+    def _delete_multi_tag_by_id(self, id_):
         multi_tags = self._h5group.open_group("multi_tags")
-        multi_tags.delete(id_or_name)
+        multi_tags.delete(id_)
 
     def _multi_tag_count(self):
         multi_tags = self._h5group.open_group("multi_tags")
@@ -99,9 +99,9 @@ class Block(EntityWithMetadata, BlockMixin):
         tags = self._h5group.open_group("tags")
         return Tag(tags.get_by_pos(pos))
 
-    def _delete_tag_by_id(self, id_or_name):
+    def _delete_tag_by_id(self, id_):
         tags = self._h5group.open_group("tags")
-        tags.delete(id_or_name)
+        tags.delete(id_)
 
     def _tag_count(self):
         tags = self._h5group.open_group("tags")
@@ -124,9 +124,9 @@ class Block(EntityWithMetadata, BlockMixin):
         sources = self._h5group.open_group("sources")
         return Source(sources.get_by_pos(pos))
 
-    def _delete_source_by_id(self, id_or_name):
+    def _delete_source_by_id(self, id_):
         sources = self._h5group.open_group("sources")
-        sources.delete(id_or_name)
+        sources.delete(id_)
 
     def _source_count(self):
         sources = self._h5group.open_group("sources")
@@ -149,9 +149,9 @@ class Block(EntityWithMetadata, BlockMixin):
         groups = self._h5group.open_group("groups")
         return Group(groups.get_by_pos(pos))
 
-    def _delete_group_by_id(self, id_or_name):
+    def _delete_group_by_id(self, id_):
         groups = self._h5group.open_group("groups")
-        groups.delete(id_or_name)
+        groups.delete(id_)
 
     def _group_count(self):
         groups = self._h5group.open_group("groups")

--- a/nixio/pycore/entity_with_metadata.py
+++ b/nixio/pycore/entity_with_metadata.py
@@ -24,4 +24,15 @@ class EntityWithMetadata(NamedEntity):
 
     @property
     def metadata(self):
-        return Section(self._h5group["metadata"])
+        if "metadata" in self._h5group:
+            return Section(self._h5group.open_group("metadata"))
+        else:
+            return None
+
+    @metadata.setter
+    def metadata(self, sect):
+        if not isinstance(sect, Section):
+            raise TypeError("Error setting metadata to {}. Not a Section."
+                            .format(sect))
+        self._h5group.create_link(sect, "metadata")
+

--- a/nixio/pycore/entity_with_sources.py
+++ b/nixio/pycore/entity_with_sources.py
@@ -37,9 +37,9 @@ class EntityWithSources(EntityWithMetadata, EntityWithSourcesMixin):
         sources = self._h5group.open_group("sources")
         return Source(sources.get_by_pos(pos))
 
-    def _remove_source_by_id(self, id_or_name):
+    def _remove_source_by_id(self, id_):
         sources = self._h5group.open_group("sources")
-        sources.delete(id_or_name)
+        sources.delete(id_)
 
     def _source_count(self):
         sources = self._h5group.open_group("sources")

--- a/nixio/pycore/entity_with_sources.py
+++ b/nixio/pycore/entity_with_sources.py
@@ -11,6 +11,8 @@ from .entity_with_metadata import EntityWithMetadata
 from ..entity_with_sources import EntityWithSourcesMixin
 from .source import Source
 
+from . import util
+
 
 class EntityWithSources(EntityWithMetadata, EntityWithSourcesMixin):
 
@@ -26,7 +28,10 @@ class EntityWithSources(EntityWithMetadata, EntityWithSourcesMixin):
     # Source
     def _get_source_by_id(self, id_or_name):
         sources = self._h5group.open_group("sources")
-        return Source(sources.get_by_id_or_name(id_or_name))
+        if not util.is_uuid(id_or_name):
+            parblock = self._h5group.root
+            id_or_name = parblock.sources[id_or_name].id
+        return Source(sources.get_by_name(id_or_name))
 
     def _get_source_by_pos(self, pos):
         sources = self._h5group.open_group("sources")
@@ -41,8 +46,14 @@ class EntityWithSources(EntityWithMetadata, EntityWithSourcesMixin):
         return len(sources)
 
     def _add_source_by_id(self, id_or_name):
+        parblock = self._h5group.root
+        if id_or_name not in parblock.sources:
+            cls = type(self).__name__
+            raise RuntimeError("{}._add_source_by_id: "
+                               "Source not found in Block!".format(cls))
+        target = parblock.sources[id_or_name]
         sources = self._h5group.open_group("sources")
-        sources.add_by_id(id_or_name)
+        sources.create_link(target, target.id)
 
     def _has_source_by_id(self, id_or_name):
         sources = self._h5group.open_group("sources")

--- a/nixio/pycore/feature.py
+++ b/nixio/pycore/feature.py
@@ -45,6 +45,9 @@ class Feature(Entity):
     def data(self, da):
         if da is None:
             raise TypeError("Feature.data cannot be None.")
+        parblock = self._h5group.root
+        if da not in parblock.data_arrays:
+            raise RuntimeError("Feature.data: DataArray not found in Block!")
         if "data" in self._h5group:
             del self._h5group["data"]
         self._h5group.create_link(da, "data")

--- a/nixio/pycore/file.py
+++ b/nixio/pycore/file.py
@@ -160,6 +160,8 @@ class File(FileMixin):
         pass
 
     def close(self):
+        # Flush is probably unnecessary
+        self._h5file.flush()
         self._h5file.close()
 
     def validate(self):

--- a/nixio/pycore/file.py
+++ b/nixio/pycore/file.py
@@ -180,8 +180,8 @@ class File(FileMixin):
     def _get_block_by_pos(self, pos):
         return Block(self._data.get_by_pos(pos))
 
-    def _delete_block_by_id(self, id_or_name):
-        self._data.delete(id_or_name)
+    def _delete_block_by_id(self, id_):
+        self._data.delete(id_)
 
     def _block_count(self):
         return len(self._data)
@@ -199,8 +199,8 @@ class File(FileMixin):
     def _get_section_by_pos(self, pos):
         return Section(self.metadata.get_by_pos(pos))
 
-    def _delete_section_by_id(self, id_or_name):
-        self.metadata.delete(id_or_name)
+    def _delete_section_by_id(self, id_):
+        self.metadata.delete(id_)
 
     def _section_count(self):
         return len(self.metadata)

--- a/nixio/pycore/file.py
+++ b/nixio/pycore/file.py
@@ -7,6 +7,7 @@
 # LICENSE file in the root of the Project.
 from __future__ import (absolute_import, division, print_function)
 import os
+import gc
 
 import h5py
 
@@ -160,6 +161,7 @@ class File(FileMixin):
         pass
 
     def close(self):
+        gc.collect()  # should handle refs better instead of calling collect()
         # Flush is probably unnecessary
         self._h5file.flush()
         self._h5file.close()

--- a/nixio/pycore/group.py
+++ b/nixio/pycore/group.py
@@ -13,6 +13,8 @@ from .data_array import DataArray
 from .tag import Tag
 from .multi_tag import MultiTag
 
+from . import util
+
 
 class Group(EntityWithSources, GroupMixin):
 
@@ -27,7 +29,11 @@ class Group(EntityWithSources, GroupMixin):
     # DataArray
     def _get_data_array_by_id(self, id_or_name):
         data_arrays = self._h5group.open_group("data_arrays")
-        return DataArray(data_arrays.get_by_id_or_name(id_or_name))
+        if not util.is_uuid(id_or_name):
+            parblock = self._h5group.root
+            id_or_name = parblock.data_arrays[id_or_name].id
+        # Using get_by_name - linked entries use id as name in backend
+        return DataArray(data_arrays.get_by_name(id_or_name))
 
     def _get_data_array_by_pos(self, pos):
         data_arrays = self._h5group.open_group("data_arrays")
@@ -41,8 +47,13 @@ class Group(EntityWithSources, GroupMixin):
         return len(self._h5group.open_group("data_arrays"))
 
     def _add_data_array_by_id(self, id_or_name):
+        parblock = self._h5group.root
+        if id_or_name not in parblock.data_arrays:
+            raise RuntimeError("Group._add_data_array_by_id: "
+                               "DataArray not found in Block!")
+        target = parblock.data_arrays[id_or_name]
         data_arrays = self._h5group.open_group("data_arrays")
-        data_arrays.add_by_id(id_or_name)
+        data_arrays.create_link(target, target.id)
 
     def _has_data_array_by_id(self, id_or_name):
         data_arrays = self._h5group.open_group("data_arrays")
@@ -51,7 +62,11 @@ class Group(EntityWithSources, GroupMixin):
     # MultiTag
     def _get_multi_tag_by_id(self, id_or_name):
         multi_tags = self._h5group.open_group("multi_tags")
-        return MultiTag(multi_tags.get_by_id_or_name(id_or_name))
+        if not util.is_uuid(id_or_name):
+            parblock = self._h5group.root
+            id_or_name = parblock.multi_tags[id_or_name].id
+        # Using get_by_name - linked entries use id as name in backend
+        return MultiTag(multi_tags.get_by_name(id_or_name))
 
     def _get_multi_tag_by_pos(self, pos):
         multi_tags = self._h5group.open_group("multi_tags")
@@ -65,8 +80,13 @@ class Group(EntityWithSources, GroupMixin):
         return len(self._h5group.open_group("multi_tags"))
 
     def _add_multi_tag_by_id(self, id_or_name):
+        parblock = self._h5group.root
+        if id_or_name not in parblock.multi_tags:
+            raise RuntimeError("Group._add_multi_tag_by_id: "
+                               "MultiTag not found in Block!")
+        target = parblock.multi_tags[id_or_name]
         multi_tags = self._h5group.open_group("multi_tags")
-        multi_tags.add_by_id(id_or_name)
+        multi_tags.create_link(target, target.id)
 
     def _has_multi_tag_by_id(self, id_or_name):
         multi_tags = self._h5group.open_group("multi_tags")
@@ -75,7 +95,11 @@ class Group(EntityWithSources, GroupMixin):
     # Tag
     def _get_tag_by_id(self, id_or_name):
         tags = self._h5group.open_group("tags")
-        return Tag(tags.get_by_id_or_name(id_or_name))
+        if not util.is_uuid(id_or_name):
+            parblock = self._h5group.root
+            id_or_name = parblock.tags[id_or_name].id
+        # Using get_by_name - linked entries use id as name in backend
+        return Tag(tags.get_by_name(id_or_name))
 
     def _get_tag_by_pos(self, pos):
         tags = self._h5group.open_group("tags")
@@ -89,8 +113,13 @@ class Group(EntityWithSources, GroupMixin):
         return len(self._h5group.open_group("tags"))
 
     def _add_tag_by_id(self, id_or_name):
+        parblock = self._h5group.root
+        if id_or_name not in parblock.tags:
+            raise RuntimeError("Group._add_tag_by_id: "
+                               "Tag not found in Block!")
+        target = parblock.tags[id_or_name]
         tags = self._h5group.open_group("tags")
-        tags.add_by_id(id_or_name)
+        tags.create_link(target, target.id)
 
     def _has_tag_by_id(self, id_or_name):
         tags = self._h5group.open_group("tags")

--- a/nixio/pycore/group.py
+++ b/nixio/pycore/group.py
@@ -39,9 +39,9 @@ class Group(EntityWithSources, GroupMixin):
         data_arrays = self._h5group.open_group("data_arrays")
         return DataArray(data_arrays.get_by_pos(pos))
 
-    def _delete_data_array_by_id(self, id_or_name):
+    def _delete_data_array_by_id(self, id_):
         data_arrays = self._h5group.open_group("data_arrays")
-        data_arrays.delete(id_or_name)
+        data_arrays.delete(id_)
 
     def _data_array_count(self):
         return len(self._h5group.open_group("data_arrays"))
@@ -72,9 +72,9 @@ class Group(EntityWithSources, GroupMixin):
         multi_tags = self._h5group.open_group("multi_tags")
         return MultiTag(multi_tags.get_by_pos(pos))
 
-    def _delete_multi_tag_by_id(self, id_or_name):
+    def _delete_multi_tag_by_id(self, id_):
         multi_tags = self._h5group.open_group("multi_tags")
-        multi_tags.delete(id_or_name)
+        multi_tags.delete(id_)
 
     def _multi_tag_count(self):
         return len(self._h5group.open_group("multi_tags"))
@@ -105,9 +105,9 @@ class Group(EntityWithSources, GroupMixin):
         tags = self._h5group.open_group("tags")
         return Tag(tags.get_by_pos(pos))
 
-    def _delete_tag_by_id(self, id_or_name):
+    def _delete_tag_by_id(self, id_):
         tags = self._h5group.open_group("tags")
-        tags.delete(id_or_name)
+        tags.delete(id_)
 
     def _tag_count(self):
         return len(self._h5group.open_group("tags"))

--- a/nixio/pycore/h5group.py
+++ b/nixio/pycore/h5group.py
@@ -222,6 +222,8 @@ class H5Group(object):
             self.group.attrs[name] = value
 
     def get_attr(self, name):
+        if self.group is None:
+            return None
         return self.group.attrs.get(name)
 
     def find_children(self, filtr=None, limit=None):

--- a/nixio/pycore/h5group.py
+++ b/nixio/pycore/h5group.py
@@ -148,16 +148,24 @@ class H5Group(object):
 
     def add_by_id(self, id_or_name):
         self._create_h5obj()
-        parblock = self.parent.parent.parent
+        parblockgrp = self.h5root
 
-        def find_group(name, group):
+        def find_group_name(name, group):
             if id_or_name in name:
                 return group
-            if (util.is_uuid(id_or_name) and
-                    group.attrs.get("entity_id") == id_or_name):
+            return None
+
+        def find_group_id(name, group):
+            if group.attrs.get("entity_id") == id_or_name:
                 return group
             return None
-        target = parblock.group.visititems(find_group)
+
+        if util.is_uuid(id_or_name):
+            target = parblockgrp.group.visititems(find_group_id)
+        else:
+            target = parblockgrp.group.visititems(find_group_name)
+        if target is None:
+            raise RuntimeError("Target not found in parent block!")
         self.group[target.attrs["entity_id"]] = target
 
     def has_by_id(self, id_or_name):

--- a/nixio/pycore/h5group.py
+++ b/nixio/pycore/h5group.py
@@ -146,28 +146,6 @@ class H5Group(object):
         else:
             return False
 
-    def add_by_id(self, id_or_name):
-        self._create_h5obj()
-        parblockgrp = self.h5root
-
-        def find_group_name(name, group):
-            if id_or_name in name:
-                return group
-            return None
-
-        def find_group_id(name, group):
-            if group.attrs.get("entity_id") == id_or_name:
-                return group
-            return None
-
-        if util.is_uuid(id_or_name):
-            target = parblockgrp.group.visititems(find_group_id)
-        else:
-            target = parblockgrp.group.visititems(find_group_name)
-        if target is None:
-            raise RuntimeError("Target not found in parent block!")
-        self.group[target.attrs["entity_id"]] = target
-
     def has_by_id(self, id_or_name):
         if not self.group:
             return False

--- a/nixio/pycore/h5group.py
+++ b/nixio/pycore/h5group.py
@@ -216,7 +216,8 @@ class H5Group(object):
     def set_attr(self, name, value):
         self._create_h5obj()
         if value is None:
-            del self.group.attrs[name]
+            if name in self.group.attrs:
+                del self.group.attrs[name]
         else:
             self.group.attrs[name] = value
 

--- a/nixio/pycore/h5group.py
+++ b/nixio/pycore/h5group.py
@@ -194,11 +194,12 @@ class H5Group(object):
         try:
             del self.group[name]
         except Exception:
-            raise ValueError
+            raise ValueError("Error deleting {} from {}".format(name, self.name))
         # Delete if empty and non-root container
         groupdepth = len(self.group.name.split("/")) - 1
         if not len(self.group) and groupdepth > 1:
-            del self.group
+            del self.parent.group[self.name]
+            # del self.group
             self.group = None
 
     def set_attr(self, name, value):

--- a/nixio/pycore/h5group.py
+++ b/nixio/pycore/h5group.py
@@ -155,7 +155,6 @@ class H5Group(object):
                 return group
             return None
         target = parblock.group.visititems(find_group)
-        # TODO: Check if name or id should be the link name
         self.group[target.attrs["entity_id"]] = target
 
     def has_by_id(self, id_or_name):

--- a/nixio/pycore/h5group.py
+++ b/nixio/pycore/h5group.py
@@ -12,8 +12,11 @@ import numpy as np
 
 from .h5dataset import H5DataSet
 from ..value import DataType
+from .block import Block
+from .section import Section
 
 from . import util
+from .exceptions import InvalidEntity
 
 
 class H5Group(object):
@@ -260,6 +263,27 @@ class H5Group(object):
             return None
 
         return self.parent.h5root
+
+    @property
+    def root(self):
+        """
+        Returns the Block or top-level Section which contains this object.
+        Returns None if requested on the file root '/' or the /data or /metadata
+        groups.
+
+        :return: Top level object containing this group (Block or Section)
+        """
+        h5root = self.h5root
+        if h5root is None:
+            return None
+        topgroup = self.group.name.split("/")[1]
+        if topgroup == "data":
+            cls = Block
+        elif topgroup == "metadata":
+            cls = Section
+        else:
+            raise InvalidEntity
+        return cls(h5root)
 
     @property
     def parent(self):

--- a/nixio/pycore/section.py
+++ b/nixio/pycore/section.py
@@ -44,9 +44,9 @@ class Section(NamedEntity, SectionMixin):
         sections = self._h5group.open_group("sections")
         return Section(sections.get_by_pos(pos))
 
-    def _delete_section_by_id(self, id_or_name):
+    def _delete_section_by_id(self, id_):
         sections = self._h5group.open_group("sections")
-        sections.delete(id_or_name)
+        sections.delete(id_)
 
     def _section_count(self):
         return len(self._h5group.open_group("sections"))
@@ -88,9 +88,9 @@ class Section(NamedEntity, SectionMixin):
         properties = self._h5group.open_group("properties")
         return Property(properties.get_by_pos(pos))
 
-    def _delete_property_by_id(self, id_or_name):
+    def _delete_property_by_id(self, id_):
         properties = self._h5group.open_group("properties")
-        properties.delete(id_or_name)
+        properties.delete(id_)
 
     def _property_count(self):
         return len(self._h5group.open_group("properties"))

--- a/nixio/pycore/source.py
+++ b/nixio/pycore/source.py
@@ -42,9 +42,9 @@ class Source(EntityWithMetadata, SourceMixin):
         sources = self._h5group.open_group("sources")
         return Source(sources.get_by_pos(pos))
 
-    def _delete_source_by_id(self, id_or_name):
+    def _delete_source_by_id(self, id_):
         sources = self._h5group.open_group("sources")
-        sources.delete(id_or_name)
+        sources.delete(id_)
 
     def _source_count(self):
         sources = self._h5group.open_group("sources")

--- a/nixio/pycore/tag.py
+++ b/nixio/pycore/tag.py
@@ -66,9 +66,9 @@ class BaseTag(EntityWithSources):
         references = self._h5group.open_group("references")
         return DataArray(references.get_by_pos(pos))
 
-    def _delete_reference_by_id(self, id_or_name):
+    def _delete_reference_by_id(self, id_):
         references = self._h5group.open_group("references")
-        references.delete(id_or_name)
+        references.delete(id_)
 
     def create_feature(self, da, link_type):
         features = self._h5group.open_group("features")
@@ -90,9 +90,9 @@ class BaseTag(EntityWithSources):
         features = self._h5group.open_group("features")
         return Feature(features.get_by_pos(pos))
 
-    def _delete_feature_by_id(self, id_or_name):
+    def _delete_feature_by_id(self, id_):
         features = self._h5group.open_group("features")
-        features.delete(id_or_name)
+        features.delete(id_)
 
     @classmethod
     def _position_and_extent_in_data(cls, data, offset, count):

--- a/nixio/pycore/tag.py
+++ b/nixio/pycore/tag.py
@@ -42,8 +42,14 @@ class BaseTag(EntityWithSources):
             self.force_updated_at()
 
     def _add_reference_by_id(self, id_or_name):
+        parblock = self._h5group.root
+        if id_or_name not in parblock.data_arrays:
+            cls = type(self).__name__
+            raise RuntimeError("{}._add_reference_by_id: "
+                               "Reference not found in Block!".format(cls))
+        target = parblock.data_arrays[id_or_name]
         references = self._h5group.open_group("references")
-        references.add_by_id(id_or_name)
+        references.create_link(target, target.id)
 
     def _has_reference_by_id(self, id_or_name):
         references = self._h5group.open_group("references")

--- a/nixio/pycore/util/names.py
+++ b/nixio/pycore/util/names.py
@@ -6,7 +6,10 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 
-from uuid import uuid4, UUID
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from uuid import uuid4
 
 
 def sanitizer(name):
@@ -14,6 +17,8 @@ def sanitizer(name):
 
 
 def check(name):
+    if isinstance(name, bytes):
+        name = name.decode()
     return "/" not in name
 
 

--- a/nixio/pycore/util/util.py
+++ b/nixio/pycore/util/util.py
@@ -7,6 +7,9 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
 import h5py
 from time import time
 from datetime import datetime

--- a/nixio/test/test_group.py
+++ b/nixio/test/test_group.py
@@ -187,6 +187,20 @@ class _TestGroup(unittest.TestCase):
         for name in tg_names:
             assert(self.block.tags[name].id == self.my_group.tags[name].id)
 
+    def test_group_invalid_add(self):
+        da = self.block.data_arrays[0]
+        mt = self.block.multi_tags[0]
+        tg = self.block.tags[0]
+
+        newblock = self.file.create_block("second block", "block")
+        newgroup = newblock.create_group("second block group", "group")
+
+        self.assertRaises(RuntimeError, newgroup.data_arrays.append, da)
+        self.assertRaises(RuntimeError, newgroup.multi_tags.append, mt)
+        self.assertRaises(RuntimeError, newgroup.tags.append, tg)
+
+        del self.file.blocks[newblock.id]
+
 
 @unittest.skipIf(skip_cpp, "HDF5 backend not available.")
 class TestGroupCPP(_TestGroup):

--- a/nixio/test/test_group.py
+++ b/nixio/test/test_group.py
@@ -162,6 +162,31 @@ class _TestGroup(unittest.TestCase):
         self.my_group.multi_tags.extend([mt1, mt2])
         assert(len(self.my_group.multi_tags) == 3)
 
+    def test_group_get_by_name(self):
+        for idx in range(3):
+            da = self.block.create_data_array("da"+str(idx), "da",
+                                              data=list(range(idx)))
+            self.my_group.data_arrays.append(da)
+
+            mt = self.block.create_multi_tag("mt"+str(idx), "mt",
+                                             da)
+            self.my_group.multi_tags.append(mt)
+            tg = self.block.create_tag("tg"+str(idx), "tg", [0.3, 0.6])
+            self.my_group.tags.append(tg)
+
+        da_names = [da.name for da in self.my_group.data_arrays]
+        mt_names = [mt.name for mt in self.my_group.multi_tags]
+        tg_names = [tg.name for tg in self.my_group.tags]
+
+        for name in da_names:
+            assert(self.block.data_arrays[name].id ==
+                   self.my_group.data_arrays[name].id)
+        for name in mt_names:
+            assert(self.block.multi_tags[name].id ==
+                   self.my_group.multi_tags[name].id)
+        for name in tg_names:
+            assert(self.block.tags[name].id == self.my_group.tags[name].id)
+
 
 @unittest.skipIf(skip_cpp, "HDF5 backend not available.")
 class TestGroupCPP(_TestGroup):

--- a/nixio/util/find.py
+++ b/nixio/util/find.py
@@ -6,7 +6,6 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 
-import gc
 import nixio
 
 
@@ -52,7 +51,6 @@ def _find_sources(with_sources, filtr, limit):
         if filtr(c.elem):
             result.append(c.elem)
 
-    gc.collect()
     return result
 
 
@@ -88,5 +86,4 @@ def _find_sections(with_sections, filtr, limit):
         if filtr(c.elem):
             result.append(c.elem)
 
-    gc.collect()
     return result


### PR DESCRIPTION
Added two new tests for containers nested under Group, i.e., `data_arrays`, `multi_tags`, and `tags`.

1. Get by name
Retrieving from these containers by name in pycore would fail. Items in these containers are links, referenced by entity ID instead of name. The getter functions have been fixed to account for this.
The new test creates a number of objects, adds them to the group, and then retrieves them by name.

2. Invalid append
Appending to these containers would succeed even when the object being added was not a child of the same parent Block as the Group. In other words, inter-block references were being allowed by nixpy which is not allowed in the NIX specification.
The new test creates a second block with a group and attempts to add children of the first block to the group under the second block. Tests expect `RuntimeError` to be raised.

Some other minor bug fixes and changes are also included.
H5Group has new utility functions for accessing the root block which contains a given item.

Fixes #180.