### PR TITLE
Adds bools to valid_types

### DIFF
--- a/nixio/value.py
+++ b/nixio/value.py
@@ -18,7 +18,7 @@ except NameError:
 
 bools = (bool, np.bool_)
 
-valid_types = (Number, strings)
+valid_types = (Number, strings, bools)
 
 
 class DataType(object):


### PR DESCRIPTION
This change is necessary for [Neo](https://github.com/NeuralEnsemble/python-neo/blob/master/neo/io/nixio.py) to save a nix file. Specific use case was saving a Neo block loaded from a Blackrock .nev file.


```
data_block = neo.io.BlackrockIO(file_name, verbose=False).read_block(name=file_name,
                                                                   nsx_to_load=None,
                                                                   channels='all',
                                                                   units='all',
                                                                   load_waveforms=False,
                                                                   load_events=True,
                                                                   lazy=False,
                                                                   cascade=True)

writer = neo.io.NixIO(filename='b.nix', mode="ow")
writer.write_block(data_block)
```