### PR TITLE
Windows: Add wheel and appveyor support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,158 @@
+version: 1.0.{build}
+environment:
+  NIX_VERSION: 1.2.0
+  NIX_BUILD_DIR: C:\nix_build
+  DEPLOY_DIR: deploy
+  BOOST_VERSION: 1.56.0
+  BOOST_VERSION_SHORT: 1_56
+  matrix:
+  - PYVER: 27
+    BITTNESS: 64
+  - PYVER: 27
+    BITTNESS: 32
+  - PYVER: 34
+    BITTNESS: 64
+  - PYVER: 34
+    BITTNESS: 32
+  - PYVER: 35
+    BITTNESS: 64
+  - PYVER: 35
+    BITTNESS: 32
+build_script:
+- ps: >-
+    function Check-Error
+
+    {
+      param([int]$SuccessVal = 0)
+      if ($SuccessVal -ne $LastExitCode) {
+        throw "Failed with exit code $LastExitCode"
+      }
+    }
+
+
+    $old_path = "$env:PYTHONPATH"
+
+    $env:PYTHONPATH = "$env:APPVEYOR_BUILD_FOLDER;$env:PYTHONPATH"
+
+
+    if ($env:BITTNESS -eq "64") {
+      $PYTHON_ROOT = "C:\Python$env:PYVER-x64"
+      $BITS = "64"
+      $vcvars = "x86_amd64"
+    } else {
+      $PYTHON_ROOT = "C:\Python$env:PYVER"
+      $BITS = "32"
+      $vcvars = "x86"
+    }
+
+    $env:PATH = "$PYTHON_ROOT;$PYTHON_ROOT\Scripts;$env:PATH;C:\Program Files\7-Zip;$env:NIX_BUILD_DIR\nix\bin"
+
+
+    python -c "import sys;print('Python version is {}'.format(sys.version))"
+
+    Check-Error
+
+
+    mkdir "$env:NIX_BUILD_DIR"
+
+    Check-Error
+
+    mkdir "$env:DEPLOY_DIR"
+
+    Check-Error
+
+
+    cd "$env:NIX_BUILD_DIR"
+
+    mkdir nix
+
+    Check-Error
+
+    cd nix
+
+    Invoke-WebRequest "https://github.com/G-Node/nix/releases/download/$env:NIX_VERSION/nix-$env:NIX_VERSION-win$BITS.exe" -OutFile "nix.exe"
+
+    Check-Error
+
+    7z x nix.exe
+
+    Check-Error
+
+    cd ..\
+
+
+    mkdir boost
+
+    mkdir boost_build
+
+    cd boost
+
+    $under = "$env:BOOST_VERSION" -replace "\.", "_"
+
+    Invoke-WebRequest "http://pilotfiber.dl.sourceforge.net/project/boost/boost/$env:BOOST_VERSION/boost_$under.7z" -OutFile "boost.7z"
+
+    Check-Error
+
+    7z x boost.7z
+
+    Check-Error
+
+    cd boost_$under
+
+
+    echo "call ""\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat"" $vcvars && bootstrap && .\b2 install -j4 -a --prefix=$env:NIX_BUILD_DIR\boost_build toolset=msvc-12.0 architecture=x86 address-model=$BITS threading=multi variant=release link=static runtime-link=shared --with-python" | out-file -filepath "nix_compile.bat" -encoding ASCII
+
+    .\nix_compile.bat
+
+    Check-Error
+
+
+    Copy-Item -Path "$env:NIX_BUILD_DIR\nix\COPYING","$env:NIX_BUILD_DIR\nix\LICENSE*" -Destination "$env:NIX_BUILD_DIR\nix\bin"
+
+    Check-Error
+
+
+    $env:BOOST_INCDIR = "$env:NIX_BUILD_DIR\boost_build\include\boost-$env:BOOST_VERSION_SHORT"
+
+    $env:BOOST_LIBDIR = "$env:NIX_BUILD_DIR\boost_build\lib"
+
+    $env:NIX_LIBDIR = "$env:NIX_BUILD_DIR\nix\lib"
+
+    $env:NIX_INCDIR = "$env:NIX_BUILD_DIR\nix\include"
+
+
+    python -m pip install pip wheel setuptools --upgrade
+
+    Check-Error
+
+    python -m pip install numpy --upgrade
+
+    Check-Error
+
+
+    $env:NIXPY_WHEEL_BINARIES = "$env:NIX_BUILD_DIR\nix\bin"
+
+    cd "$env:APPVEYOR_BUILD_FOLDER"
+
+
+    $env:DISTUTILS_USE_SDK = "1"
+
+    $env:MSSdk = "1"
+
+    echo "call ""\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat"" $vcvars" | out-file -filepath "python_compile.bat" -encoding ASCII
+
+    echo "python setup.py bdist_wheel -d ""$env:DEPLOY_DIR"" --with-nix" | out-file -filepath "python_compile.bat" -append -encoding ASCII
+
+    if ($env:BITTNESS -eq "64" -and $env:PYVER -eq "27") {
+      echo "python setup.py sdist -d ""$env:DEPLOY_DIR"" --with-nix" | out-file -filepath "python_compile.bat" -append -encoding ASCII
+    }
+
+    .\python_compile.bat
+
+    Check-Error
+
+
+    $env:PYTHONPATH = "$old_path"
+artifacts:
+- path: $(DEPLOY_DIR)\*
+  name: wheels

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -89,7 +89,7 @@ build_script:
 
     $under = "$env:BOOST_VERSION" -replace "\.", "_"
 
-    Invoke-WebRequest "http://pilotfiber.dl.sourceforge.net/project/boost/boost/$env:BOOST_VERSION/boost_$under.7z" -OutFile "boost.7z"
+    Invoke-WebRequest "http://heanet.dl.sourceforge.net/project/boost/boost/$env:BOOST_VERSION/boost_$under.7z" -OutFile "boost.7z"
 
     Check-Error
 

--- a/checknix.py
+++ b/checknix.py
@@ -30,9 +30,10 @@ def check_nix(library_dirs=(), include_dirs=(), compile_args=()):
     compiler = distutils.ccompiler.new_compiler()
     assert isinstance(compiler, distutils.ccompiler.CCompiler)
 
-    compiler.library_dirs.extend(library_dirs)
-    compiler.include_dirs.extend(include_dirs)
     distutils.sysconfig.customize_compiler(compiler)
+    compiler.initialize()
+    compiler.set_library_dirs(library_dirs)
+    compiler.set_include_dirs(include_dirs)
 
     stderr = os.dup(sys.stderr.fileno())
     errfile = open(os.path.join(tmpdir, "check_nix.err"), 'w')

--- a/checknix.py
+++ b/checknix.py
@@ -31,7 +31,6 @@ def check_nix(library_dirs=(), include_dirs=(), compile_args=()):
     assert isinstance(compiler, distutils.ccompiler.CCompiler)
 
     distutils.sysconfig.customize_compiler(compiler)
-    compiler.initialize()
     compiler.set_library_dirs(library_dirs)
     compiler.set_include_dirs(include_dirs)
 

--- a/findboost.py
+++ b/findboost.py
@@ -32,6 +32,11 @@ class BoostPyLib(object):
         return self.major == major and self.minor == minor and (ignore_threading or self.threadsafe == threadsafe)
 
     @property
+    def library_name(self):
+        name, ext = os.path.splitext(self.filename)
+        return name if ext.endswith('lib') else name[3:]
+
+    @property
     def link_directive(self):
         name, ext = os.path.splitext(self.filename)
         if ext == 'lib':
@@ -126,6 +131,7 @@ class BoostPyLib(object):
             ('libboost_python.lib', (None, None, False)),
             ('libboost_python-mt.dylib', (None, None, True)),
             ('libboost_python-vc120-mt-1_57.lib', (None, None, True)),
+            ('libboost_python-vc120-mt-1_61.lib', (None, None, True)),
             ('/usr/lib/libboost_python.a', None)]
 
         try:

--- a/nixio/__init__.py
+++ b/nixio/__init__.py
@@ -20,7 +20,14 @@ try:
 except ImportError:
     pass
 
+import sys
+import os
+
 __all__ = ("File", "FileMode", "DataType", "Value", "LinkType", "DimensionType")
 
 __author__ = ('Christian Kellner, Adrian Stoewer, Andrey Sobolev, Jan Grewe,'
               ' Balint Morvai')
+
+_nixio_bin = os.path.join(sys.prefix, 'share', 'nixio', 'bin')
+if os.path.isdir(_nixio_bin):
+    os.environ["PATH"] += os.pathsep + _nixio_bin

--- a/setup.py
+++ b/setup.py
@@ -80,10 +80,7 @@ is_win = os.name == 'nt'
 
 nix_inc_dir = os.getenv('NIX_INCDIR', '/usr/local/include')
 nix_lib_dir = os.getenv('NIX_LIBDIR', '/usr/local/lib')
-if not is_win:
-    nix_lnk_arg = ['-lnix']
-else:
-    nix_lnk_arg = ['/LIBPATH:'+nix_lib_dir, '/DEFAULTLIB:nix.lib']
+nix_lib = 'nix'
 
 nixpy_sources = [
     'src/core.cc',
@@ -121,6 +118,7 @@ boost_libs = BoostPyLib.list_in_dirs(lib_dirs)
 boost_lib = BoostPyLib.find_lib_for_current_python(boost_libs)
 library_dirs = [boost_lib_dir, nix_lib_dir]
 include_dirs = [boost_inc_dir, nix_inc_dir, np_inc_dir, 'src']
+libraries = [nix_lib]
 compile_args = ['--std=c++11'] if not is_win else ['/DBOOST_PYTHON_STATIC_LIB',
                                                    '/EHsc']
 
@@ -139,12 +137,12 @@ if with_nix:
         print("Available boost python libs:\n" + "\n".join(map(str, boost_libs)))
         sys.exit(-1)
 
-    boost_lnk_arg = boost_lib.link_directive
+    libraries.append(boost_lib.library_name)
 
     native_ext = Extension(
         'nixio.core',
         extra_compile_args=['-std=c++11'] if not is_win else ['/DBOOST_PYTHON_STATIC_LIB', '/EHsc'],
-        extra_link_args=boost_lnk_arg + nix_lnk_arg,
+        libraries=libraries,
         sources=nixpy_sources,
         runtime_library_dirs=library_dirs if not is_win else None,
         **pkg_config(

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,15 @@ def pkg_config(*packages, **kw):
 
     return kw
 
+def get_wheel_data():
+    data = []
+    bin = os.environ.get('NIXPY_WHEEL_BINARIES', '')
+    if bin and os.path.isdir(bin):
+        data.append(
+            ('share/nixio/bin',
+             [os.path.join(bin, f) for f in os.listdir(bin)]))
+    return data
+
 is_win = os.name == 'nt'
 
 nix_inc_dir = os.getenv('NIX_INCDIR', '/usr/local/include')
@@ -175,5 +184,6 @@ setup(name             = 'nixio',
       package_data     = {'nixio': [license_text, description_text]},
       include_package_data = True,
       zip_safe         = False,
+      data_files=get_wheel_data()
 )
 


### PR DESCRIPTION
Regarding wheels, this works by getting the most recent nix (currently the version is set using `NIX_VERSION` in appveyor) binaries and including them in the wheel. It adds them under share/nixio/bin in your python installation folder. Then at runtime that folder, if it exists, is added to the PATH.

This is how we do it at [kivy ](https://github.com/kivy/kivy) and is similarly how numpy [does it](https://github.com/numpy/numpy/issues/6923) (although a bit differently). This makes it easy to install and uninstall since you just need to do pip install wheel_name, provided you have the numpy and h5py dependencies installed of course. If it's uploaded to pypi, then they just do `pip install nixio`.

When packaging and building a end user exe using e.g. pyinstaller, for projects that use nixio, this is also super easy, as the project just specifies that pyinstaller include the contents of that folder which includes al the binaries.

Currently, it works with 64 and 32 bit versions of py 2.7, 3.4, and 3.5. The wheels are found under the [artifacts tab](https://ci.appveyor.com/project/matham/nixpy/build/1.0.52) for each build.

For you to make it work, you'd need to merge this PR and then in appveyor you'd import the nixpy project in your account and in the settings tell it it to build all the branches, but only the branches that include an appveyor.yml file. The settings that run the builds will then be provided by the appveyor.yml file included in the PR (most of the setting in the general tab in appveyor control panel cannot be controlled from the appveyor.yml file so you have to set them there).

Finally, the docs need to be updated, but that can be done after we're sure it works. Also, I tried to set up the tests to run on appveyor for each build, however, the h5py and numpy wheels, when using vanilla python, must be downloaded from www.lfd.uci.edu/~gohlke/pythonlibs/ which cannot be done from the command line. So I couldn't run it. We could download manually and then upload those wheels somewhere if you have a server, in which case it should be easy to setup the tests to run automatically. Finally, appveyor runs and generates wheels for every commit, PR, and git tag. So automatic tests would be useful there.