### PR TITLE
Added version attribute

### DIFF
--- a/nixio/__init__.py
+++ b/nixio/__init__.py
@@ -22,6 +22,8 @@ from nixio.link_type import LinkType
 
 from nixio.section import S
 
+from nixio.info import VERSION as __version__
+
 try:
     import nixio.util.inject
 except ImportError:


### PR DESCRIPTION
Closing #242.
Added `__version__` attribute.
```python
>>> import nixio as nix
>>> nix.__version__
'1.3dev'
```

And I see that `__author__` attribute is defined in `nixio/__init__.py` and `info.py` separately. But we can import it from `info.py` as I did for `__version__`. Any comments?