### PR TITLE
Delete dimensions

### DIFF
--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -34,9 +34,9 @@ class DataArrayMixin(object):
     def dimensions(self):
         """
         A property containing all dimensions of a DataArray. Dimensions can be
-        obtained via their index. Dimensions can be deleted from the list. Adding
-        sources is done using the respective create and append methods for
-        dimension descriptors. This is a read only attribute.
+        obtained via their index. Adding dimensions is done using the respective
+        append methods for dimension descriptors.
+        This is a read only attribute.
 
         :type: ProxyList of dimension descriptors.
         """

--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -98,10 +98,6 @@ class DimensionProxyList(object):
         else:
             raise TypeError("The key must be an int but was: " + type(key))
 
-    def __delitem__(self, key):
-        elem = self.__getitem__(key)
-        self.__obj._delete_dimension_by_pos(elem.index)
-
     def __iter__(self):
         for i in range(0, len(self)):
             yield self.__obj._get_dimension_by_pos(i + 1)

--- a/nixio/pycore/data_array.py
+++ b/nixio/pycore/data_array.py
@@ -7,6 +7,8 @@
 # LICENSE file in the root of the Project.
 from numbers import Number
 
+from warnings import warn
+
 from .entity_with_sources import EntityWithSources
 from ..data_array import DataArrayMixin, DataSetMixin
 from ..value import DataType
@@ -68,30 +70,38 @@ class DataArray(EntityWithSources, DataSet, DataArrayMixin):
             super(DataArray, self)._read_data(data, count, offset)
 
     def create_set_dimension(self, index):
-        dimgroup = self._h5group.open_group("dimensions")
-        return SetDimension._create_new(dimgroup, index)
+        warn("This function is deprecated and ignores the index argument")
+        return self.append_set_dimension()
 
     def create_sampled_dimension(self, index, sample):
-        dimgroup = self._h5group.open_group("dimensions")
-        return SampledDimension._create_new(dimgroup, index, sample)
+        warn("This function is deprecated and ignores the index argument")
+        return self.append_sampled_dimension(sample)
 
     def create_range_dimension(self, index, range_):
-        dimgroup = self._h5group.open_group("dimensions")
-        return RangeDimension._create_new(dimgroup, index, range_)
+        warn("This function is deprecated and ignores the index argument")
+        return self.append_range_dimension(range_)
 
     def append_set_dimension(self):
+        dimgroup = self._h5group.open_group("dimensions")
         index = len(self._h5group.open_group("dimensions")) + 1
-        return self.create_set_dimension(index)
+        return SetDimension._create_new(dimgroup, index)
 
     def append_sampled_dimension(self, sample):
         index = len(self._h5group.open_group("dimensions")) + 1
-        return self.create_sampled_dimension(index, sample)
+        dimgroup = self._h5group.open_group("dimensions")
+        return SampledDimension._create_new(dimgroup, index, sample)
 
     def append_range_dimension(self, range_):
         index = len(self._h5group.open_group("dimensions")) + 1
-        return self.create_range_dimension(index, range_)
+        dimgroup = self._h5group.open_group("dimensions")
+        return RangeDimension._create_new(dimgroup, index, range_)
 
     def create_alias_range_dimension(self):
+        warn("This function is deprecated and will be removed. "
+             "Use append_alias_range_dimension instead.", DeprecationWarning)
+        return self.append_alias_range_dimension()
+
+    def append_alias_range_dimension(self):
         if (len(self.data_extent) > 1 or
                 not DataType.is_numeric_dtype(self.dtype)):
             raise ValueError("AliasRangeDimensions only allowed for 1D "

--- a/nixio/pycore/data_array.py
+++ b/nixio/pycore/data_array.py
@@ -103,14 +103,15 @@ class DataArray(EntityWithSources, DataSet, DataArrayMixin):
         data = self._h5group.group["data"]
         return RangeDimension._create_new(dimgroup, 1, data)
 
-    def append_alias_range_dimension(self):
-        return self.create_alias_range_dimension()
+    def delete_dimensions(self):
+        dimgroup = self._h5group.open_group("dimensions")
+        ndims = len(dimgroup)
+        for idx in range(ndims):
+            del dimgroup[str(idx+1)]
+        return True
 
     def _dimension_count(self):
         return len(self._h5group.open_group("dimensions"))
-
-    def _delete_dimension_by_pos(self, index):
-        self._h5group.open_group("dimensions").delete(str(index))
 
     def _get_dimension_by_pos(self, index):
         h5dim = self._h5group.open_group("dimensions").open_group(str(index))

--- a/nixio/test/test_data_array.py
+++ b/nixio/test/test_data_array.py
@@ -300,19 +300,19 @@ class _TestDataArray(unittest.TestCase):
 
             assert(self.array.dimensions[i].index == self.array.dimensions[i - 3].index)
 
-        del self.array.dimensions[2]
-        del self.array.dimensions[1]
-        del self.array.dimensions[0]
+        self.array.delete_dimensions()
 
         assert(len(self.array.dimensions) == 0)
         self.array.append_alias_range_dimension()
         assert(len(self.array.dimensions) == 1)
-        del self.array.dimensions[0]
-        self.array.create_alias_range_dimension()
+        self.array.delete_dimensions()
+        self.array.append_alias_range_dimension()
         assert(len(self.array.dimensions) == 1)
 
-        self.assertRaises(ValueError, lambda : self.array.append_alias_range_dimension())
-        self.assertRaises(ValueError, lambda : self.array.create_alias_range_dimension())
+        self.assertRaises(ValueError,
+                          lambda: self.array.append_alias_range_dimension())
+        self.assertRaises(ValueError,
+                          lambda: self.array.append_alias_range_dimension())
         string_array = self.block.create_data_array('string_array', 'nix.texts',
                                                     dtype=DataType.String,
                                                     shape=(10,))

--- a/src/PyDataArray.cpp
+++ b/src/PyDataArray.cpp
@@ -127,7 +127,7 @@ void PyDataArray::do_export() {
         .def("append_alias_range_dimension", &DataArray::appendAliasRangeDimension,
              doc::data_array_append_alias_range_dimension)
         .def("_dimension_count", &DataArray::dimensionCount)
-        .def("_delete_dimension_by_pos", &DataArray::deleteDimension)
+        .def("delete_dimensions", &DataArray::deleteDimensions)
         .def("_get_dimension_by_pos", getDimension)
         // Other
         .def("__str__", &toStr<DataArray>)


### PR DESCRIPTION
Individual dimensions cannot be deleted. Instead, `DataArray.delete_dimensions()` should now be used to delete all dimensions simultaneously.

Creating dimensions at specific indices has also been deprecated. Dimensions can only be created by appending.