### PR TITLE
Appveyor builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
           env: NIX_LIBDIR=./nix-build/inst/lib NIX_INCDIR=./nix-build/inst/include
         - python: "2.7_with_system_site_packages"
         - python: "3.4"
+        - python: "3.5"
 
 addons:
   apt:
@@ -29,7 +30,7 @@ install:
   - pip install --upgrade numpy coveralls h5py
   #build NIX
   - if [ -n "$NIX_LIBDIR" ]; then
-      git clone https://github.com/G-Node/nix.git nix-build;
+      git clone --branch master https://github.com/G-Node/nix.git nix-build;
       pushd nix-build;
       cmake -DCMAKE_INSTALL_PREFIX=./inst -DBUILD_TESTING=OFF .;
       make;

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Versions
 This repository's `master` is the development branch of *NIXPY*.
 It is not guaranteed to build or work properly with the *NIX* (HDF5) backend.
 At times it may not even work at all.
-We strongly recommend using the latest stable version, which can be found on PyPI as nixio_ 
+We strongly recommend using the latest stable version, which can be found on PyPI as nixio_.
 
 About NIXPY
 -----------

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,7 @@
 .. image:: https://travis-ci.org/G-Node/nixpy.svg?branch=master
     :target: https://travis-ci.org/G-Node/nixpy
+.. image:: https://ci.appveyor.com/api/projects/status/8hi7323w3lijr16y/branch/master?svg=true
+    :target: https://ci.appveyor.com/project/achilleas-k/nixpy/branch/master
 .. image:: https://coveralls.io/repos/github/G-Node/nixpy/badge.svg?branch=master
     :target: https://coveralls.io/github/G-Node/nixpy?branch=master
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,158 +1,122 @@
 version: 1.2.0-3.{build}
+
 environment:
+
   NIX_VERSION: 1.2.0
   NIX_BUILD_DIR: C:\nix_build
   DEPLOY_DIR: deploy
-  BOOST_VERSION: 1.56.0
-  BOOST_VERSION_SHORT: 1_56
+  BOOST_ROOT: C:\Libraries\boost_1_62_0
+
+  NIX_APPVEYOR_ROOT: https://ci.appveyor.com/api/projects/stoewer/nix/artifacts/build
+
+
   matrix:
-  - PYVER: 27
-    BITTNESS: 64
-  - PYVER: 27
-    BITTNESS: 32
-  - PYVER: 34
-    BITTNESS: 64
-  - PYVER: 34
-    BITTNESS: 32
+    # Miniconda 32 bit
+    - MINICONDA: "C:\\Miniconda"
+      bits: 32
+      withnix: "--without-nix"
+    - MINICONDA: "C:\\Miniconda"
+      bits: 32
+      withnix: "--with-nix"
+
+    # Miniconda35 32 bit
+    - MINICONDA: "C:\\Miniconda35"
+      bits: 32
+      withnix: "--without-nix"
+    - MINICONDA: "C:\\Miniconda35"
+      bits: 32
+      withnix: "--with-nix"
+
+    # Miniconda 64 bit
+    - MINICONDA: "C:\\Miniconda-x64"
+      bits: 64
+      withnix: "--without-nix"
+    - MINICONDA: "C:\\Miniconda-x64"
+      bits: 64
+      withnix: "--with-nix"
+
+    # Miniconda35 64 bit
+    - MINICONDA: "C:\\Miniconda35-x64"
+      bits: 64
+      withnix: "--without-nix"
+    - MINICONDA: "C:\\Miniconda35-x64"
+      bits: 64
+      withnix: "--with-nix"
+
+matrix:
+    allow_failures:
+        - withnix: "--with-nix"
+
+init:
+  - "ECHO %MINICONDA% %vcvars% (%bits%)"
+  - ps: $env:PATH = "$env:MINICONDA;$env:MINICONDA\Scripts;$env:PATH;C:\Program Files\7-Zip;$env:NIX_BUILD_DIR\nix\bin"
+  - python -c "import sys;print('Python version is {}'.format(sys.version))"
+
+install:
+
+    - ps: |
+        if ($env:bits -eq "64") {
+            $env:vcvars = "x86_amd64"
+            $env:avjob = "job=Environment%3A%20PLATFORM%3Dx64%2C%20CONFIGURATION%3DRelease"
+            $env:avfname = "nix-$env:NIX_VERSION-win64.exe"
+        } else {
+            $env:vcvars = "x86"
+            $env:avjob = "job=Environment%3A%20PLATFORM%3Dx86%2C%20CONFIGURATION%3DRelease"
+            $env:avfname = "nix-$env:NIX_VERSION-win32.exe"
+        }
+
+    - ps: |
+        if ($env:withnix -eq "--with-nix") {
+            mkdir "$env:NIX_BUILD_DIR"
+            cd "$env:NIX_BUILD_DIR"
+            mkdir nix
+            cd nix
+
+            $env:nix_exe_url = "$env:NIX_APPVEYOR_ROOT/$env:avfname`?$env:avjob"
+            Write-Host "Downloading $env:nix_exe_url"
+
+            Invoke-WebRequest -URI $env:nix_exe_url -OutFile "nix.exe"
+
+            7z x nix.exe
+
+            cd ..
+
+            $env:BOOST_INC_DIR = "$env:BOOST_ROOT\include"
+            $env:BOOST_LIB_DIR = "$env:BOOST_ROOT\lib"
+        }
+
+    - conda update --all --yes
+
+    - conda install --yes numpy
+
+    - conda install --yes h5py
+
+    - ps: cd "$env:APPVEYOR_BUILD_FOLDER"
+
+    - ps: $env:DISTUTILS_USE_SDK = "1"
+
+    - ps: $env:MSSdk = "1"
+
 build_script:
-- ps: >-
-    function Check-Error
+    - python setup.py build %withnix%
 
-    {
-      param([int]$SuccessVal = 0)
-      if ($SuccessVal -ne $LastExitCode) {
-        throw "Failed with exit code $LastExitCode"
-      }
-    }
+test_script:
+    - python setup.py test
 
+after_test:
+    - ps: mkdir "$env:DEPLOY_DIR"
 
-    $old_path = "$env:PYTHONPATH"
+    - python setup.py bdist_wheel -d %DEPLOY_DIR% %withnix%
 
-    $env:PYTHONPATH = "$env:APPVEYOR_BUILD_FOLDER;$env:PYTHONPATH"
+    - ps: |
+        if ($env:bits -eq "64" -and $env:PYVER -eq "27") {
+            python setup.py sdist -d $env:DEPLOY_DIR $env:withnix
+        }
 
-
-    if ($env:BITTNESS -eq "64") {
-      $PYTHON_ROOT = "C:\Python$env:PYVER-x64"
-      $BITS = "64"
-      $vcvars = "x86_amd64"
-    } else {
-      $PYTHON_ROOT = "C:\Python$env:PYVER"
-      $BITS = "32"
-      $vcvars = "x86"
-    }
-
-    $env:PATH = "$PYTHON_ROOT;$PYTHON_ROOT\Scripts;$env:PATH;C:\Program Files\7-Zip;$env:NIX_BUILD_DIR\nix\bin"
-
-
-    python -c "import sys;print('Python version is {}'.format(sys.version))"
-
-    Check-Error
-
-
-    mkdir "$env:NIX_BUILD_DIR"
-
-    Check-Error
-
-    mkdir "$env:DEPLOY_DIR"
-
-    Check-Error
-
-
-    cd "$env:NIX_BUILD_DIR"
-
-    mkdir nix
-
-    Check-Error
-
-    cd nix
-
-    Invoke-WebRequest "https://github.com/G-Node/nix/releases/download/$env:NIX_VERSION/nix-$env:NIX_VERSION-win$BITS.exe" -OutFile "nix.exe"
-
-    Check-Error
-
-    7z x nix.exe
-
-    Check-Error
-
-    cd ..\
-
-
-    mkdir boost
-
-    mkdir boost_build
-
-    cd boost
-
-    $under = "$env:BOOST_VERSION" -replace "\.", "_"
-
-    Invoke-WebRequest "http://heanet.dl.sourceforge.net/project/boost/boost/$env:BOOST_VERSION/boost_$under.7z" -OutFile "boost.7z"
-
-    Check-Error
-
-    7z x boost.7z
-
-    Check-Error
-
-    cd boost_$under
-
-
-    echo "call ""\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat"" $vcvars && bootstrap && .\b2 install -j4 -a --prefix=$env:NIX_BUILD_DIR\boost_build toolset=msvc-12.0 architecture=x86 address-model=$BITS threading=multi variant=release link=static runtime-link=shared --with-python" | out-file -filepath "nix_compile.bat" -encoding ASCII
-
-    .\nix_compile.bat
-
-    Check-Error
-
-
-    Copy-Item -Path "$env:NIX_BUILD_DIR\nix\COPYING","$env:NIX_BUILD_DIR\nix\LICENSE*" -Destination "$env:NIX_BUILD_DIR\nix\bin"
-
-    Check-Error
-
-
-    $env:BOOST_INCDIR = "$env:NIX_BUILD_DIR\boost_build\include\boost-$env:BOOST_VERSION_SHORT"
-
-    $env:BOOST_LIBDIR = "$env:NIX_BUILD_DIR\boost_build\lib"
-
-    $env:NIX_LIBDIR = "$env:NIX_BUILD_DIR\nix\lib"
-
-    $env:NIX_INCDIR = "$env:NIX_BUILD_DIR\nix\include"
-
-
-    python -m pip install pip wheel setuptools --upgrade
-
-    Check-Error
-
-    python -m pip install numpy --upgrade
-
-    Check-Error
-
-
-    $env:NIXPY_WHEEL_BINARIES = "$env:NIX_BUILD_DIR\nix\bin"
-
-    cd "$env:APPVEYOR_BUILD_FOLDER"
-
-
-    $env:DISTUTILS_USE_SDK = "1"
-
-    $env:MSSdk = "1"
-
-    echo "call ""\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat"" $vcvars" | out-file -filepath "python_compile.bat" -encoding ASCII
-
-    echo "python setup.py build --with-nix" | out-file -filepath "python_compile.bat" -append -encoding ASCII
-
-    echo "python setup.py test" | out-file -filepath "python_compile.bat" -append -encoding ASCII
-
-    echo "python setup.py bdist_wheel -d ""$env:DEPLOY_DIR"" --with-nix" | out-file -filepath "python_compile.bat" -append -encoding ASCII
-
-    if ($env:BITTNESS -eq "64" -and $env:PYVER -eq "27") {
-      echo "python setup.py sdist -d ""$env:DEPLOY_DIR"" --with-nix" | out-file -filepath "python_compile.bat" -append -encoding ASCII
-    }
-
-    .\python_compile.bat
-
-    Check-Error
-
-
-    $env:PYTHONPATH = "$old_path"
 artifacts:
 - path: $(DEPLOY_DIR)\*
   name: wheels
+
+# Uncomment on_finish block to enable RDP
+# on_finish:
+#   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -137,6 +137,10 @@ build_script:
 
     echo "call ""\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat"" $vcvars" | out-file -filepath "python_compile.bat" -encoding ASCII
 
+    echo "python setup.py build --with-nix" | out-file -filepath "python_compile.bat" -append -encoding ASCII
+
+    echo "python setup.py test" | out-file -filepath "python_compile.bat" -append -encoding ASCII
+
     echo "python setup.py bdist_wheel -d ""$env:DEPLOY_DIR"" --with-nix" | out-file -filepath "python_compile.bat" -append -encoding ASCII
 
     if ($env:BITTNESS -eq "64" -and $env:PYVER -eq "27") {

--- a/findboost.py
+++ b/findboost.py
@@ -4,13 +4,10 @@
 from __future__ import print_function
 from __future__ import division
 
-import functools
 import os
 import re
 import sys
 from operator import itemgetter
-
-import operator
 
 try:
     from commands import getstatusoutput
@@ -57,7 +54,7 @@ class BoostPyLib(object):
         cmd = "%s --print-search-dirs | grep ^libraries" % cc
         res, out = getstatusoutput(cmd)
         if res != 0:
-            print("Warning: \"%s\" failed with %d" % (cmd, res), file=sys.stderr)
+            print("WARNING: \"%s\" failed with %d" % (cmd, res), file=sys.stderr)
             return dirs
 
         start = out.find("=") + 1

--- a/nixio/__init__.py
+++ b/nixio/__init__.py
@@ -6,7 +6,14 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 
-from __future__ import (absolute_import, division, print_function)#, unicode_literals)
+from __future__ import (absolute_import, division, print_function)
+
+import sys
+import os
+
+_nixio_bin = os.path.join(sys.prefix, 'share', 'nixio', 'bin')
+if os.path.isdir(_nixio_bin):
+    os.environ["PATH"] += os.pathsep + _nixio_bin
 
 import sys
 import os
@@ -27,7 +34,8 @@ try:
 except ImportError:
     pass
 
-__all__ = ("File", "FileMode", "DataType", "Value", "LinkType", "DimensionType")
+__all__ = ("File", "FileMode", "DataType", "Value",
+           "LinkType", "DimensionType")
 
 __author__ = ('Christian Kellner, Adrian Stoewer, Andrey Sobolev, Jan Grewe,'
               ' Balint Morvai')

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -7,8 +7,6 @@
 # LICENSE file in the root of the Project.
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
-import sys
-
 import nixio.util.find as finders
 from nixio.util.proxy_list import ProxyList
 

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -5,7 +5,8 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
-from __future__ import (absolute_import, division, print_function, unicode_literals)
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 import nixio.util.find as finders
 from nixio.util.proxy_list import ProxyList

--- a/nixio/pycore/section.py
+++ b/nixio/pycore/section.py
@@ -127,6 +127,7 @@ class Section(NamedEntity, SectionMixin):
         properties = self._h5group.open_group("properties")
         return Property(properties.get_by_id_or_name(id_or_name))
 
+
     def _get_property_by_pos(self, pos):
         properties = self._h5group.open_group("properties")
         return Property(properties.get_by_pos(pos))

--- a/nixio/test/test_backend_compatibility.py
+++ b/nixio/test/test_backend_compatibility.py
@@ -456,7 +456,7 @@ class _TestBackendCompatibility(unittest.TestCase):
         sec.create_property("prop Float", nix.DataType.Float)
         sec.create_property("prop Double", nix.DataType.Double)
         sec.create_property("prop String", nix.DataType.String)
-        # sec.create_property("prop Bool", nix.DataType.Bool)
+        sec.create_property("prop Bool", nix.DataType.Bool)
 
         sec.props[0].mapping = "mapping"
         sec.props[1].definition = "def"

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ def pkg_config(*packages, **kw):
     if status != 0:
         err_str = 'Some packages were not found: %s [%s]' % (pkg_string, out)
         if ignore_error:
-            sys.stderr.write('WARNING: ' + err_str)
+            sys.stderr.write('WARNING: ' + err_str + "\n")
             out = ''
         else:
             raise PackageNotFoundError(err_str)
@@ -130,7 +130,7 @@ classifiers   = [
 
 boost_inc_dir = os.getenv('BOOST_INCDIR', '/usr/local/include')
 boost_lib_dir = os.getenv('BOOST_LIBDIR', '/usr/local/lib')
-lib_dirs = BoostPyLib.library_search_dirs([boost_lib_dir])
+lib_dirs = BoostPyLib.library_search_dirs([boost_lib_dir]) if not is_win else []
 boost_libs = BoostPyLib.list_in_dirs(lib_dirs)
 boost_lib = BoostPyLib.find_lib_for_current_python(boost_libs)
 library_dirs = [boost_lib_dir, nix_lib_dir]

--- a/src/PyDataSet.cpp
+++ b/src/PyDataSet.cpp
@@ -78,6 +78,10 @@ static nix::DataType pyDtypeToNixDtype(const PyArray_Descr *dtype)
         return nix::DataType::String;
         break;
 
+    case 'b':
+        return nix::DataType::Bool;
+        break;
+
     default:
         break;
     }
@@ -87,18 +91,19 @@ static nix::DataType pyDtypeToNixDtype(const PyArray_Descr *dtype)
 static std::string nixDtypeToPyDtypeStr(nix::DataType nix_dtype)
 {
     switch (nix_dtype) {
-    case nix::DataType::UInt8:  return "<u1";
-    case nix::DataType::UInt16: return "<u2";
-    case nix::DataType::UInt32: return "<u4";
-    case nix::DataType::UInt64: return "<u8";
-    case nix::DataType::Int8:   return "<i1";
-    case nix::DataType::Int16:  return "<i2";
-    case nix::DataType::Int32:  return "<i4";
-    case nix::DataType::Int64:  return "<i8";
-    case nix::DataType::Float:  return "<f4";
-    case nix::DataType::Double: return "<f8";
-    case nix::DataType::Opaque: return "|V1";
-    default:                    return "";
+        case nix::DataType::Bool:   return "<b1";
+        case nix::DataType::UInt8:  return "<u1";
+        case nix::DataType::UInt16: return "<u2";
+        case nix::DataType::UInt32: return "<u4";
+        case nix::DataType::UInt64: return "<u8";
+        case nix::DataType::Int8:   return "<i1";
+        case nix::DataType::Int16:  return "<i2";
+        case nix::DataType::Int32:  return "<i4";
+        case nix::DataType::Int64:  return "<i8";
+        case nix::DataType::Float:  return "<f4";
+        case nix::DataType::Double: return "<f8";
+        case nix::DataType::Opaque: return "|V1";
+        default:                    return "";
     }
 }
 

--- a/src/PyProperty.cpp
+++ b/src/PyProperty.cpp
@@ -86,6 +86,8 @@ struct value_transmogrify {
             case DataType::String:
                 pyvalue = PyObject_CallFunction(PyValueClass, "s", value.get<std::string>().c_str());
                 break;
+            default:
+                return nullptr;
         }
 
         PyObject_SetAttrString(pyvalue, "reference", PyUnicode_FromString(value.reference.c_str()));


### PR DESCRIPTION
Major cleanup of appveyor build configuration.

- Use Miniconda for h5py.
- Use latest build NIX from Appveyor.
- Run tests.
- Build Windows wheels for distribution.
- *Ignore failures when building against NIX C++ backend.*