### PR TITLE
Section.parent fix

### DIFF
--- a/nixio/pycore/entity_with_metadata.py
+++ b/nixio/pycore/entity_with_metadata.py
@@ -25,7 +25,21 @@ class EntityWithMetadata(NamedEntity):
     @property
     def metadata(self):
         if "metadata" in self._h5group:
-            return Section(self._h5group.open_group("metadata"))
+            mdsection = Section(self._h5group.open_group("metadata"))
+            sectionid = mdsection.id
+
+            rootmd = self._h5group.file.open_group("metadata")
+            results = []
+            for sectgroup in rootmd:
+                sect = Section(sectgroup)
+                results.extend(
+                    sect.find_sections(filtr=lambda x: x.id == sectionid)
+                )
+            if results:
+                return results[0]
+            else:
+                raise RuntimeError("Invalid metadata found in {}".
+                                   format(self))
         else:
             return None
 

--- a/nixio/pycore/h5group.py
+++ b/nixio/pycore/h5group.py
@@ -244,6 +244,15 @@ class H5Group(object):
         return result
 
     @property
+    def file(self):
+        """
+        An H5Group object which represents the file root.
+
+        :return: H5Group at '/'
+        """
+        return H5Group(self.group.file, "/", create=False)
+
+    @property
     def h5root(self):
         """
         Returns the H5Group of the Block or top-level Section which contains

--- a/nixio/test/test_backend_compatibility.py
+++ b/nixio/test/test_backend_compatibility.py
@@ -488,7 +488,7 @@ class _TestBackendCompatibility(unittest.TestCase):
         block = self.write_file.create_block("block", "section test")
         block.metadata = self.write_file.sections[0].sections[0].sections[0]
 
-        # self.check_compatibility()
+        self.check_compatibility()
 
         wblock = self.write_file.blocks[0]
         rblock = self.read_file.blocks[0]

--- a/nixio/test/test_section.py
+++ b/nixio/test/test_section.py
@@ -205,6 +205,10 @@ class _TestSection(unittest.TestCase):
         block.metadata = mdsection
         self.assertIs(block.metadata.parent, None)
 
+        grp = block.create_group("group", "section parent test")
+        grp.metadata = child
+        self.assertEqual(grp.metadata.parent, self.section)
+
 
 @unittest.skipIf(skip_cpp, "HDF5 backend not available.")
 class TestSectionCPP(_TestSection):


### PR DESCRIPTION
Section constructor now accepts parent section and keeps a reference. When accessing a section through an object's `.metadata` reference, the Section is found by searching the file's metadata tree in order to return an object with the correct parent reference.

This PR also includes a restructuring of the File creation and open methods, which is unrelated to the fix described above.

Fixes #174.