### PR TITLE
Fix "Invalid format string" error in now_int

### DIFF
--- a/nixio/pycore/util/util.py
+++ b/nixio/pycore/util/util.py
@@ -93,8 +93,13 @@ def check_entity_input(entity, raise_exception=True):
 
 
 def now_int():
-    now = datetime.now()
-    return int(now.strftime("%s"))
+    """
+    Returns the current POSIX time as an integer.
+
+    :return: integer POSIX time
+    """
+    now = datetime.now() - datetime(1970, 1, 1)
+    return int(now.total_seconds())
 
 
 def time_to_str(t):


### PR DESCRIPTION
Currently, when simply creating a file, e.g. with `f = nix.File.open(file_name, nix.FileMode.Overwrite)` I get the following error:

```
Traceback (most recent call last):
  File "G:\Python\libs\Playground\src\nix.py", line 6, in <module>
    f = nix.File.open(file_name, nix.FileMode.Overwrite)
  File "E:\Python27_x64\lib\site-packages\nixio\pycore\file.py", line 130, in open
    return cls._open(path, mode)
  File "E:\Python27_x64\lib\site-packages\nixio\pycore\file.py", line 101, in _open
    newfile = cls._create_new(path, h5mode)
  File "E:\Python27_x64\lib\site-packages\nixio\pycore\file.py", line 83, in _create_new
    newfile = cls(h5file)
  File "E:\Python27_x64\lib\site-packages\nixio\pycore\file.py", line 64, in __init__
    self.force_created_at()
  File "E:\Python27_x64\lib\site-packages\nixio\pycore\file.py", line 188, in force_created_at
    t = util.now_int()
  File "E:\Python27_x64\lib\site-packages\nixio\pycore\util\util.py", line 97, in now_int
    return int(now.strftime("%s"))
ValueError: Invalid format string
```

I'm assuming my fix is how it's supposed to be? I'm not sure why no one else is getting this error?