### PR TITLE
Python only builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ pip-log.txt
 *~
 *.log
 *.kate-swp
+*.swp
 
 # idea / pycharm files
 .idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,18 +7,17 @@ env:
     global:
         - NIX_LIBDIR=./nix-build/inst/lib
         - NIX_INCDIR=./nix-build/inst/include
-    matrix:
-        - SETUP_ARGS=""
-        - SETUP_ARGS="--pyonly"
-
-python:
-    - 2.7_with_system_site_packages
-    - 3.4
 
 matrix:
-  include:
-    - python: "2.7_with_system_site_packages"
-      env: COVERALLS=1
+    include:
+        - python: "2.7_with_system_site_packages"
+          env: PYONLY="" COVERALLS=1
+        - python: "3.4"
+          env: PYONLY=""
+        - python: "2.7_with_system_site_packages"
+          env: PYONLY="--pyonly"
+        - python: "3.4"
+          env: PYONLY="--pyonly"
 
 addons:
   apt:
@@ -36,7 +35,7 @@ install:
     fi
   - pip install --upgrade numpy coveralls h5py
   #build NIX
-  - if [ -z "$SETUP_ARGS" ]; then
+  - if [ -z "$PYONLY" ]; then
       git clone https://github.com/G-Node/nix.git nix-build;
       pushd nix-build;
       cmake -DCMAKE_INSTALL_PREFIX=./inst -DBUILD_TESTING=OFF .;
@@ -46,11 +45,11 @@ install:
     fi
 
 script:
-- python setup.py build $SETUP_ARGS
+- python setup.py build $PYONLY
 - if [ $COVERALLS = 1 ]; then
-    coverage${PYVER} run --source=nixio setup.py test && coverage${PYVER} report -m;
+    coverage${PYVER} run --source=nixio setup.py test $PYONLY && coverage${PYVER} report -m;
   else
-    python setup.py test;
+    python setup.py test $PYONLY;
   fi;
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: python
 matrix:
     include:
         - python: "2.7_with_system_site_packages"
-          env: COVERALLS=1 NIX_LIBDIR=./nix-build/inst/lib NIX_INCDIR=./nix-build/inst/include
+          env: COVERALLS=1 NIX_LIBDIR=./nix-build/inst/lib NIX_INCDIR=./nix-build/inst/include SETUP_ARG=--with-nix
         - python: "3.4"
           env: NIX_LIBDIR=./nix-build/inst/lib NIX_INCDIR=./nix-build/inst/include
         - python: "2.7_with_system_site_packages"
@@ -38,7 +38,7 @@ install:
     fi
 
 script:
-- python setup.py build
+- python setup.py build $SETUP_ARG
 - if [ $COVERALLS = 1 ]; then
     coverage${PYVER} run --source=nixio setup.py test && coverage${PYVER} report -m;
   else

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,21 +3,14 @@ dist: trusty
 
 language: python
 
-env:
-    global:
-        - NIX_LIBDIR=./nix-build/inst/lib
-        - NIX_INCDIR=./nix-build/inst/include
-
 matrix:
     include:
         - python: "2.7_with_system_site_packages"
-          env: PYONLY="" COVERALLS=1
+          env: COVERALLS=1 NIX_LIBDIR="./nix-build/inst/lib" NIX_INCDIR="./nix-build/inst/include"
         - python: "3.4"
-          env: PYONLY=""
+          env: NIX_LIBDIR="./nix-build/inst/lib" NIX_INCDIR="./nix-build/inst/include"
         - python: "2.7_with_system_site_packages"
-          env: PYONLY="--pyonly"
         - python: "3.4"
-          env: PYONLY="--pyonly"
 
 addons:
   apt:
@@ -35,7 +28,7 @@ install:
     fi
   - pip install --upgrade numpy coveralls h5py
   #build NIX
-  - if [ -z "$PYONLY" ]; then
+  - if [[ -v "$NIX_LIBDIR" ]]; then
       git clone https://github.com/G-Node/nix.git nix-build;
       pushd nix-build;
       cmake -DCMAKE_INSTALL_PREFIX=./inst -DBUILD_TESTING=OFF .;
@@ -45,11 +38,11 @@ install:
     fi
 
 script:
-- python setup.py build $PYONLY
+- python setup.py build
 - if [ $COVERALLS = 1 ]; then
-    coverage${PYVER} run --source=nixio setup.py test $PYONLY && coverage${PYVER} report -m;
+    coverage${PYVER} run --source=nixio setup.py test && coverage${PYVER} report -m;
   else
-    python setup.py test $PYONLY;
+    python setup.py test;
   fi;
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
         - SETUP_ARGS="--pyonly"
 
 python:
-    - 2.7
+    - 2.7_with_system_site_packages
     - 3.4
 
 matrix:
@@ -36,7 +36,7 @@ install:
     fi
   - pip install --upgrade numpy coveralls h5py
   #build NIX
-  - if [ "$SETUP_ARGS" ]; then
+  - if [ -z "$SETUP_ARGS" ]; then
       git clone https://github.com/G-Node/nix.git nix-build;
       pushd nix-build;
       cmake -DCMAKE_INSTALL_PREFIX=./inst -DBUILD_TESTING=OFF .;

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,21 @@ dist: trusty
 language: python
 
 env:
-  global:
-    - NIX_LIBDIR=./nix-build/inst/lib
-    - NIX_INCDIR=./nix-build/inst/include
+    global:
+        - NIX_LIBDIR=./nix-build/inst/lib
+        - NIX_INCDIR=./nix-build/inst/include
+    matrix:
+        - SETUP_ARGS=""
+        - SETUP_ARGS="--pyonly"
+
+python:
+    - 2.7
+    - 3.4
 
 matrix:
   include:
     - python: "2.7_with_system_site_packages"
       env: COVERALLS=1
-    - python: "3.4"
-      env: COVERALLS=0
 
 addons:
   apt:
@@ -31,15 +36,17 @@ install:
     fi
   - pip install --upgrade numpy coveralls h5py
   #build NIX
-  - git clone https://github.com/G-Node/nix.git nix-build
-  - cd nix-build
-  - cmake -DCMAKE_INSTALL_PREFIX=./inst -DBUILD_TESTING=OFF .
-  - make
-  - make install
-  - cd ..
+  - if [ "$SETUP_ARGS" ]; then
+      git clone https://github.com/G-Node/nix.git nix-build;
+      pushd nix-build;
+      cmake -DCMAKE_INSTALL_PREFIX=./inst -DBUILD_TESTING=OFF .;
+      make;
+      make install;
+      popd;
+    fi
 
 script:
-- python setup.py build
+- python setup.py build $SETUP_ARGS
 - if [ $COVERALLS = 1 ]; then
     coverage${PYVER} run --source=nixio setup.py test && coverage${PYVER} report -m;
   else

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
     fi
   - pip install --upgrade numpy coveralls h5py
   #build NIX
-  - if [[ -v "$NIX_LIBDIR" ]]; then
+  - if [ -n "$NIX_LIBDIR" ]; then
       git clone https://github.com/G-Node/nix.git nix-build;
       pushd nix-build;
       cmake -DCMAKE_INSTALL_PREFIX=./inst -DBUILD_TESTING=OFF .;

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ language: python
 matrix:
     include:
         - python: "2.7_with_system_site_packages"
-          env: COVERALLS=1 NIX_LIBDIR="./nix-build/inst/lib" NIX_INCDIR="./nix-build/inst/include"
+          env: COVERALLS=1 NIX_LIBDIR=./nix-build/inst/lib NIX_INCDIR=./nix-build/inst/include
         - python: "3.4"
-          env: NIX_LIBDIR="./nix-build/inst/lib" NIX_INCDIR="./nix-build/inst/include"
+          env: NIX_LIBDIR=./nix-build/inst/lib NIX_INCDIR=./nix-build/inst/include
         - python: "2.7_with_system_site_packages"
         - python: "3.4"
 

--- a/checknix.py
+++ b/checknix.py
@@ -1,0 +1,57 @@
+import os, sys
+from textwrap import dedent
+import tempfile
+
+import distutils.sysconfig
+import distutils.ccompiler
+from distutils.errors import CompileError, LinkError
+
+
+def check_nix(libdirs=(), incdirs=()):
+    """
+    Check if NIX is available by trying to compile a tiny program.
+    """
+
+    cpp_code = dedent("""
+    #include <nix.hpp>
+
+    int main() {
+        return 0;
+    }
+    """)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        bin_file_name = os.path.join(tmpdir, "check_nix")
+        file_name = bin_file_name + '.cpp'
+        with open(file_name, 'w') as cfile:
+            cfile.write(cpp_code)
+
+        compiler = distutils.ccompiler.new_compiler()
+        assert isinstance(compiler, distutils.ccompiler.CCompiler)
+
+        compiler.library_dirs.extend(libdirs)
+        compiler.include_dirs.extend(incdirs)
+        distutils.sysconfig.customize_compiler(compiler)
+
+        # stderr = os.dup(sys.stderr.fileno())
+        errfile = open(os.path.join(tmpdir, "check_nix.err"), 'w')
+        os.dup2(errfile.fileno(), sys.stderr.fileno())
+        try:
+            compiler.compile([file_name])
+        except (CompileError, LinkError):
+            ret_val = False
+        else:
+            ret_val = True
+        errfile.close()
+    return ret_val
+
+
+if __name__ == '__main__':
+    nix_inc_dir = os.getenv('NIX_INCDIR', '/usr/local/include')
+    nix_lib_dir = os.getenv('NIX_LIBDIR', '/usr/local/lib')
+    res = check_nix([nix_lib_dir], [nix_inc_dir])
+    if res:
+        print("Found NIX.")
+    else:
+        print("NIX not found.")
+
+

--- a/checknix.py
+++ b/checknix.py
@@ -8,7 +8,7 @@ import distutils.ccompiler
 from distutils.errors import CompileError, LinkError
 
 
-def check_nix(libdirs=(), incdirs=()):
+def check_nix(library_dirs=(), include_dirs=(), compile_args=()):
     """
     Check if NIX is available by trying to compile a tiny program.
     """
@@ -30,8 +30,8 @@ def check_nix(libdirs=(), incdirs=()):
     compiler = distutils.ccompiler.new_compiler()
     assert isinstance(compiler, distutils.ccompiler.CCompiler)
 
-    compiler.library_dirs.extend(libdirs)
-    compiler.include_dirs.extend(incdirs)
+    compiler.library_dirs.extend(library_dirs)
+    compiler.include_dirs.extend(include_dirs)
     distutils.sysconfig.customize_compiler(compiler)
 
     stderr = os.dup(sys.stderr.fileno())
@@ -40,7 +40,7 @@ def check_nix(libdirs=(), incdirs=()):
     os.dup2(errfile.fileno(), sys.stderr.fileno())
     try:
         compiler.compile([file_name], output_dir=tmpdir,
-                         extra_postargs=["--std=c++11"])
+                         extra_postargs=compile_args)
     except (CompileError, LinkError):
         ret_val = False
     else:

--- a/checknix.py
+++ b/checknix.py
@@ -37,7 +37,7 @@ def check_nix(libdirs=(), incdirs=()):
     stderr = os.dup(sys.stderr.fileno())
     errfile = open(os.path.join(tmpdir, "check_nix.err"), 'w')
     # redirect stderr to file
-    # os.dup2(errfile.fileno(), sys.stderr.fileno())
+    os.dup2(errfile.fileno(), sys.stderr.fileno())
     try:
         compiler.compile([file_name], output_dir=tmpdir,
                          extra_postargs=["--std=c++11"])
@@ -46,7 +46,7 @@ def check_nix(libdirs=(), incdirs=()):
     else:
         ret_val = True
     # restore stderr
-    # os.dup2(stderr, sys.stderr.fileno())
+    os.dup2(stderr, sys.stderr.fileno())
     errfile.close()
     shutil.rmtree(tmpdir)
     return ret_val

--- a/checknix.py
+++ b/checknix.py
@@ -36,7 +36,7 @@ def check_nix(libdirs=(), incdirs=()):
 
     # stderr = os.dup(sys.stderr.fileno())
     errfile = open(os.path.join(tmpdir, "check_nix.err"), 'w')
-    os.dup2(errfile.fileno(), sys.stderr.fileno())
+    # os.dup2(errfile.fileno(), sys.stderr.fileno())
     try:
         compiler.compile([file_name], output_dir=tmpdir)
     except (CompileError, LinkError):

--- a/checknix.py
+++ b/checknix.py
@@ -34,15 +34,19 @@ def check_nix(libdirs=(), incdirs=()):
     compiler.include_dirs.extend(incdirs)
     distutils.sysconfig.customize_compiler(compiler)
 
-    # stderr = os.dup(sys.stderr.fileno())
+    stderr = os.dup(sys.stderr.fileno())
     errfile = open(os.path.join(tmpdir, "check_nix.err"), 'w')
+    # redirect stderr to file
     # os.dup2(errfile.fileno(), sys.stderr.fileno())
     try:
-        compiler.compile([file_name], output_dir=tmpdir)
+        compiler.compile([file_name], output_dir=tmpdir,
+                         extra_postargs=["--std=c++11"])
     except (CompileError, LinkError):
         ret_val = False
     else:
         ret_val = True
+    # restore stderr
+    # os.dup2(stderr, sys.stderr.fileno())
     errfile.close()
     shutil.rmtree(tmpdir)
     return ret_val

--- a/nixio/test/test_backend_compatibility.py
+++ b/nixio/test/test_backend_compatibility.py
@@ -43,6 +43,11 @@ class _TestBackendCompatibility(unittest.TestCase):
 
     def check_attributes(self, writeitem, readitem):
         for attr in all_attrs:
+            # skip deprecated data attribute for DataArrays
+            if (isinstance(writeitem, (nixio.pycore.data_array.DataArray,
+                                       nixio.core.DataArray)) and
+                    attr == "data"):
+                continue
             if hasattr(writeitem, attr) or hasattr(readitem, attr):
                 writeval = getattr(writeitem, attr)
                 readval = getattr(readitem, attr)

--- a/setup.py
+++ b/setup.py
@@ -123,19 +123,27 @@ classifiers   = [
                     'Topic :: Scientific/Engineering'
 ]
 
-native_ext    = Extension(
-                    'nixio.core',
-                    extra_compile_args = ['-std=c++11'] if not is_win else ['/DBOOST_PYTHON_STATIC_LIB', '/EHsc'],
-                    extra_link_args=boost_lnk_arg + nix_lnk_arg,
-                    sources = nixpy_sources,
-                    runtime_library_dirs = [nix_lib_dir, boost_lib_dir] if not is_win else None,
-                    **pkg_config(
-                        "nixio",
-                        library_dirs=[boost_lib_dir, nix_lib_dir],
-                        include_dirs=[boost_inc_dir, nix_inc_dir, np.get_include(), 'src'],
-                        ignore_error=True
-                    )
-                )
+
+if "--pyonly" in sys.argv:
+    sys.argv.remove("--pyonly")
+    print("Skipping NIX C++ bindings.")
+    ext_modules = []
+else:
+    native_ext    = Extension(
+        'nixio.core',
+        extra_compile_args = ['-std=c++11'] if not is_win else ['/DBOOST_PYTHON_STATIC_LIB', '/EHsc'],
+        extra_link_args=boost_lnk_arg + nix_lnk_arg,
+        sources = nixpy_sources,
+        runtime_library_dirs = [nix_lib_dir, boost_lib_dir] if not is_win else None,
+        **pkg_config(
+            "nixio",
+            library_dirs=[boost_lib_dir, nix_lib_dir],
+            include_dirs=[boost_inc_dir, nix_inc_dir, np.get_include(), 'src'],
+            ignore_error=False
+        )
+    )
+    ext_modules = [native_ext]
+    print("Done configuring")
 
 setup(name             = 'nixio',
       version          = VERSION,
@@ -146,7 +154,7 @@ setup(name             = 'nixio',
       long_description = description_text,
       classifiers      = classifiers,
       license          = 'BSD',
-      ext_modules      = [native_ext],
+      ext_modules      = ext_modules,
       packages         = ['nixio', 'nixio.pycore', 'nixio.util', 'nixio.pycore.util', 'nixio.pycore.exceptions'],
       scripts          = [],
       tests_require    = ['nose'],
@@ -156,3 +164,4 @@ setup(name             = 'nixio',
       include_package_data = True,
       zip_safe         = False,
 )
+

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,9 @@ import numpy as np
 import sys
 import os
 import re
-import distutils
-import platform
 
 from findboost import BoostPyLib
+from checknix import check_nix
 
 with open('README.md') as f:
     description_text = f.read()
@@ -127,7 +126,9 @@ classifiers   = [
 
 if "--pyonly" in sys.argv:
     sys.argv.remove("--pyonly")
-    print("Skipping NIX C++ bindings.")
+    ext_modules = []
+elif not check_nix([nix_lib_dir], [nix_inc_dir]):
+    print("NIX not found.")
     ext_modules = []
 else:
     native_ext    = Extension(
@@ -144,7 +145,9 @@ else:
         )
     )
     ext_modules = [native_ext]
-    print("Done configuring")
+
+if not ext_modules:
+    print("Skipping NIX C++ bindings.")
 
 setup(name             = 'nixio',
       version          = VERSION,

--- a/setup.py
+++ b/setup.py
@@ -123,24 +123,28 @@ classifiers   = [
                     'Topic :: Scientific/Engineering'
 ]
 
+library_dirs = [boost_lib_dir, nix_lib_dir],
+include_dirs = [boost_inc_dir, nix_inc_dir, np.get_include(), 'src'],
+compile_args = ['-std=c++11'] if not is_win else ['/DBOOST_PYTHON_STATIC_LIB',
+                                                  '/EHsc']
 
 if "--pyonly" in sys.argv:
     sys.argv.remove("--pyonly")
     ext_modules = []
-elif not check_nix([nix_lib_dir], [nix_inc_dir]):
+elif not check_nix(library_dirs, include_dirs, compile_args):
     print("NIX not found.")
     ext_modules = []
 else:
-    native_ext    = Extension(
+    native_ext = Extension(
         'nixio.core',
-        extra_compile_args = ['-std=c++11'] if not is_win else ['/DBOOST_PYTHON_STATIC_LIB', '/EHsc'],
+        extra_compile_args=compile_args,
         extra_link_args=boost_lnk_arg + nix_lnk_arg,
-        sources = nixpy_sources,
-        runtime_library_dirs = [nix_lib_dir, boost_lib_dir] if not is_win else None,
+        sources=nixpy_sources,
+        runtime_library_dirs=library_dirs if not is_win else None,
         **pkg_config(
             "nixio",
-            library_dirs=[boost_lib_dir, nix_lib_dir],
-            include_dirs=[boost_inc_dir, nix_inc_dir, np.get_include(), 'src'],
+            library_dirs=library_dirs,
+            include_dirs=include_dirs,
             ignore_error=False
         )
     )

--- a/setup.py
+++ b/setup.py
@@ -123,21 +123,24 @@ classifiers   = [
                     'Topic :: Scientific/Engineering'
 ]
 
-library_dirs = [boost_lib_dir, nix_lib_dir],
-include_dirs = [boost_inc_dir, nix_inc_dir, np.get_include(), 'src'],
-compile_args = ['-std=c++11'] if not is_win else ['/DBOOST_PYTHON_STATIC_LIB',
-                                                  '/EHsc']
+library_dirs = [boost_lib_dir, nix_lib_dir]
+include_dirs = [boost_inc_dir, nix_inc_dir, np.get_include(), 'src']
+compile_args = ['--std=c++11'] if not is_win else ['/DBOOST_PYTHON_STATIC_LIB',
+                                                   '/EHsc']
 
-if "--pyonly" in sys.argv:
-    sys.argv.remove("--pyonly")
-    ext_modules = []
-elif not check_nix(library_dirs, include_dirs, compile_args):
-    print("NIX not found.")
-    ext_modules = []
+if "--without-nix" in sys.argv:
+    sys.argv.remove("--without-nix")
+    with_nix = False
+elif "--with-nix" in sys.argv:
+    sys.argv.remove("--with-nix")
+    with_nix = True
 else:
+    with_nix = check_nix(library_dirs, include_dirs, compile_args)
+
+if with_nix:
     native_ext = Extension(
         'nixio.core',
-        extra_compile_args=compile_args,
+        extra_compile_args=['-std=c++11'] if not is_win else ['/DBOOST_PYTHON_STATIC_LIB', '/EHsc'],
         extra_link_args=boost_lnk_arg + nix_lnk_arg,
         sources=nixpy_sources,
         runtime_library_dirs=library_dirs if not is_win else None,
@@ -149,9 +152,9 @@ else:
         )
     )
     ext_modules = [native_ext]
-
-if not ext_modules:
+else:
     print("Skipping NIX C++ bindings.")
+    ext_modules = []
 
 setup(name             = 'nixio',
       version          = VERSION,

--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,7 @@ classifiers   = [
                     'Programming Language :: Python :: 2.6',
                     'Programming Language :: Python :: 2.7',
                     'Programming Language :: Python :: 3.4',
+                    'Programming Language :: Python :: 3.5',
                     'Topic :: Scientific/Engineering'
 ]
 


### PR DESCRIPTION
Setup script updated to support building without the NIX dependency.

The setup script detects if NIX is available by attempting to compile a dummy C++ file that simply imports `nix.hpp` and checking if it fails (see new file `checknix.py`).

Additionally, Python only builds can now be explicitly performed using `python setup.py build --pyonly`.

Travis build config now includes 4 configurations: Python 2.7 and 3.4 with and without NIX.
