### PR TITLE
Add bins to path early

### DIFF
--- a/nixio/__init__.py
+++ b/nixio/__init__.py
@@ -8,6 +8,13 @@
 
 from __future__ import (absolute_import, division, print_function)#, unicode_literals)
 
+import sys
+import os
+
+_nixio_bin = os.path.join(sys.prefix, 'share', 'nixio', 'bin')
+if os.path.isdir(_nixio_bin):
+    os.environ["PATH"] += os.pathsep + _nixio_bin
+
 from nixio.pycore.file import File, FileMode
 from nixio.value import Value, DataType
 from nixio.dimension_type import DimensionType
@@ -20,14 +27,7 @@ try:
 except ImportError:
     pass
 
-import sys
-import os
-
 __all__ = ("File", "FileMode", "DataType", "Value", "LinkType", "DimensionType")
 
 __author__ = ('Christian Kellner, Adrian Stoewer, Andrey Sobolev, Jan Grewe,'
               ' Balint Morvai')
-
-_nixio_bin = os.path.join(sys.prefix, 'share', 'nixio', 'bin')
-if os.path.isdir(_nixio_bin):
-    os.environ["PATH"] += os.pathsep + _nixio_bin


### PR DESCRIPTION
If nixio is imported before the binaries are added to path the hdf5 backend doesn't work and instead h5py is used.