### PR TITLE
Version compatibility checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
           env: NIX_LIBDIR=./nix-build/inst/lib NIX_INCDIR=./nix-build/inst/include
         - python: "2.7_with_system_site_packages"
         - python: "3.4"
+        - python: "3.5"
 
 addons:
   apt:
@@ -29,7 +30,7 @@ install:
   - pip install --upgrade numpy coveralls h5py
   #build NIX
   - if [ -n "$NIX_LIBDIR" ]; then
-      git clone https://github.com/G-Node/nix.git nix-build;
+      git clone --branch master https://github.com/G-Node/nix.git nix-build;
       pushd nix-build;
       cmake -DCMAKE_INSTALL_PREFIX=./inst -DBUILD_TESTING=OFF .;
       make;

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Versions
 This repository's `master` is the development branch of *NIXPY*.
 It is not guaranteed to build or work properly with the *NIX* (HDF5) backend.
 At times it may not even work at all.
-We strongly recommend using the latest stable version, which can be found on PyPI as nixio_ 
+We strongly recommend using the latest stable version, which can be found on PyPI as nixio_.
 
 About NIXPY
 -----------

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,7 @@
 .. image:: https://travis-ci.org/G-Node/nixpy.svg?branch=master
     :target: https://travis-ci.org/G-Node/nixpy
+.. image:: https://ci.appveyor.com/api/projects/status/8hi7323w3lijr16y/branch/master?svg=true
+    :target: https://ci.appveyor.com/project/achilleas-k/nixpy/branch/master
 .. image:: https://coveralls.io/repos/github/G-Node/nixpy/badge.svg?branch=master
     :target: https://coveralls.io/github/G-Node/nixpy?branch=master
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,158 +1,122 @@
 version: 1.2.0-3.{build}
+
 environment:
+
   NIX_VERSION: 1.2.0
   NIX_BUILD_DIR: C:\nix_build
   DEPLOY_DIR: deploy
-  BOOST_VERSION: 1.56.0
-  BOOST_VERSION_SHORT: 1_56
+  BOOST_ROOT: C:\Libraries\boost_1_62_0
+
+  NIX_APPVEYOR_ROOT: https://ci.appveyor.com/api/projects/stoewer/nix/artifacts/build
+
+
   matrix:
-  - PYVER: 27
-    BITTNESS: 64
-  - PYVER: 27
-    BITTNESS: 32
-  - PYVER: 34
-    BITTNESS: 64
-  - PYVER: 34
-    BITTNESS: 32
+    # Miniconda 32 bit
+    - MINICONDA: "C:\\Miniconda"
+      bits: 32
+      withnix: "--without-nix"
+    - MINICONDA: "C:\\Miniconda"
+      bits: 32
+      withnix: "--with-nix"
+
+    # Miniconda35 32 bit
+    - MINICONDA: "C:\\Miniconda35"
+      bits: 32
+      withnix: "--without-nix"
+    - MINICONDA: "C:\\Miniconda35"
+      bits: 32
+      withnix: "--with-nix"
+
+    # Miniconda 64 bit
+    - MINICONDA: "C:\\Miniconda-x64"
+      bits: 64
+      withnix: "--without-nix"
+    - MINICONDA: "C:\\Miniconda-x64"
+      bits: 64
+      withnix: "--with-nix"
+
+    # Miniconda35 64 bit
+    - MINICONDA: "C:\\Miniconda35-x64"
+      bits: 64
+      withnix: "--without-nix"
+    - MINICONDA: "C:\\Miniconda35-x64"
+      bits: 64
+      withnix: "--with-nix"
+
+matrix:
+    allow_failures:
+        - withnix: "--with-nix"
+
+init:
+  - "ECHO %MINICONDA% %vcvars% (%bits%)"
+  - ps: $env:PATH = "$env:MINICONDA;$env:MINICONDA\Scripts;$env:PATH;C:\Program Files\7-Zip;$env:NIX_BUILD_DIR\nix\bin"
+  - python -c "import sys;print('Python version is {}'.format(sys.version))"
+
+install:
+
+    - ps: |
+        if ($env:bits -eq "64") {
+            $env:vcvars = "x86_amd64"
+            $env:avjob = "job=Environment%3A%20PLATFORM%3Dx64%2C%20CONFIGURATION%3DRelease"
+            $env:avfname = "nix-$env:NIX_VERSION-win64.exe"
+        } else {
+            $env:vcvars = "x86"
+            $env:avjob = "job=Environment%3A%20PLATFORM%3Dx86%2C%20CONFIGURATION%3DRelease"
+            $env:avfname = "nix-$env:NIX_VERSION-win32.exe"
+        }
+
+    - ps: |
+        if ($env:withnix -eq "--with-nix") {
+            mkdir "$env:NIX_BUILD_DIR"
+            cd "$env:NIX_BUILD_DIR"
+            mkdir nix
+            cd nix
+
+            $env:nix_exe_url = "$env:NIX_APPVEYOR_ROOT/$env:avfname`?$env:avjob"
+            Write-Host "Downloading $env:nix_exe_url"
+
+            Invoke-WebRequest -URI $env:nix_exe_url -OutFile "nix.exe"
+
+            7z x nix.exe
+
+            cd ..
+
+            $env:BOOST_INC_DIR = "$env:BOOST_ROOT\include"
+            $env:BOOST_LIB_DIR = "$env:BOOST_ROOT\lib"
+        }
+
+    - conda update --all --yes
+
+    - conda install --yes numpy
+
+    - conda install --yes h5py
+
+    - ps: cd "$env:APPVEYOR_BUILD_FOLDER"
+
+    - ps: $env:DISTUTILS_USE_SDK = "1"
+
+    - ps: $env:MSSdk = "1"
+
 build_script:
-- ps: >-
-    function Check-Error
+    - python setup.py build %withnix%
 
-    {
-      param([int]$SuccessVal = 0)
-      if ($SuccessVal -ne $LastExitCode) {
-        throw "Failed with exit code $LastExitCode"
-      }
-    }
+test_script:
+    - python setup.py test
 
+after_test:
+    - ps: mkdir "$env:DEPLOY_DIR"
 
-    $old_path = "$env:PYTHONPATH"
+    - python setup.py bdist_wheel -d %DEPLOY_DIR% %withnix%
 
-    $env:PYTHONPATH = "$env:APPVEYOR_BUILD_FOLDER;$env:PYTHONPATH"
+    - ps: |
+        if ($env:bits -eq "64" -and $env:PYVER -eq "27") {
+            python setup.py sdist -d $env:DEPLOY_DIR $env:withnix
+        }
 
-
-    if ($env:BITTNESS -eq "64") {
-      $PYTHON_ROOT = "C:\Python$env:PYVER-x64"
-      $BITS = "64"
-      $vcvars = "x86_amd64"
-    } else {
-      $PYTHON_ROOT = "C:\Python$env:PYVER"
-      $BITS = "32"
-      $vcvars = "x86"
-    }
-
-    $env:PATH = "$PYTHON_ROOT;$PYTHON_ROOT\Scripts;$env:PATH;C:\Program Files\7-Zip;$env:NIX_BUILD_DIR\nix\bin"
-
-
-    python -c "import sys;print('Python version is {}'.format(sys.version))"
-
-    Check-Error
-
-
-    mkdir "$env:NIX_BUILD_DIR"
-
-    Check-Error
-
-    mkdir "$env:DEPLOY_DIR"
-
-    Check-Error
-
-
-    cd "$env:NIX_BUILD_DIR"
-
-    mkdir nix
-
-    Check-Error
-
-    cd nix
-
-    Invoke-WebRequest "https://github.com/G-Node/nix/releases/download/$env:NIX_VERSION/nix-$env:NIX_VERSION-win$BITS.exe" -OutFile "nix.exe"
-
-    Check-Error
-
-    7z x nix.exe
-
-    Check-Error
-
-    cd ..\
-
-
-    mkdir boost
-
-    mkdir boost_build
-
-    cd boost
-
-    $under = "$env:BOOST_VERSION" -replace "\.", "_"
-
-    Invoke-WebRequest "http://heanet.dl.sourceforge.net/project/boost/boost/$env:BOOST_VERSION/boost_$under.7z" -OutFile "boost.7z"
-
-    Check-Error
-
-    7z x boost.7z
-
-    Check-Error
-
-    cd boost_$under
-
-
-    echo "call ""\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat"" $vcvars && bootstrap && .\b2 install -j4 -a --prefix=$env:NIX_BUILD_DIR\boost_build toolset=msvc-12.0 architecture=x86 address-model=$BITS threading=multi variant=release link=static runtime-link=shared --with-python" | out-file -filepath "nix_compile.bat" -encoding ASCII
-
-    .\nix_compile.bat
-
-    Check-Error
-
-
-    Copy-Item -Path "$env:NIX_BUILD_DIR\nix\COPYING","$env:NIX_BUILD_DIR\nix\LICENSE*" -Destination "$env:NIX_BUILD_DIR\nix\bin"
-
-    Check-Error
-
-
-    $env:BOOST_INCDIR = "$env:NIX_BUILD_DIR\boost_build\include\boost-$env:BOOST_VERSION_SHORT"
-
-    $env:BOOST_LIBDIR = "$env:NIX_BUILD_DIR\boost_build\lib"
-
-    $env:NIX_LIBDIR = "$env:NIX_BUILD_DIR\nix\lib"
-
-    $env:NIX_INCDIR = "$env:NIX_BUILD_DIR\nix\include"
-
-
-    python -m pip install pip wheel setuptools --upgrade
-
-    Check-Error
-
-    python -m pip install numpy --upgrade
-
-    Check-Error
-
-
-    $env:NIXPY_WHEEL_BINARIES = "$env:NIX_BUILD_DIR\nix\bin"
-
-    cd "$env:APPVEYOR_BUILD_FOLDER"
-
-
-    $env:DISTUTILS_USE_SDK = "1"
-
-    $env:MSSdk = "1"
-
-    echo "call ""\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat"" $vcvars" | out-file -filepath "python_compile.bat" -encoding ASCII
-
-    echo "python setup.py build --with-nix" | out-file -filepath "python_compile.bat" -append -encoding ASCII
-
-    echo "python setup.py test" | out-file -filepath "python_compile.bat" -append -encoding ASCII
-
-    echo "python setup.py bdist_wheel -d ""$env:DEPLOY_DIR"" --with-nix" | out-file -filepath "python_compile.bat" -append -encoding ASCII
-
-    if ($env:BITTNESS -eq "64" -and $env:PYVER -eq "27") {
-      echo "python setup.py sdist -d ""$env:DEPLOY_DIR"" --with-nix" | out-file -filepath "python_compile.bat" -append -encoding ASCII
-    }
-
-    .\python_compile.bat
-
-    Check-Error
-
-
-    $env:PYTHONPATH = "$old_path"
 artifacts:
 - path: $(DEPLOY_DIR)\*
   name: wheels
+
+# Uncomment on_finish block to enable RDP
+# on_finish:
+#   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -137,6 +137,10 @@ build_script:
 
     echo "call ""\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat"" $vcvars" | out-file -filepath "python_compile.bat" -encoding ASCII
 
+    echo "python setup.py build --with-nix" | out-file -filepath "python_compile.bat" -append -encoding ASCII
+
+    echo "python setup.py test" | out-file -filepath "python_compile.bat" -append -encoding ASCII
+
     echo "python setup.py bdist_wheel -d ""$env:DEPLOY_DIR"" --with-nix" | out-file -filepath "python_compile.bat" -append -encoding ASCII
 
     if ($env:BITTNESS -eq "64" -and $env:PYVER -eq "27") {

--- a/findboost.py
+++ b/findboost.py
@@ -4,13 +4,10 @@
 from __future__ import print_function
 from __future__ import division
 
-import functools
 import os
 import re
 import sys
 from operator import itemgetter
-
-import operator
 
 try:
     from commands import getstatusoutput
@@ -57,7 +54,7 @@ class BoostPyLib(object):
         cmd = "%s --print-search-dirs | grep ^libraries" % cc
         res, out = getstatusoutput(cmd)
         if res != 0:
-            print("Warning: \"%s\" failed with %d" % (cmd, res), file=sys.stderr)
+            print("WARNING: \"%s\" failed with %d" % (cmd, res), file=sys.stderr)
             return dirs
 
         start = out.find("=") + 1

--- a/nixio/__init__.py
+++ b/nixio/__init__.py
@@ -6,7 +6,14 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 
-from __future__ import (absolute_import, division, print_function)#, unicode_literals)
+from __future__ import (absolute_import, division, print_function)
+
+import sys
+import os
+
+_nixio_bin = os.path.join(sys.prefix, 'share', 'nixio', 'bin')
+if os.path.isdir(_nixio_bin):
+    os.environ["PATH"] += os.pathsep + _nixio_bin
 
 import sys
 import os
@@ -27,7 +34,8 @@ try:
 except ImportError:
     pass
 
-__all__ = ("File", "FileMode", "DataType", "Value", "LinkType", "DimensionType")
+__all__ = ("File", "FileMode", "DataType", "Value",
+           "LinkType", "DimensionType")
 
 __author__ = ('Christian Kellner, Adrian Stoewer, Andrey Sobolev, Jan Grewe,'
               ' Balint Morvai')

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -7,8 +7,6 @@
 # LICENSE file in the root of the Project.
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
-import sys
-
 import nixio.util.find as finders
 from nixio.util.proxy_list import ProxyList
 

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -5,7 +5,8 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
-from __future__ import (absolute_import, division, print_function, unicode_literals)
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 import nixio.util.find as finders
 from nixio.util.proxy_list import ProxyList

--- a/nixio/pycore/exceptions/exceptions.py
+++ b/nixio/pycore/exceptions/exceptions.py
@@ -51,3 +51,10 @@ class IncompatibleDimensions(ValueError):
         self.message = "IncompatibleDimensions: {} evoked at: {})".format(what,
                                                                           where)
         super(IncompatibleDimensions, self).__init__(self.message)
+
+
+class InvalidFile(Exception):
+
+    def __init__(self):
+        self.message = "Invalid file - file is not a nix file."
+        super(InvalidFile, self).__init__(self.message)

--- a/nixio/pycore/file.py
+++ b/nixio/pycore/file.py
@@ -26,7 +26,7 @@ except ImportError:
 
 
 FILE_FORMAT = "nix"
-HDF_FF_VERSION = (1, 0, 0)
+HDF_FF_VERSION = (1, 1, 0)
 
 
 def can_write(nixfile):

--- a/nixio/pycore/file.py
+++ b/nixio/pycore/file.py
@@ -39,7 +39,7 @@ def map_file_mode(mode):
     elif mode == FileMode.Overwrite:
         return h5py.h5f.ACC_TRUNC
     else:
-        ValueError("Invalid file mode specified.")
+        raise ValueError("Invalid file mode specified.")
 
 
 def make_fapl():
@@ -124,7 +124,6 @@ class File(FileMixin):
             if CFile:
                 return CFile.open(path, mode)
             else:
-                # TODO: Brief instructions or web URL for building C++ files?
                 raise RuntimeError("HDF5 backend is not available.")
         elif backend == "h5py":
             return cls._open(path, mode)
@@ -232,7 +231,7 @@ class File(FileMixin):
         :rtype: bool
         """
         try:
-            _ = self._h5file.mode
+            self._h5file.mode
             return True
         except ValueError:
             return False

--- a/nixio/pycore/file.py
+++ b/nixio/pycore/file.py
@@ -123,8 +123,7 @@ class File(FileMixin):
 
         h5mode = map_file_mode(mode)
         newfile = cls._open_existing(path, h5mode)
-        if not newfile._check_header(mode):
-            raise exceptions.InvalidFile()
+        newfile._check_header(mode)
         newfile.mode = mode
         return newfile
 
@@ -161,14 +160,16 @@ class File(FileMixin):
 
     def _check_header(self, mode):
         if self.format != FILE_FORMAT:
-            return False
+            raise exceptions.InvalidFile()
 
         if mode == FileMode.ReadWrite:
-            return can_write(self)
+            if not can_write(self):
+                raise RuntimeError("Cannot open file for writing. "
+                                   "Incompatible version.")
         elif mode == FileMode.ReadOnly:
-            return can_read(self)
-        else:
-            return False
+            if not can_read(self):
+                raise RuntimeError("Cannot open file. "
+                                   "Incompatible version.")
 
 
     @property

--- a/nixio/pycore/file.py
+++ b/nixio/pycore/file.py
@@ -26,7 +26,7 @@ except ImportError:
 
 
 FILE_FORMAT = "nix"
-HDF_FF_VERSION = (1, 1, 0)
+HDF_FF_VERSION = (1, 0, 0)
 
 
 def can_write(nixfile):
@@ -179,14 +179,14 @@ class File(FileMixin):
 
         :type: tuple
         """
-        return tuple(self._h5file.attrs["version"])
+        return tuple(self._root.get_attr("version"))
 
     @version.setter
     def version(self, v):
         util.check_attr_type(v, tuple)
         for part in v:
             util.check_attr_type(part, int)
-        self._h5file.attrs["version"] = v
+        self._root.set_attr("version", v)
 
     @property
     def format(self):
@@ -196,12 +196,12 @@ class File(FileMixin):
 
         :type: str
         """
-        return self._h5file.attrs["format"].decode()
+        return self._root.get_attr("format")
 
     @format.setter
     def format(self, f):
         util.check_attr_type(f, str)
-        self._h5file.attrs["format"] = f.encode("utf-8")
+        self._root.set_attr("format", f)
 
     @property
     def created_at(self):

--- a/nixio/pycore/file.py
+++ b/nixio/pycore/file.py
@@ -114,6 +114,11 @@ class File(FileMixin):
         except (UnicodeError, LookupError):
             pass
 
+        if (not os.path.exists(path) and mode == FileMode.ReadOnly):
+            raise RuntimeError(
+                "Cannot open non-existent file in ReadOnly mode!"
+            )
+
         if (not os.path.exists(path)) or (mode == FileMode.Overwrite):
             mode = FileMode.Overwrite
             h5mode = map_file_mode(mode)
@@ -170,7 +175,6 @@ class File(FileMixin):
             if not can_read(self):
                 raise RuntimeError("Cannot open file. "
                                    "Incompatible version.")
-
 
     @property
     def version(self):
@@ -342,5 +346,3 @@ class File(FileMixin):
 
     def _section_count(self):
         return len(self.metadata)
-
-

--- a/nixio/pycore/file.py
+++ b/nixio/pycore/file.py
@@ -93,13 +93,10 @@ class File(FileMixin):
 
     @classmethod
     def _open_existing(cls, path, h5mode):
-        if h5mode == h5py.h5f.ACC_TRUNC:
-            file = cls._create_new(path, h5mode)
-        else:
-            fid = h5py.h5f.open(path, flags=h5mode, fapl=make_fapl())
-            h5file = h5py.File(fid)
-            file = cls(h5file)
-        return file
+        fid = h5py.h5f.open(path, flags=h5mode, fapl=make_fapl())
+        h5file = h5py.File(fid)
+        nixfile = cls(h5file)
+        return nixfile
 
     @classmethod
     def _create_new(cls, path, h5mode):
@@ -116,16 +113,18 @@ class File(FileMixin):
             path = path.encode("utf-8")
         except (UnicodeError, LookupError):
             pass
-        if not os.path.exists(path):
+
+        if (not os.path.exists(path)) or (mode == FileMode.Overwrite):
             mode = FileMode.Overwrite
+            h5mode = map_file_mode(mode)
+            newfile = cls._create_new(path, h5mode)
+            newfile.mode = mode
+            return newfile
 
         h5mode = map_file_mode(mode)
-
-        if os.path.exists(path):
-            newfile = cls._open_existing(path, h5mode)
-        else:
-            newfile = cls._create_new(path, h5mode)
-
+        newfile = cls._open_existing(path, h5mode)
+        if not newfile._check_header(mode):
+            raise exceptions.InvalidFile()
         newfile.mode = mode
         return newfile
 
@@ -157,8 +156,20 @@ class File(FileMixin):
             raise ValueError("Valid backends are 'hdf5' and 'h5py'.")
 
     def _create_header(self):
-        self.format = "nix"
-        self.version = (1, 0, 0)
+        self.format = FILE_FORMAT
+        self.version = HDF_FF_VERSION
+
+    def _check_header(self, mode):
+        if self.format != FILE_FORMAT:
+            return False
+
+        if mode == FileMode.ReadWrite:
+            return can_write(self)
+        elif mode == FileMode.ReadOnly:
+            return can_read(self)
+        else:
+            return False
+
 
     @property
     def version(self):

--- a/nixio/pycore/file.py
+++ b/nixio/pycore/file.py
@@ -114,12 +114,12 @@ class File(FileMixin):
         except (UnicodeError, LookupError):
             pass
 
-        if (not os.path.exists(path) and mode == FileMode.ReadOnly):
+        if not os.path.exists(path) and mode == FileMode.ReadOnly:
             raise RuntimeError(
                 "Cannot open non-existent file in ReadOnly mode!"
             )
 
-        if (not os.path.exists(path)) or (mode == FileMode.Overwrite):
+        if not os.path.exists(path) or mode == FileMode.Overwrite:
             mode = FileMode.Overwrite
             h5mode = map_file_mode(mode)
             newfile = cls._create_new(path, h5mode)

--- a/nixio/pycore/file.py
+++ b/nixio/pycore/file.py
@@ -25,6 +25,32 @@ except ImportError:
     CFile = None
 
 
+FILE_FORMAT = "nix"
+HDF_FF_VERSION = (1, 0, 0)
+
+
+def can_write(nixfile):
+    filever = nixfile.version
+    if len(filever) != 3:
+        raise RuntimeError("Invalid version specified in file.")
+    if HDF_FF_VERSION == filever:
+        return True
+    else:
+        return False
+
+
+def can_read(nixfile):
+    filever = nixfile.version
+    if len(filever) != 3:
+        raise RuntimeError("Invalid version specified in file.")
+    vx, vy, vz = HDF_FF_VERSION
+    fx, fy, fz = filever
+    if vx == fx and vy >= fy:
+        return True
+    else:
+        return False
+
+
 class FileMode(object):
     ReadOnly = 'r'
     ReadWrite = 'a'

--- a/nixio/pycore/section.py
+++ b/nixio/pycore/section.py
@@ -127,6 +127,7 @@ class Section(NamedEntity, SectionMixin):
         properties = self._h5group.open_group("properties")
         return Property(properties.get_by_id_or_name(id_or_name))
 
+
     def _get_property_by_pos(self, pos):
         properties = self._h5group.open_group("properties")
         return Property(properties.get_by_pos(pos))

--- a/nixio/test/test_backend_compatibility.py
+++ b/nixio/test/test_backend_compatibility.py
@@ -456,7 +456,7 @@ class _TestBackendCompatibility(unittest.TestCase):
         sec.create_property("prop Float", nix.DataType.Float)
         sec.create_property("prop Double", nix.DataType.Double)
         sec.create_property("prop String", nix.DataType.String)
-        # sec.create_property("prop Bool", nix.DataType.Bool)
+        sec.create_property("prop Bool", nix.DataType.Bool)
 
         sec.props[0].mapping = "mapping"
         sec.props[1].definition = "def"

--- a/nixio/test/test_file.py
+++ b/nixio/test/test_file.py
@@ -135,6 +135,11 @@ class FileVerTestPy(unittest.TestCase):
             version = self.filever
         self.h5root.attrs["format"] = fformat
         self.h5root.attrs["version"] = version
+        self.h5root.attrs["created_at"] = 0
+        self.h5root.attrs["updated_at"] = 0
+        if "data" not in self.h5root:
+            self.h5root.create_group("data")
+            self.h5root.create_group("metadata")
 
     def setUp(self):
         self.h5file = h5py.File(self.filename, mode="w")

--- a/nixio/test/test_file.py
+++ b/nixio/test/test_file.py
@@ -180,6 +180,9 @@ class FileVerTestPy(unittest.TestCase):
         self.set_header(version=(-1, -1, -1))
         with self.assertRaises(RuntimeError):
             self.try_open(FileMode.ReadOnly)
+        self.set_header(version=(1, 2))
+        with self.assertRaises(RuntimeError):
+            self.try_open(FileMode.ReadOnly)
 
 
     def test_bad_format(self):

--- a/nixio/test/test_file.py
+++ b/nixio/test/test_file.py
@@ -35,7 +35,7 @@ class _FileTest(unittest.TestCase):
 
     def test_file_format(self):
         assert(self.file.format == "nix")
-        assert(self.file.version == (1, 0, 0))
+        assert(self.file.version == filepy.HDF_FF_VERSION)
 
     def test_file_timestamps(self):
         created_at = self.file.created_at

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ def pkg_config(*packages, **kw):
     if status != 0:
         err_str = 'Some packages were not found: %s [%s]' % (pkg_string, out)
         if ignore_error:
-            sys.stderr.write('WARNING: ' + err_str)
+            sys.stderr.write('WARNING: ' + err_str + "\n")
             out = ''
         else:
             raise PackageNotFoundError(err_str)
@@ -130,7 +130,7 @@ classifiers   = [
 
 boost_inc_dir = os.getenv('BOOST_INCDIR', '/usr/local/include')
 boost_lib_dir = os.getenv('BOOST_LIBDIR', '/usr/local/lib')
-lib_dirs = BoostPyLib.library_search_dirs([boost_lib_dir])
+lib_dirs = BoostPyLib.library_search_dirs([boost_lib_dir]) if not is_win else []
 boost_libs = BoostPyLib.list_in_dirs(lib_dirs)
 boost_lib = BoostPyLib.find_lib_for_current_python(boost_libs)
 library_dirs = [boost_lib_dir, nix_lib_dir]

--- a/src/PyDataSet.cpp
+++ b/src/PyDataSet.cpp
@@ -78,6 +78,10 @@ static nix::DataType pyDtypeToNixDtype(const PyArray_Descr *dtype)
         return nix::DataType::String;
         break;
 
+    case 'b':
+        return nix::DataType::Bool;
+        break;
+
     default:
         break;
     }
@@ -87,18 +91,19 @@ static nix::DataType pyDtypeToNixDtype(const PyArray_Descr *dtype)
 static std::string nixDtypeToPyDtypeStr(nix::DataType nix_dtype)
 {
     switch (nix_dtype) {
-    case nix::DataType::UInt8:  return "<u1";
-    case nix::DataType::UInt16: return "<u2";
-    case nix::DataType::UInt32: return "<u4";
-    case nix::DataType::UInt64: return "<u8";
-    case nix::DataType::Int8:   return "<i1";
-    case nix::DataType::Int16:  return "<i2";
-    case nix::DataType::Int32:  return "<i4";
-    case nix::DataType::Int64:  return "<i8";
-    case nix::DataType::Float:  return "<f4";
-    case nix::DataType::Double: return "<f8";
-    case nix::DataType::Opaque: return "|V1";
-    default:                    return "";
+        case nix::DataType::Bool:   return "<b1";
+        case nix::DataType::UInt8:  return "<u1";
+        case nix::DataType::UInt16: return "<u2";
+        case nix::DataType::UInt32: return "<u4";
+        case nix::DataType::UInt64: return "<u8";
+        case nix::DataType::Int8:   return "<i1";
+        case nix::DataType::Int16:  return "<i2";
+        case nix::DataType::Int32:  return "<i4";
+        case nix::DataType::Int64:  return "<i8";
+        case nix::DataType::Float:  return "<f4";
+        case nix::DataType::Double: return "<f8";
+        case nix::DataType::Opaque: return "|V1";
+        default:                    return "";
     }
 }
 

--- a/src/PyProperty.cpp
+++ b/src/PyProperty.cpp
@@ -86,6 +86,8 @@ struct value_transmogrify {
             case DataType::String:
                 pyvalue = PyObject_CallFunction(PyValueClass, "s", value.get<std::string>().c_str());
                 break;
+            default:
+                return nullptr;
         }
 
         PyObject_SetAttrString(pyvalue, "reference", PyUnicode_FromString(value.reference.c_str()));


### PR DESCRIPTION
Counterpart to G-Node/nix#638.

Compares supported file version with the format version of the file being opened and decides whether it can be opened in the requested mode (read only or read write).

Follows the [NIX documentation on versioning](https://github.com/G-Node/nix/blob/master/docs/versioning.md).