### PR TITLE
PEP8 everywhere

### DIFF
--- a/nixio/__init__.py
+++ b/nixio/__init__.py
@@ -31,5 +31,5 @@ except ImportError:
 
 __all__ = ("File", "FileMode", "DataType", "Value",
            "LinkType", "DimensionType")
-__author__ = ('Christian Kellner, Adrian Stoewer, Andrey Sobolev, Jan Grewe,'
-              ' Balint Morvai')
+__author__ = ('Christian Kellner, Adrian Stoewer, Andrey Sobolev, Jan Grewe, '
+              'Balint Morvai, Achilleas Koutsou')

--- a/nixio/block.py
+++ b/nixio/block.py
@@ -71,7 +71,8 @@ class BlockMixin(object):
         """
         Create a new data array for this block. Either ``shape``
         or ``data`` must be given. If both are given their shape must agree.
-        If ``dtype`` is not specified it will default to 64-bit floating points.
+        If ``dtype`` is not specified it will default to 64-bit floating
+        points.
 
         :param name: The name of the data array to create.
         :type name: str
@@ -112,9 +113,9 @@ class BlockMixin(object):
         Get all sources in this block recursively.
 
         This method traverses the tree of all sources in the block. The
-        traversal is accomplished via breadth first and can be limited in depth.
-        On each node or source a filter is applied. If the filter returns true
-        the respective source will be added to the result list.
+        traversal is accomplished via breadth first and can be limited in
+        depth.  On each node or source a filter is applied. If the filter
+        returns true the respective source will be added to the result list.
         By default a filter is used that accepts all sources.
 
         :param filtr: A filter function
@@ -147,8 +148,8 @@ class BlockMixin(object):
     def multi_tags(self):
         """
         A property containing all multi tags of a block. MultiTag entities can
-        be obtained via their index or by their id. Tags can be deleted from the
-        list. Adding tags is done using the Blocks create_multi_tag method.
+        be obtained via their index or by their id. Tags can be deleted from
+        the list. Adding tags is done using the Blocks create_multi_tag method.
         This is a read only attribute.
 
         :type: ProxyList of MultiTag entities.
@@ -174,9 +175,9 @@ class BlockMixin(object):
     @property
     def data_arrays(self):
         """
-        A property containing all data arrays of a block. DataArray entities can
-        be obtained via their index or by their id. Data arrays can be deleted
-        from the list. Adding a data array is done using the Blocks
+        A property containing all data arrays of a block. DataArray entities
+        can be obtained via their index or by their id. Data arrays can be
+        deleted from the list. Adding a data array is done using the Blocks
         create_data_array method.
         This is a read only attribute.
 
@@ -216,4 +217,3 @@ class BlockMixin(object):
         implemented or escaped
         """
         return hash(self.id)
-

--- a/nixio/block.py
+++ b/nixio/block.py
@@ -6,9 +6,7 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 
-from __future__ import (absolute_import, division, print_function, unicode_literals)
-
-import sys
+from __future__ import (absolute_import, division, print_function)
 
 import nixio.util.find as finders
 from nixio.util.proxy_list import ProxyList

--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -227,20 +227,27 @@ class DataSetMixin(object):
     def append(self, data, axis=0):
         """
         Append ``data`` to the DataSet along the ``axis`` specified.
-        :param data: The data to append. Shape must agree except for the specified axis
+
+        :param data: The data to append. Shape must agree except for the
+        specified axis
         :param axis: Along which axis to append the data to
         """
         data = np.ascontiguousarray(data)
 
         if len(self.shape) != len(data.shape):
-            raise ValueError("Data and DataArray must have the same dimensionality")
+            raise ValueError(
+                "Data and DataArray must have the same dimensionality"
+            )
 
-        if any([s != ds for i, (s, ds) in enumerate(zip(self.shape, data.shape)) if i != axis]):
-            raise ValueError("Shape of data and shape of DataArray must match in all dimension but axis!")
+        if any([s != ds for i, (s, ds) in
+                enumerate(zip(self.shape, data.shape)) if i != axis]):
+            raise ValueError("Shape of data and shape of DataArray must match "
+                             "in all dimension but axis!")
 
         offset = tuple(0 if i != axis else x for i, x in enumerate(self.shape))
         count = data.shape
-        enlarge = tuple(self.shape[i] + (0 if i != axis else x) for i, x in enumerate(data.shape))
+        enlarge = tuple(self.shape[i] + (0 if i != axis else x)
+                        for i, x in enumerate(data.shape))
         self.data_extent = enlarge
         self._write_data(data, count, offset)
 
@@ -323,7 +330,8 @@ class DataSetMixin(object):
         # NB: special case when we only have ints, e.g. (int, ) then
         # we get back the empty tuple and this is what we want,
         # because it indicates a scalar result
-        squeezed = map(lambda i, c: c if type(i) != int else None, index, count)
+        squeezed = map(lambda i, c: c if type(i) != int
+                       else None, index, count)
         shape = list(filter(lambda x: x is not None, squeezed))
 
         return count, offset, shape

--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -34,8 +34,8 @@ class DataArrayMixin(object):
     def dimensions(self):
         """
         A property containing all dimensions of a DataArray. Dimensions can be
-        obtained via their index. Adding dimensions is done using the respective
-        append methods for dimension descriptors.
+        obtained via their index. Adding dimensions is done using the
+        respective append methods for dimension descriptors.
         This is a read only attribute.
 
         :type: ProxyList of dimension descriptors.
@@ -52,8 +52,9 @@ class DataArrayMixin(object):
 
     def __hash__(self):
         """
-        overwriting method __eq__ blocks inheritance of __hash__ in Python 3
-        hash has to be either explicitly inherited from parent class, implemented or escaped
+        Overwriting method __eq__ blocks inheritance of __hash__ in Python 3
+        hash has to be either explicitly inherited from parent class,
+        implemented or escaped
         """
         return hash(self.id)
 
@@ -198,11 +199,11 @@ class DataSetMixin(object):
 
     def write_direct(self, data):
         """
-        Directly write all of ``data`` to the :class:`~nixio.data_array.DataSet`.
-        The supplied data must be a :class:`numpy.ndarray` that matches the
-        DataSet's shape and must have C-style contiguous memory layout (see
-        :attr:`numpy.ndarray.flags` and :class:`~numpy.ndarray` for more
-        information).
+        Directly write all of ``data`` to the
+        :class:`~nixio.data_array.DataSet`.  The supplied data must be a
+        :class:`numpy.ndarray` that matches the DataSet's shape and must have
+        C-style contiguous memory layout (see :attr:`numpy.ndarray.flags` and
+        :class:`~numpy.ndarray` for more information).
 
         :param data: The array which contents is being written
         :type data: :class:`numpy.ndarray`

--- a/nixio/entity_with_sources.py
+++ b/nixio/entity_with_sources.py
@@ -20,6 +20,7 @@ class RefSourceProxyList(RefProxyList):
             "_remove_source_by_id", "_add_source_by_id"
         )
 
+
 _sources_doc = """
 Getter for sources.
 """

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -42,8 +42,8 @@ class FileMixin(object):
         """
         A property containing all blocks of a file. Blocks can be obtained by
         their id or their index. Blocks can be deleted from the list, when a
-        block is deleted all its content (data arrays, tags and sources) will be
-        also deleted from the file. Adding new Block is done via the
+        block is deleted all its content (data arrays, tags and sources) will
+        be also deleted from the file. Adding new Block is done via the
         create_block method of File. This is a read-only attribute.
 
         :type: ProxyList of Block entities.
@@ -57,8 +57,8 @@ class FileMixin(object):
         Get all sections and their child sections recursively.
 
         This method traverses the trees of all sections. The traversal is
-        accomplished via breadth first and can be limited in depth. On each node
-        or section a filter is applied. If the filter returns true the
+        accomplished via breadth first and can be limited in depth. On each
+        node or section a filter is applied. If the filter returns true the
         respective section will be added to the result list.
         By default a filter is used that accepts all sections.
 
@@ -80,8 +80,9 @@ class FileMixin(object):
         A property containing all root sections of a file. Specific root
         sections can be obtained by their id or their index. Sections can be
         deleted from this list. Notice: when a section is deleted all its child
-        section and properties will be removed too. Adding a new Section is done
-        via the crate_section method of File. This is a read-only property.
+        section and properties will be removed too. Adding a new Section is
+        done via the crate_section method of File.
+        This is a read-only property.
 
         :type: ProxyList of Section entities.
         """

--- a/nixio/group.py
+++ b/nixio/group.py
@@ -65,8 +65,8 @@ class GroupMixin(object):
         """
         A property containing all tags referenced by the group. Tags can be
         obtained by index or their id. Tags can be removed from the list,
-        removing a referenced Tag will not remove it from the file. New Tags can
-        be added using the append method of the list.
+        removing a referenced Tag will not remove it from the file.
+        New Tags can be added using the append method of the list.
         This is a read only attribute.
 
         :type: TagProxyList of Tags
@@ -79,9 +79,9 @@ class GroupMixin(object):
     def multi_tags(self):
         """
         A property containing all MultiTags referenced by the group. MultiTags
-        can be obtained by index or their id. Tags can be removed from the list,
-        removing a referenced MultiTag will not remove it from the file. New
-        MultiTags can be added using the append method of the list.
+        can be obtained by index or their id. Tags can be removed from the
+        list, removing a referenced MultiTag will not remove it from the file.
+        New MultiTags can be added using the append method of the list.
         This is a read only attribute.
 
         :type: MultiTagProxyList of MultiTags

--- a/nixio/info.py
+++ b/nixio/info.py
@@ -6,11 +6,12 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 
-VERSION         = '1.3dev'
-STATUS          = 'Release'
-RELEASE         = '%s %s' % (VERSION, STATUS)
-AUTHOR          = 'Christian Kellner, Adrian Stoewer, Andrey Sobolev, Jan Grewe, Balint Morvai, Achilleas Koutsou'
-COPYRIGHT       = '2014, German Neuroinformatics Node, ' + AUTHOR
-CONTACT         = 'kellner@bio.lmu.de'
-BRIEF           = 'Python bindings for NIX'
-HOMEPAGE        = 'https://github.com/G-Node/nixpy'
+VERSION = '1.3dev'
+STATUS = 'Release'
+RELEASE = '%s %s' % (VERSION, STATUS)
+AUTHOR = 'Christian Kellner, Adrian Stoewer, Andrey Sobolev, Jan Grewe,\
+Balint Morvai, Achilleas Koutsou'
+COPYRIGHT = '2014, German Neuroinformatics Node, ' + AUTHOR
+CONTACT = 'kellner@bio.lmu.de'
+BRIEF = 'Python bindings for NIX'
+HOMEPAGE = 'https://github.com/G-Node/nixpy'

--- a/nixio/link_type.py
+++ b/nixio/link_type.py
@@ -12,5 +12,3 @@ class LinkType(object):
     Tagged = "Tagged"
     Untagged = "Untagged"
     Indexed = "Indexed"
-
-

--- a/nixio/multi_tag.py
+++ b/nixio/multi_tag.py
@@ -19,8 +19,8 @@ class MultiTagMixin(object):
         A property containing all data arrays referenced by the tag. Referenced
         data arrays can be obtained by index or their id. References can be
         removed from the list, removing a referenced DataArray will not remove
-        it from the file. New references can be added using the append method of
-        the list.
+        it from the file. New references can be added using the append method
+        of the list.
         This is a read only attribute.
 
         :type: RefProxyList of DataArray
@@ -42,4 +42,3 @@ class MultiTagMixin(object):
         if not hasattr(self, "_features"):
             setattr(self, "_features", FeatureProxyList(self))
         return self._features
-

--- a/nixio/multi_tag.py
+++ b/nixio/multi_tag.py
@@ -6,7 +6,8 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 
-from __future__ import (absolute_import, division, print_function, unicode_literals)
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
 
 from nixio.tag import ReferenceProxyList, FeatureProxyList
 

--- a/nixio/pycore/__init__.py
+++ b/nixio/pycore/__init__.py
@@ -9,4 +9,3 @@ from .multi_tag import MultiTag
 from .group import Group
 from .block import Block
 from .file import File, FileMode
-

--- a/nixio/pycore/block.py
+++ b/nixio/pycore/block.py
@@ -36,7 +36,8 @@ class Block(EntityWithMetadata, BlockMixin):
         data_arrays = self._h5group.open_group("data_arrays")
         if name in data_arrays:
             raise exceptions.DuplicateName("create_data_array")
-        da = DataArray._create_new(self, data_arrays, name, type_, data_type, shape)
+        da = DataArray._create_new(self, data_arrays, name, type_,
+                                   data_type, shape)
         return da
 
     def _get_data_array_by_id(self, id_or_name):
@@ -205,4 +206,3 @@ class Block(EntityWithMetadata, BlockMixin):
     def _group_count(self):
         groups = self._h5group.open_group("groups")
         return len(groups)
-

--- a/nixio/pycore/data_array.py
+++ b/nixio/pycore/data_array.py
@@ -7,8 +7,6 @@
 # LICENSE file in the root of the Project.
 from numbers import Number
 
-from warnings import warn
-
 from .entity_with_sources import EntityWithSources
 from ..data_array import DataArrayMixin, DataSetMixin
 from ..value import DataType

--- a/nixio/pycore/dimensions.py
+++ b/nixio/pycore/dimensions.py
@@ -155,7 +155,8 @@ class RangeDimension(Dimension):
     def _create_new(cls, parent, index, ticks):
         newdim = super(RangeDimension, cls)._create_new(parent, index)
         newdim.dimension_type = DimensionType.Range
-        ticksds = newdim._h5group.create_dataset("ticks", shape=np.shape(ticks),
+        ticksds = newdim._h5group.create_dataset("ticks",
+                                                 shape=np.shape(ticks),
                                                  dtype=DataType.Double)
         ticksds.write_data(ticks)
         return newdim

--- a/nixio/pycore/dimensions.py
+++ b/nixio/pycore/dimensions.py
@@ -127,8 +127,6 @@ class SampledDimension(Dimension):
         util.check_attr_type(interval, Number)
         self._h5group.set_attr("sampling_interval", interval)
 
-
-
     @property
     def unit(self):
         return self._h5group.get_attr("unit")
@@ -270,4 +268,3 @@ class SetDimension(Dimension):
         labelsds = self._h5group.create_dataset("labels", shape=lshape,
                                                 dtype=dt)
         labelsds.write_data(labels)
-

--- a/nixio/pycore/entity.py
+++ b/nixio/pycore/entity.py
@@ -162,4 +162,3 @@ class NamedEntity(Entity):
 
     def __repr__(self):
         return self.__str__()
-

--- a/nixio/pycore/entity_with_metadata.py
+++ b/nixio/pycore/entity_with_metadata.py
@@ -58,4 +58,3 @@ class EntityWithMetadata(NamedEntity):
             raise TypeError("Error setting metadata to {}. Not a Section."
                             .format(sect))
         self._h5group.create_link(sect, "metadata")
-

--- a/nixio/pycore/entity_with_sources.py
+++ b/nixio/pycore/entity_with_sources.py
@@ -74,4 +74,3 @@ class EntityWithSources(EntityWithMetadata, EntityWithSourcesMixin):
     def _has_source_by_id(self, id_or_name):
         sources = self._h5group.open_group("sources")
         sources.has_by_id(id_or_name)
-

--- a/nixio/pycore/exceptions/exceptions.py
+++ b/nixio/pycore/exceptions/exceptions.py
@@ -11,7 +11,8 @@ class UninitializedEntity(Exception):
 
     def __init__(self, *args, **kwargs):
         self.message = "The Entity being accessed is uninitialized or empty."
-        super(UninitializedEntity, self).__init__(self.message, *args, **kwargs)
+        super(UninitializedEntity, self).__init__(self.message,
+                                                  *args, **kwargs)
 
 
 class InvalidUnit(Exception):
@@ -48,8 +49,9 @@ class OutOfBounds(IndexError):
 class IncompatibleDimensions(ValueError):
 
     def __init__(self, what, where):
-        self.message = "IncompatibleDimensions: {} evoked at: {})".format(what,
-                                                                          where)
+        self.message = "IncompatibleDimensions: {} evoked at: {})".format(
+            what, where
+        )
         super(IncompatibleDimensions, self).__init__(self.message)
 
 

--- a/nixio/pycore/feature.py
+++ b/nixio/pycore/feature.py
@@ -36,7 +36,8 @@ class Feature(Entity):
 
     @property
     def data(self):
-        return DataArray(self._parent._parent, self._h5group.open_group("data"))
+        return DataArray(self._parent._parent,
+                         self._h5group.open_group("data"))
 
     @data.setter
     def data(self, da):

--- a/nixio/pycore/group.py
+++ b/nixio/pycore/group.py
@@ -118,4 +118,3 @@ class Group(EntityWithSources, GroupMixin):
     def _has_tag_by_id(self, id_or_name):
         tags = self._h5group.open_group("tags")
         return tags.has_by_id(id_or_name)
-

--- a/nixio/pycore/group.py
+++ b/nixio/pycore/group.py
@@ -23,7 +23,8 @@ class Group(EntityWithSources, GroupMixin):
 
     @classmethod
     def _create_new(cls, nixparent, h5parent, name, type_):
-        newentity = super(Group, cls)._create_new(nixparent, h5parent, name, type_)
+        newentity = super(Group, cls)._create_new(nixparent, h5parent,
+                                                  name, type_)
         return newentity
 
     # DataArray

--- a/nixio/pycore/h5group.py
+++ b/nixio/pycore/h5group.py
@@ -202,7 +202,8 @@ class H5Group(object):
         try:
             del self.group[name]
         except Exception:
-            raise ValueError("Error deleting {} from {}".format(name, self.name))
+            raise ValueError("Error deleting {} from {}".format(name,
+                                                                self.name))
         # Delete if empty and non-root container
         groupdepth = len(self.group.name.split("/")) - 1
         if not len(self.group) and groupdepth > 1:

--- a/nixio/pycore/h5group.py
+++ b/nixio/pycore/h5group.py
@@ -59,9 +59,9 @@ class H5Group(object):
 
     def open_group(self, name, create=False):
         """
-        Returns a new H5Group with the given name contained in the current group.
-        If the current group does not exist in the file, it is automatically
-        created.
+        Returns a new H5Group with the given name contained in the current
+        group.  If the current group does not exist in the file,
+        it is automatically created.
 
         :param name: the name of the group
         :param create: creates the child group in the file if it does not exist
@@ -101,8 +101,8 @@ class H5Group(object):
 
     def write_data(self, name, data, dtype=None):
         """
-        Writes the data to a Dataset contained in the group with the given name.
-        Creates the Dataset if necessary.
+        Writes the data to a Dataset contained in the group with the
+        given name.  Creates the Dataset if necessary.
 
         :param name: name of the Dataset object
         :param data: the data to write
@@ -256,8 +256,8 @@ class H5Group(object):
     def h5root(self):
         """
         Returns the H5Group of the Block or top-level Section which contains
-        this object. Returns None if requested on the file root '/' or the /data
-        or /metadata groups.
+        this object. Returns None if requested on the file root '/' or the
+        /data or /metadata groups.
 
         :return: Top level object containing this group (H5Group)
         """
@@ -275,8 +275,8 @@ class H5Group(object):
     def root(self):
         """
         Returns the Block or top-level Section which contains this object.
-        Returns None if requested on the file root '/' or the /data or /metadata
-        groups.
+        Returns None if requested on the file root '/' or the /data or
+        /metadata groups.
 
         :return: Top level object containing this group (Block or Section)
         """
@@ -316,4 +316,3 @@ class H5Group(object):
 
     def __str__(self):
         return "<H5Group object: {}>".format(self.group.name)
-

--- a/nixio/pycore/multi_tag.py
+++ b/nixio/pycore/multi_tag.py
@@ -12,7 +12,8 @@ from .tag import BaseTag
 from .data_array import DataArray
 from .data_view import DataView
 from ..link_type import LinkType
-from .exceptions import OutOfBounds, IncompatibleDimensions, UninitializedEntity
+from .exceptions import (OutOfBounds, IncompatibleDimensions,
+                         UninitializedEntity)
 
 
 class MultiTag(BaseTag, MultiTagMixin):
@@ -95,7 +96,7 @@ class MultiTag(BaseTag, MultiTagMixin):
             )
 
         if (extents and len(ext_size) > 1 and
-                    ext_size[1] > len(data.dimensions)):
+                ext_size[1] > len(data.dimensions)):
             raise IncompatibleDimensions(
                 "Number of dimensions in extents does not match "
                 "dimensionality of data",
@@ -162,7 +163,9 @@ class MultiTag(BaseTag, MultiTagMixin):
 
     def retrieve_feature_data(self, posidx, featidx):
         if self._feature_count() == 0:
-            raise OutOfBounds("There are no features associated with this tag!")
+            raise OutOfBounds(
+                "There are no features associated with this tag!"
+            )
         if featidx > self._feature_count():
             raise OutOfBounds("Feature index out of bounds.")
         feat = self.features[featidx]

--- a/nixio/pycore/multi_tag.py
+++ b/nixio/pycore/multi_tag.py
@@ -192,4 +192,3 @@ class MultiTag(BaseTag, MultiTagMixin):
         count = da.data_extent
         offset = (0,) * len(count)
         return DataView(da, count, offset)
-

--- a/nixio/pycore/property.py
+++ b/nixio/pycore/property.py
@@ -140,4 +140,3 @@ class Property(Entity, PropertyMixin):
 
     def __repr__(self):
         return self.__str__()
-

--- a/nixio/pycore/section.py
+++ b/nixio/pycore/section.py
@@ -126,7 +126,6 @@ class Section(NamedEntity, SectionMixin):
         properties = self._h5group.open_group("properties")
         return Property(self, properties.get_by_id_or_name(id_or_name))
 
-
     def _get_property_by_pos(self, pos):
         properties = self._h5group.open_group("properties")
         return Property(self, properties.get_by_pos(pos))
@@ -286,4 +285,3 @@ class Section(NamedEntity, SectionMixin):
             sources.extend(src for src in blk.sources
                            if src.metadata.id == self.id)
         return sources
-

--- a/nixio/pycore/source.py
+++ b/nixio/pycore/source.py
@@ -74,7 +74,6 @@ class Source(EntityWithMetadata, SourceMixin):
     def referring_data_arrays(self):
         return [da for da in self._parent.data_arrays if self in da.sources]
 
-
     @property
     def referring_tags(self):
         return [tg for tg in self._parent.tags if self in tg.sources]

--- a/nixio/pycore/tag.py
+++ b/nixio/pycore/tag.py
@@ -145,7 +145,8 @@ class BaseTag(EntityWithSources):
         if dimtype == DimensionType.Sample:
             if not dimunit and unit is not None:
                 raise IncompatibleDimensions(
-                    "Units of position and SampledDimension must both be given!",
+                    "Units of position and SampledDimension "
+                    "must both be given!",
                     "Tag._pos_to_idx"
                 )
             if dimunit and unit is not None:
@@ -283,7 +284,9 @@ class Tag(BaseTag, TagMixin):
 
     def retrieve_feature_data(self, featidx):
         if self._feature_count() == 0:
-            raise OutOfBounds("There are no features associated with this tag!")
+            raise OutOfBounds(
+                "There are no features associated with this tag!"
+            )
         if featidx > self._feature_count():
             raise OutOfBounds("Feature index out of bounds.")
         feat = self.features[featidx]
@@ -300,4 +303,3 @@ class Tag(BaseTag, TagMixin):
         count = da.data_extent
         offset = (0,) * len(count)
         return DataView(da, count, offset)
-

--- a/nixio/pycore/util/names.py
+++ b/nixio/pycore/util/names.py
@@ -37,5 +37,3 @@ def check(name):
     if isinstance(name, bytes):
         name = name.decode()
     return "/" not in name
-
-

--- a/nixio/pycore/util/names.py
+++ b/nixio/pycore/util/names.py
@@ -9,8 +9,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from uuid import uuid4
-
 
 def sanitizer(name):
     """

--- a/nixio/section.py
+++ b/nixio/section.py
@@ -158,7 +158,8 @@ class SectionMixin(object):
         if not isinstance(data, list):
             data = [data]
 
-        val = list(map(lambda x: x if isinstance(x, Value) else Value(x), data))
+        val = list(map(lambda x: x if isinstance(x, Value) else Value(x),
+                       data))
         dtypes = functools.reduce(
             lambda x, y: x if y.data_type in x else x + [y.data_type],
             val, [val[0].data_type]

--- a/nixio/section.py
+++ b/nixio/section.py
@@ -62,10 +62,10 @@ class SectionMixin(object):
         """
         Get all child sections recursively.
         This method traverses the trees of all sections. The traversal is
-        accomplished via breadth first and can be limited in depth. On each node
-        or section a filter is applied. If the filter returns true the
-        respective section will be added to the result list.
-        By default a filter is used that accepts all sections.
+        accomplished via breadth first and can be limited in depth.
+        On each node or section a filter is applied.
+        If the filter returns true the respective section will be added to the
+        result list.  By default a filter is used that accepts all sections.
 
         :param filtr: A filter function
         :type filtr:  function
@@ -83,9 +83,10 @@ class SectionMixin(object):
         """
         Get all related sections of this section.
 
-        The result can be filtered. On each related section a filter is applied.
-        If the filter returns true the respective section will be added to the
-        result list. By default a filter is used that accepts all sections.
+        The result can be filtered. On each related section a filter is
+        applied.  If the filter returns true the respective section will be
+        added to the result list. By default a filter is used that accepts all
+        sections.
 
         :param filtr: A filter function
         :type filtr:  function
@@ -104,12 +105,12 @@ class SectionMixin(object):
     @property
     def sections(self):
         """
-        A property providing all child sections of a section. Child sections can
-        be accessed by index or by their id. Sections can also be deleted: if a
-        section is deleted, all its properties and child sections are removed
-        from the file too. Adding new sections is achieved using the
-        create_section method. This is a read-only
-        attribute.
+        A property providing all child sections of a section. Child sections
+        can be accessed by index or by their id. Sections can also be deleted:
+        if a section is deleted, all its properties and child sections are
+        removed from the file too. Adding new sections is achieved using the
+        create_section method.
+        This is a read-only attribute.
 
         :type: ProxyList of Section
         """
@@ -187,10 +188,11 @@ class SectionMixin(object):
     @property
     def props(self):
         """
-        A property containing all Property entities associated with the section.
-        Properties can be accessed by index of via their id. Properties can be
-        deleted from the list. Adding new properties is done using the
-        create_property method. This is a read-only attribute.
+        A property containing all Property entities associated with the
+        section.  Properties can be accessed by index of via their id.
+        Properties can be deleted from the list. Adding new properties is done
+        using the create_property method.
+        This is a read-only attribute.
 
         :type: ProxyList of Property
         """
@@ -206,4 +208,3 @@ class SectionMixin(object):
         if p is None and self.has_property_by_name(ident):
             p = self.get_property_by_name(ident)
         return p
-

--- a/nixio/source.py
+++ b/nixio/source.py
@@ -69,4 +69,3 @@ class SourceMixin(object):
         implemented or escaped
         """
         return hash(self.id)
-

--- a/nixio/tag.py
+++ b/nixio/tag.py
@@ -39,8 +39,8 @@ class TagMixin(object):
         A property containing all data arrays referenced by the tag. Referenced
         data arrays can be obtained by index or their id. References can be
         removed from the list, removing a referenced DataArray will not remove
-        it from the file. New references can be added using the append method of
-        the list.
+        it from the file. New references can be added using the append method
+        of the list.
         This is a read only attribute.
 
         :type: RefProxyList of DataArray
@@ -62,4 +62,3 @@ class TagMixin(object):
         if not hasattr(self, "_features"):
             setattr(self, "_features", FeatureProxyList(self))
         return self._features
-

--- a/nixio/test/test_backend_compatibility.py
+++ b/nixio/test/test_backend_compatibility.py
@@ -12,9 +12,9 @@ import numpy as np
 
 import nixio as nix
 try:
-    import nixio.core
+    nix.core
     skip = False
-except ImportError:
+except AttributeError:
     skip = True
 
 
@@ -45,8 +45,8 @@ class _TestBackendCompatibility(unittest.TestCase):
     def check_attributes(self, writeitem, readitem):
         for attr in all_attrs:
             # skip deprecated data attribute for DataArrays
-            if (isinstance(writeitem, (nixio.pycore.data_array.DataArray,
-                                       nixio.core.DataArray)) and
+            if (isinstance(writeitem, (nix.pycore.data_array.DataArray,
+                                       nix.core.DataArray)) and
                     attr == "data"):
                 continue
             if hasattr(writeitem, attr) or hasattr(readitem, attr):
@@ -282,7 +282,8 @@ class _TestBackendCompatibility(unittest.TestCase):
         tag_feat = blk.create_tag("tag for feat", "tagtype", [2])
         tag_feat.references.append(da_ref)
 
-        linktypes = [nix.LinkType.Tagged, nix.LinkType.Untagged, nix.LinkType.Indexed]
+        linktypes = [nix.LinkType.Tagged, nix.LinkType.Untagged,
+                     nix.LinkType.Indexed]
         for idx in range(6):
             da_feat = blk.create_data_array("da for feat " + str(idx),
                                             "datype", nix.DataType.Float,
@@ -330,8 +331,8 @@ class _TestBackendCompatibility(unittest.TestCase):
             value = 100 * i
             for j in range(10):
                 value += 1
-                data1[i,j] = value
-                total += data1[i,j]
+                data1[i, j] = value
+                total += data1[i, j]
 
         index_data[:, :] = data1
 
@@ -474,7 +475,8 @@ class _TestBackendCompatibility(unittest.TestCase):
         for wprop, rprop in zip(wsec.props, rsec.props):
             self.check_attributes(wprop, rprop)
 
-        sec.props[1].values = [nix.Value("foo"), nix.Value("bar"), nix.Value("baz")]
+        sec.props[1].values = [nix.Value("foo"), nix.Value("bar"),
+                               nix.Value("baz")]
         for wprop, rprop in zip(wsec.props, rsec.props):
             self.check_attributes(wprop, rprop)
 

--- a/nixio/test/test_backend_compatibility.py
+++ b/nixio/test/test_backend_compatibility.py
@@ -11,11 +11,9 @@ import unittest
 import numpy as np
 
 import nixio as nix
-try:
-    nix.core
-    skip = False
-except AttributeError:
-    skip = True
+
+
+skip = not hasattr(nix, "core")
 
 
 all_attrs = [

--- a/nixio/test/test_block.py
+++ b/nixio/test/test_block.py
@@ -11,11 +11,9 @@ from __future__ import (absolute_import, division, print_function)
 import unittest
 
 import nixio as nix
-try:
-    nix.core
-    skip_cpp = False
-except AttributeError:
-    skip_cpp = True
+
+
+skip_cpp = not hasattr(nix, "core")
 
 
 class _TestBlock(unittest.TestCase):

--- a/nixio/test/test_block.py
+++ b/nixio/test/test_block.py
@@ -10,11 +10,11 @@ from __future__ import (absolute_import, division, print_function)
 
 import unittest
 
-from nixio import *
+import nixio as nix
 try:
-    import nixio.core
+    nix.core
     skip_cpp = False
-except ImportError:
+except AttributeError:
     skip_cpp = True
 
 
@@ -29,8 +29,8 @@ class _TestBlock(unittest.TestCase):
         #  the c++ function can handle the string # but is not able to create
         #  the file any longer. Should this somehow be adressed on the c++ side
         #  of the code?
-        self.file  = File.open('unittest.h5', FileMode.Overwrite,
-                               backend=self.backend)
+        self.file = nix.File.open('unittest.h5', nix.FileMode.Overwrite,
+                                  backend=self.backend)
         self.block = self.file.create_block("test block", "recordingsession")
         self.other = self.file.create_block("other block", "recordingsession")
 
@@ -42,7 +42,7 @@ class _TestBlock(unittest.TestCase):
     def test_block_eq(self):
         assert(self.block == self.block)
         assert(not self.block == self.other)
-        assert(not self.block == None)
+        assert(self.block is not None)
 
     def test_block_id(self):
         assert(self.block.id is not None)
@@ -84,13 +84,12 @@ class _TestBlock(unittest.TestCase):
 
         data_array = self.block.create_data_array("test data_array",
                                                   "recordingsession",
-                                                  DataType.Int32, (0, ))
+                                                  nix.DataType.Int32, (0, ))
 
         assert(len(self.block.data_arrays) == 1)
 
         # TODO implement __eq__ for DataArray
-        #assert(data_array      in self.block.data_arrays)
-        assert(data_array.id   in self.block.data_arrays)
+        assert(data_array.id in self.block.data_arrays)
         assert("notexist" not in self.block.data_arrays)
 
         assert(data_array.id == self.block.data_arrays[0].id)
@@ -105,15 +104,15 @@ class _TestBlock(unittest.TestCase):
 
         data_array = self.block.create_data_array("test array",
                                                   "recording",
-                                                  DataType.Int32, (0, ))
+                                                  nix.DataType.Int32, (0, ))
         multi_tag = self.block.create_multi_tag("test multi_tag",
                                                 "recordingsession", data_array)
 
         assert(len(self.block.multi_tags) == 1)
 
         # TODO implement __eq__ for MultiTag
-        #assert(multi_tag      in self.block.multi_tags)
-        assert(multi_tag.id   in self.block.multi_tags)
+        # assert(multi_tag in self.block.multi_tags)
+        assert(multi_tag.id in self.block.multi_tags)
         assert("notexist" not in self.block.multi_tags)
 
         assert(multi_tag.id == self.block.multi_tags[0].id)
@@ -130,8 +129,8 @@ class _TestBlock(unittest.TestCase):
 
         assert(len(self.block.tags) == 1)
 
-        assert(tag      in self.block.tags)
-        assert(tag.id   in self.block.tags)
+        assert(tag in self.block.tags)
+        assert(tag.id in self.block.tags)
         assert("notexist" not in self.block.tags)
 
         assert(tag.id == self.block.tags[0].id)
@@ -148,8 +147,8 @@ class _TestBlock(unittest.TestCase):
 
         assert(len(self.block.sources) == 1)
 
-        assert(source      in self.block.sources)
-        assert(source.id   in self.block.sources)
+        assert(source in self.block.sources)
+        assert(source.id in self.block.sources)
         assert("notexist" not in self.block.sources)
 
         assert(source.id == self.block.sources[0].id)
@@ -163,9 +162,11 @@ class _TestBlock(unittest.TestCase):
         for i in range(2):
             self.block.create_source("level1-p0-s" + str(i), "dummy")
         for i in range(2):
-            self.block.sources[0].create_source("level2-p1-s" + str(i), "dummy")
+            self.block.sources[0].create_source("level2-p1-s" + str(i),
+                                                "dummy")
         for i in range(2):
-            self.block.sources[1].create_source("level2-p2-s" + str(i), "dummy")
+            self.block.sources[1].create_source("level2-p2-s" + str(i),
+                                                "dummy")
         for i in range(2):
             self.block.sources[0].sources[0].create_source(
                 "level3-p1-s" + str(i), "dummy"
@@ -186,8 +187,8 @@ class _TestBlock(unittest.TestCase):
 
         assert(len(self.block.groups) == 1)
 
-        assert(group      in self.block.groups)
-        assert(group.id   in self.block.groups)
+        assert(group in self.block.groups)
+        assert(group.id in self.block.groups)
         assert("notexist" not in self.block.groups)
 
         assert(group.id == self.block.groups[0].id)

--- a/nixio/test/test_block.py
+++ b/nixio/test/test_block.py
@@ -207,4 +207,3 @@ class TestBlockCPP(_TestBlock):
 class TestBlockPy(_TestBlock):
 
     backend = "h5py"
-

--- a/nixio/test/test_data_array.py
+++ b/nixio/test/test_data_array.py
@@ -13,11 +13,10 @@ import sys
 import numpy as np
 
 import nixio as nix
-try:
-    nix.core
-    skip_cpp = False
-except AttributeError:
-    skip_cpp = True
+
+
+skip_cpp = not hasattr(nix, "core")
+
 
 try:
     basestring = basestring

--- a/nixio/test/test_data_array.py
+++ b/nixio/test/test_data_array.py
@@ -255,7 +255,6 @@ class _TestDataArray(unittest.TestCase):
         self.assertRaises(ValueError, lambda: da.append(np.zeros((3, 3, 3))))
         self.assertRaises(ValueError, lambda: da.append(np.zeros((5, 5))))
 
-
     def test_data_array_dtype(self):
         da = self.block.create_data_array('dtype_f8', 'b', 'f8', (10, 10))
         assert(da.dtype == np.dtype('f8'))

--- a/nixio/test/test_data_array.py
+++ b/nixio/test/test_data_array.py
@@ -6,23 +6,23 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 
-from __future__ import (absolute_import, division, print_function)#, unicode_literals)
+from __future__ import (absolute_import, division, print_function)
 
 import unittest
 import sys
 import numpy as np
 
-from nixio import *
+import nixio as nix
 try:
-    import nixio.core
+    nix.core
     skip_cpp = False
-except ImportError:
+except AttributeError:
     skip_cpp = True
 
 try:
     basestring = basestring
 except NameError:  # 'basestring' is undefined, must be Python 3
-    basestring = (str,bytes)
+    basestring = (str, bytes)
 
 
 class _TestDataArray(unittest.TestCase):
@@ -30,13 +30,13 @@ class _TestDataArray(unittest.TestCase):
     backend = None
 
     def setUp(self):
-        self.file  = File.open("unittest.h5", FileMode.Overwrite,
-                               backend=self.backend)
+        self.file = nix.File.open("unittest.h5", nix.FileMode.Overwrite,
+                                  backend=self.backend)
         self.block = self.file.create_block("test block", "recordingsession")
         self.array = self.block.create_data_array("test array", "signal",
-                                                  DataType.Double, (100, ))
+                                                  nix.DataType.Double, (100, ))
         self.other = self.block.create_data_array("other array", "signal",
-                                                  DataType.Double, (100, ))
+                                                  nix.DataType.Double, (100, ))
 
     def tearDown(self):
         del self.file.blocks[self.block.id]
@@ -45,7 +45,7 @@ class _TestDataArray(unittest.TestCase):
     def test_data_array_eq(self):
         assert(self.array == self.array)
         assert(not self.array == self.other)
-        assert(not self.array == None)
+        assert(self.array is not None)
 
     def test_data_array_id(self):
         assert(self.array.id is not None)
@@ -135,9 +135,9 @@ class _TestDataArray(unittest.TestCase):
 
         assert(len(self.array) == len(data))
 
-        #indexing support in 1-d arrays
+        # indexing support in 1-d arrays
         self.assertRaises(IndexError, lambda: self.array[1:4:5])
-        self.assertRaises(IndexError, lambda: self.array[[1,3,]])
+        self.assertRaises(IndexError, lambda: self.array[[1, 3, ]])
 
         dout = np.array([self.array[i] for i in range(100)])
         assert(np.array_equal(data, dout))
@@ -145,7 +145,7 @@ class _TestDataArray(unittest.TestCase):
         dout = self.array[...]
         assert(np.array_equal(data, dout))
 
-        #indexed writing (1-d)
+        # indexed writing (1-d)
         data = np.array([float(-i) for i in range(100)])
         self.array[()] = data
         assert(np.array_equal(self.array[...], data))
@@ -158,22 +158,22 @@ class _TestDataArray(unittest.TestCase):
         self.array[0] = 42
         assert(self.array[0] == 42.0)
 
-        #changing shape via data_extent property
+        # changing shape via data_extent property
         self.array.data_extent = (200, )
         assert(self.array.data_extent == (200, ))
 
         # TODO delete does not work
         data = np.eye(123)
         a1 = self.block.create_data_array("double array", "signal",
-                                          DataType.Double, (123, 123))
+                                          nix.DataType.Double, (123, 123))
         dset = a1
         dset.write_direct(data)
         dout = np.empty_like(data)
         dset.read_direct(dout)
         assert(np.array_equal(data, dout))
 
-        #indexing support in 2-d arrays
-        self.assertRaises(IndexError, lambda: self.array[[], [1,2]])
+        # indexing support in 2-d arrays
+        self.assertRaises(IndexError, lambda: self.array[[], [1, 2]])
 
         dout = dset[12]
         assert(dout.shape == data[12].shape)
@@ -190,13 +190,13 @@ class _TestDataArray(unittest.TestCase):
         assert(np.array_equal(dset[1:-2, 1:-2], data[1:121, 1:121]))
 
         a3 = self.block.create_data_array("int identity array", "signal",
-                                          DataType.Int32, (123, 123))
+                                          nix.DataType.Int32, (123, 123))
         assert(a3.shape == (123, 123))
         assert(a3.dtype == np.dtype('i4'))
 
         data = np.random.rand(3, 4, 5)
         a4 = self.block.create_data_array("3d array", "signal",
-                                          DataType.Double, (3, 4, 5))
+                                          nix.DataType.Double, (3, 4, 5))
         dset = a4
         dset.write_direct(data)
         assert(dset.shape == data.shape)
@@ -211,8 +211,8 @@ class _TestDataArray(unittest.TestCase):
         assert(np.array_equal(dset[1:2, ..., 3:5], data[1:2, ..., 3:5]))
         assert(np.array_equal(dset[1:2, ..., 3:-1], data[1:2, ..., 3:4]))
 
-        #indexed writing (n-d)
-        d2 = np.random.rand(2,2)
+        # indexed writing (n-d)
+        d2 = np.random.rand(2, 2)
         dset[1, 0:2, 0:2] = d2
         assert(np.array_equal(dset[1, 0:2, 0:2], d2))
 
@@ -232,7 +232,7 @@ class _TestDataArray(unittest.TestCase):
         assert(np.array_equal(test_data, da[:]))
         assert(test_ten == [x for x in da])
 
-        #test for exceptions
+        # test for exceptions
         self.assertRaises(ValueError,
                           lambda: self.block.create_data_array('x', 'y'))
         self.assertRaises(ValueError,
@@ -240,7 +240,7 @@ class _TestDataArray(unittest.TestCase):
                               'x', 'y', data=test_data, shape=(1, 1, 1)
                           ))
 
-        #test appending
+        # test appending
         data = np.zeros((10, 5))
         da = self.block.create_data_array('append', 'double', data=data)
         to_append = np.zeros((2, 5))
@@ -268,7 +268,7 @@ class _TestDataArray(unittest.TestCase):
         assert(da.dtype == np.dtype(int))
 
         da = self.block.create_data_array('dtype_ndouble', 'b',
-                                          DataType.Double, (10, 10))
+                                          nix.DataType.Double, (10, 10))
         assert(da.dtype == np.dtype('f8'))
 
         da = self.block.create_data_array('dtype_auto', 'b', None, (10, 10))
@@ -291,9 +291,9 @@ class _TestDataArray(unittest.TestCase):
     def test_data_array_dimensions(self):
         assert(len(self.array.dimensions) == 0)
 
-        setd    = self.array.append_set_dimension()
-        ranged  = self.array.append_range_dimension(range(10))
-        sampled = self.array.append_sampled_dimension(0.1)
+        self.array.append_set_dimension()
+        self.array.append_range_dimension(range(10))
+        self.array.append_sampled_dimension(0.1)
 
         assert(len(self.array.dimensions) == 3)
 
@@ -326,8 +326,9 @@ class _TestDataArray(unittest.TestCase):
                           lambda: self.array.append_alias_range_dimension())
         self.assertRaises(ValueError,
                           lambda: self.array.append_alias_range_dimension())
-        string_array = self.block.create_data_array('string_array', 'nix.texts',
-                                                    dtype=DataType.String,
+        string_array = self.block.create_data_array('string_array',
+                                                    'nix.texts',
+                                                    dtype=nix.DataType.String,
                                                     shape=(10,))
         self.assertRaises(ValueError,
                           lambda: string_array.append_alias_range_dimension())
@@ -335,7 +336,7 @@ class _TestDataArray(unittest.TestCase):
         del self.block.data_arrays['string_array']
 
         array_2D = self.block.create_data_array(
-            'array_2d', 'nix.2d', dtype=DataType.Double, shape=(10, 10)
+            'array_2d', 'nix.2d', dtype=nix.DataType.Double, shape=(10, 10)
         )
         self.assertRaises(ValueError,
                           lambda: array_2D.append_alias_range_dimension())

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -136,4 +136,3 @@ class TestDimensionsCPP(_TestDimensions):
 class TestDimensionsPy(_TestDimensions):
 
     backend = "h5py"
-

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -6,20 +6,20 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 
-from __future__ import (absolute_import, division, print_function)#, unicode_literals)
+from __future__ import (absolute_import, division, print_function)
 
 import unittest
 import numpy as np
-from nixio import *
+import nixio as nix
 try:
-    import nixio.core
+    nix.core
     skip_cpp = False
-except ImportError:
+except AttributeError:
     skip_cpp = True
 
-test_range  = tuple([float(i) for i in range(10)])
-test_sampl  = 0.1
-test_label  = "test label"
+test_range = tuple([float(i) for i in range(10)])
+test_sampl = 0.1
+test_label = "test label"
 test_labels = tuple([str(i) + "_label" for i in range(10)])
 
 
@@ -28,14 +28,15 @@ class _TestDimensions(unittest.TestCase):
     backend = None
 
     def setUp(self):
-        self.file  = File.open("unittest.h5", FileMode.Overwrite,
-                               backend=self.backend)
+        self.file = nix.File.open("unittest.h5", nix.FileMode.Overwrite,
+                                  backend=self.backend)
         self.block = self.file.create_block("test block", "recordingsession")
-        self.array = self.block.create_data_array("test array", "signal", DataType.Float, (0, ))
+        self.array = self.block.create_data_array("test array", "signal",
+                                                  nix.DataType.Float, (0, ))
 
-        self.set_dim    = self.array.append_set_dimension()
+        self.set_dim = self.array.append_set_dimension()
         self.sample_dim = self.array.append_sampled_dimension(test_sampl)
-        self.range_dim  = self.array.append_range_dimension(test_range)
+        self.range_dim = self.array.append_range_dimension(test_range)
 
     def tearDown(self):
         del self.file.blocks[self.block.id]
@@ -43,7 +44,7 @@ class _TestDimensions(unittest.TestCase):
 
     def test_set_dimension(self):
         assert(self.set_dim.index == 1)
-        assert(self.set_dim.dimension_type == DimensionType.Set)
+        assert(self.set_dim.dimension_type == nix.DimensionType.Set)
 
         assert(self.set_dim.labels == ())
         self.set_dim.labels = test_labels
@@ -51,7 +52,7 @@ class _TestDimensions(unittest.TestCase):
 
     def test_sample_dimension(self):
         assert(self.sample_dim.index == 2)
-        assert(self.sample_dim.dimension_type == DimensionType.Sample)
+        assert(self.sample_dim.dimension_type == nix.DimensionType.Sample)
 
         assert(self.sample_dim.label is None)
         self.sample_dim.label = test_label
@@ -90,7 +91,7 @@ class _TestDimensions(unittest.TestCase):
 
     def test_range_dimension(self):
         assert(self.range_dim.index == 3)
-        assert(self.range_dim.dimension_type == DimensionType.Range)
+        assert(self.range_dim.dimension_type == nix.DimensionType.Range)
 
         assert(self.range_dim.label is None)
         self.range_dim.label = test_label

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -11,11 +11,9 @@ from __future__ import (absolute_import, division, print_function)
 import unittest
 import numpy as np
 import nixio as nix
-try:
-    nix.core
-    skip_cpp = False
-except AttributeError:
-    skip_cpp = True
+
+
+skip_cpp = not hasattr(nix, "core")
 
 test_range = tuple([float(i) for i in range(10)])
 test_sampl = 0.1

--- a/nixio/test/test_feature.py
+++ b/nixio/test/test_feature.py
@@ -11,11 +11,9 @@ from __future__ import (absolute_import, division, print_function)
 import unittest
 
 import nixio as nix
-try:
-    nix.core
-    skip_cpp = False
-except AttributeError:
-    skip_cpp = True
+
+
+skip_cpp = not hasattr(nix, "core")
 
 
 class _TestFeature(unittest.TestCase):

--- a/nixio/test/test_feature.py
+++ b/nixio/test/test_feature.py
@@ -6,15 +6,15 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 
-from __future__ import (absolute_import, division, print_function)#, unicode_literals)
+from __future__ import (absolute_import, division, print_function)
 
 import unittest
 
-from nixio import *
+import nixio as nix
 try:
-    import nixio.core
+    nix.core
     skip_cpp = False
-except ImportError:
+except AttributeError:
     skip_cpp = True
 
 
@@ -23,23 +23,26 @@ class _TestFeature(unittest.TestCase):
     backend = None
 
     def setUp(self):
-        self.file     = File.open("unittest.h5", FileMode.Overwrite,
+        self.file = nix.File.open("unittest.h5", nix.FileMode.Overwrite,
                                   backend=self.backend)
-        self.block    = self.file.create_block("test block", "recordingsession")
+        self.block = self.file.create_block("test block", "recordingsession")
 
-        self.signal = self.block.create_data_array("output", "analogsignal", DataType.Float, (0, ))
-        self.stimuli_tag   = self.block.create_tag(
+        self.signal = self.block.create_data_array("output", "analogsignal",
+                                                   nix.DataType.Float, (0, ))
+        self.stimuli_tag = self.block.create_tag(
             "stimuli used", "tag", [0]
         )
         self.stimuli_tag.references.append(self.signal)
 
-        self.movie1 = self.block.create_data_array("stimulus movie 1", "movie", DataType.Float, (0, ))
+        self.movie1 = self.block.create_data_array("stimulus movie 1", "movie",
+                                                   nix.DataType.Float, (0, ))
         self.feature_1 = self.stimuli_tag.create_feature(
-            self.movie1, LinkType.Tagged
+            self.movie1, nix.LinkType.Tagged
         )
-        self.movie2 = self.block.create_data_array("stimulus movie 2", "movie", DataType.Float, (0, ))
+        self.movie2 = self.block.create_data_array("stimulus movie 2", "movie",
+                                                   nix.DataType.Float, (0, ))
         self.feature_2 = self.stimuli_tag.create_feature(
-            self.movie2, LinkType.Tagged
+            self.movie2, nix.LinkType.Tagged
         )
 
     def tearDown(self):
@@ -49,7 +52,7 @@ class _TestFeature(unittest.TestCase):
     def test_feature_eq(self):
         assert(self.feature_1 == self.feature_1)
         assert(not self.feature_1 == self.feature_2)
-        assert(not self.feature_1 is None)
+        assert(self.feature_1 is not None)
 
     def test_feature_id(self):
         assert(self.feature_1.id is not None)
@@ -61,8 +64,8 @@ class _TestFeature(unittest.TestCase):
         assert(self.feature_1.link_type is not None)
         self.assertRaises(Exception, set_none)
 
-        self.feature_1.link_type = LinkType.Untagged
-        assert(self.feature_1.link_type == LinkType.Untagged)
+        self.feature_1.link_type = nix.LinkType.Untagged
+        assert(self.feature_1.link_type == nix.LinkType.Untagged)
 
     def test_feature_data(self):
         def set_none():
@@ -71,7 +74,8 @@ class _TestFeature(unittest.TestCase):
         assert(self.feature_1.data is not None)
         self.assertRaises(Exception, set_none)
 
-        new_data_ref = self.block.create_data_array("test", "current", DataType.Float, (0, ))
+        new_data_ref = self.block.create_data_array("test", "current",
+                                                    nix.DataType.Float, (0, ))
         self.feature_1.data = new_data_ref
         assert(self.feature_1.data == new_data_ref)
 

--- a/nixio/test/test_file.py
+++ b/nixio/test/test_file.py
@@ -9,17 +9,14 @@
 from __future__ import (absolute_import, division, print_function)
 
 import unittest
+import h5py
 
 import nixio as nix
-try:
-    nix.core
-    skip_cpp = False
-except AttributeError:
-    skip_cpp = True
-
-import h5py
 import nixio.pycore.file as filepy
 from nixio.pycore.exceptions.exceptions import InvalidFile
+
+
+skip_cpp = not hasattr(nix, "core")
 
 
 class _FileTest(unittest.TestCase):

--- a/nixio/test/test_file.py
+++ b/nixio/test/test_file.py
@@ -6,18 +6,18 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 
-from __future__ import (absolute_import, division, print_function)#, unicode_literals)
+from __future__ import (absolute_import, division, print_function)
 
 import unittest
 
+import nixio as nix
 try:
-    import nixio.core
+    nix.core
     skip_cpp = False
-except ImportError:
+except AttributeError:
     skip_cpp = True
 
 import h5py
-from nixio import *
 import nixio.pycore.file as filepy
 from nixio.pycore.exceptions.exceptions import InvalidFile
 
@@ -27,8 +27,8 @@ class _FileTest(unittest.TestCase):
     backend = None
 
     def setUp(self):
-        self.file = File.open("unittest.h5", FileMode.Overwrite,
-                              backend=self.backend)
+        self.file = nix.File.open("unittest.h5", nix.FileMode.Overwrite,
+                                  backend=self.backend)
 
     def tearDown(self):
         self.file.close()
@@ -54,8 +54,8 @@ class _FileTest(unittest.TestCase):
 
         assert(len(self.file.blocks) == 1)
 
-        assert(block      in self.file.blocks)
-        assert(block.id   in self.file.blocks)
+        assert(block in self.file.blocks)
+        assert(block.id in self.file.blocks)
         assert("notexist" not in self.file.blocks)
 
         assert(block.id == self.file.blocks[0].id)
@@ -72,8 +72,8 @@ class _FileTest(unittest.TestCase):
 
         assert(len(self.file.sections) == 1)
 
-        assert(section      in self.file.sections)
-        assert(section.id   in self.file.sections)
+        assert(section in self.file.sections)
+        assert(section.id in self.file.sections)
         assert("notexist" not in self.file.sections)
 
         assert(section.id == self.file.sections[0].id)
@@ -125,7 +125,7 @@ class FileVerTestPy(unittest.TestCase):
     fformat = filepy.FILE_FORMAT
 
     def try_open(self, mode):
-        f = File.open(self.filename, mode, backend=self.backend)
+        f = nix.File.open(self.filename, mode, backend=self.backend)
         f.close()
 
     def set_header(self, fformat=None, version=None):
@@ -150,47 +150,46 @@ class FileVerTestPy(unittest.TestCase):
 
     def test_read_write(self):
         self.set_header()
-        self.try_open(FileMode.ReadWrite)
+        self.try_open(nix.FileMode.ReadWrite)
 
     def test_read_only(self):
         vx, vy, vz = self.filever
         roversion = (vx, vy, vz+2)
         self.set_header(version=roversion)
-        self.try_open(FileMode.ReadOnly)
+        self.try_open(nix.FileMode.ReadOnly)
         with self.assertRaises(RuntimeError):
-            self.try_open(FileMode.ReadWrite)
+            self.try_open(nix.FileMode.ReadWrite)
 
     def test_no_open(self):
         vx, vy, vz = self.filever
         noversion = (vx, vy+3, vz+2)
         self.set_header(version=noversion)
         with self.assertRaises(RuntimeError):
-            self.try_open(FileMode.ReadWrite)
+            self.try_open(nix.FileMode.ReadWrite)
         with self.assertRaises(RuntimeError):
-            self.try_open(FileMode.ReadOnly)
+            self.try_open(nix.FileMode.ReadOnly)
         noversion = (vx, vy+1, vz)
         self.set_header(version=noversion)
         with self.assertRaises(RuntimeError):
-            self.try_open(FileMode.ReadWrite)
+            self.try_open(nix.FileMode.ReadWrite)
         with self.assertRaises(RuntimeError):
-            self.try_open(FileMode.ReadOnly)
+            self.try_open(nix.FileMode.ReadOnly)
         noversion = (vx+1, vy, vz)
         self.set_header(version=noversion)
         with self.assertRaises(RuntimeError):
-            self.try_open(FileMode.ReadWrite)
+            self.try_open(nix.FileMode.ReadWrite)
         with self.assertRaises(RuntimeError):
-            self.try_open(FileMode.ReadOnly)
+            self.try_open(nix.FileMode.ReadOnly)
 
     def test_bad_tuple(self):
         self.set_header(version=(-1, -1, -1))
         with self.assertRaises(RuntimeError):
-            self.try_open(FileMode.ReadOnly)
+            self.try_open(nix.FileMode.ReadOnly)
         self.set_header(version=(1, 2))
         with self.assertRaises(RuntimeError):
-            self.try_open(FileMode.ReadOnly)
+            self.try_open(nix.FileMode.ReadOnly)
 
     def test_bad_format(self):
         self.set_header(fformat="NOT_A_NIX_FILE")
         with self.assertRaises(InvalidFile):
-            self.try_open(FileMode.ReadOnly)
-
+            self.try_open(nix.FileMode.ReadOnly)

--- a/nixio/test/test_group.py
+++ b/nixio/test/test_group.py
@@ -6,14 +6,14 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 
-from __future__ import (absolute_import, division, print_function)#, unicode_literals)
+from __future__ import (absolute_import, division, print_function)
 
 import unittest
-from nixio import *
+import nixio as nix
 try:
-    import nixio.core
+    nix.core
     skip_cpp = False
-except ImportError:
+except AttributeError:
     skip_cpp = True
 
 
@@ -22,13 +22,13 @@ class _TestGroup(unittest.TestCase):
     backend = None
 
     def setUp(self):
-        self.file  = File.open("unittest.h5", FileMode.Overwrite,
-                               backend=self.backend)
+        self.file = nix.File.open("unittest.h5", nix.FileMode.Overwrite,
+                                  backend=self.backend)
         self.block = self.file.create_block("test block", "recordingsession")
 
         self.my_array = self.block.create_data_array("my array", "test",
-                                                     DataType.Int16, (1, ))
-        self.my_tag   = self.block.create_tag("my tag", "test", [0.25])
+                                                     nix.DataType.Int16, (1, ))
+        self.my_tag = self.block.create_tag("my tag", "test", [0.25])
         self.my_group = self.block.create_group("my group", "group")
         self.my_multiTag = self.block.create_multi_tag("my_mt", "test",
                                                        self.my_array)
@@ -38,7 +38,8 @@ class _TestGroup(unittest.TestCase):
         self.my_group.multi_tags.append(self.my_multiTag)
 
         self.your_array = self.block.create_data_array("your array", "test",
-                                                       DataType.Int16, (1, ))
+                                                       nix.DataType.Int16,
+                                                       (1, ))
         self.your_group = self.block.create_group("your group", "group")
         self.your_group.data_arrays.append(self.your_array)
 
@@ -93,9 +94,9 @@ class _TestGroup(unittest.TestCase):
                           lambda _: self.my_group.data_arrays.append(100))
 
         a1 = self.block.create_data_array("reference1", "stimuli",
-                                          DataType.Int16, (1, ))
+                                          nix.DataType.Int16, (1, ))
         a2 = self.block.create_data_array("reference2", "stimuli",
-                                          DataType.Int16, (1, ))
+                                          nix.DataType.Int16, (1, ))
 
         self.my_group.data_arrays.append(a1)
         self.my_group.data_arrays.append(a2)

--- a/nixio/test/test_group.py
+++ b/nixio/test/test_group.py
@@ -10,11 +10,9 @@ from __future__ import (absolute_import, division, print_function)
 
 import unittest
 import nixio as nix
-try:
-    nix.core
-    skip_cpp = False
-except AttributeError:
-    skip_cpp = True
+
+
+skip_cpp = not hasattr(nix, "core")
 
 
 class _TestGroup(unittest.TestCase):

--- a/nixio/test/test_multi_tag.py
+++ b/nixio/test/test_multi_tag.py
@@ -14,11 +14,9 @@ import unittest
 
 import nixio as nix
 import numpy as np
-try:
-    nix.core
-    skip_cpp = False
-except AttributeError:
-    skip_cpp = True
+
+
+skip_cpp = not hasattr(nix, "core")
 
 
 class _TestMultiTag(unittest.TestCase):

--- a/nixio/test/test_multi_tag.py
+++ b/nixio/test/test_multi_tag.py
@@ -68,7 +68,7 @@ class _TestMultiTag(unittest.TestCase):
         event_extents[0, 0] = 0.0
         event_extents[0, 1] = 6.0
         event_extents[0, 2] = 2.3
-        
+
         event_extents[1, 0] = 0.0
         event_extents[1, 1] = 3.0
         event_extents[1, 2] = 2.0

--- a/nixio/test/test_multi_tag.py
+++ b/nixio/test/test_multi_tag.py
@@ -6,18 +6,18 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 
-from __future__ import (absolute_import, division, print_function)#, unicode_literals)
+from __future__ import (absolute_import, division, print_function)
 
 from __future__ import print_function
 
 import unittest
 
-from nixio import *
+import nixio as nix
 import numpy as np
 try:
-    import nixio.core
+    nix.core
     skip_cpp = False
-except ImportError:
+except AttributeError:
     skip_cpp = True
 
 
@@ -26,23 +26,27 @@ class _TestMultiTag(unittest.TestCase):
     backend = None
 
     def setUp(self):
-        self.file     = File.open("unittest.h5", FileMode.Overwrite,
+        self.file = nix.File.open("unittest.h5", nix.FileMode.Overwrite,
                                   backend=self.backend)
-        self.block    = self.file.create_block("test block", "recordingsession")
+        self.block = self.file.create_block("test block", "recordingsession")
 
-        self.my_array = self.block.create_data_array("my array", "test", DataType.Int16, (0, 0))
-        self.my_tag   = self.block.create_multi_tag(
+        self.my_array = self.block.create_data_array("my array", "test",
+                                                     nix.DataType.Int16,
+                                                     (0, 0))
+        self.my_tag = self.block.create_multi_tag(
             "my tag", "tag", self.my_array
         )
 
-        self.your_array = self.block.create_data_array("your array", "test", DataType.Int16, (0, 0))
+        self.your_array = self.block.create_data_array("your array", "test",
+                                                       nix.DataType.Int16,
+                                                       (0, 0))
         self.your_tag = self.block.create_multi_tag(
             "your tag", "tag", self.your_array
         )
 
-        self.data_array = self.block.create_data_array("featureTest", "test", DataType.Double, (2, 10, 5))
-        ticks = [1.2, 2.3, 3.4, 4.5, 6.7]
-        unit = "ms"
+        self.data_array = self.block.create_data_array("featureTest", "test",
+                                                       nix.DataType.Double,
+                                                       (2, 10, 5))
 
         data = np.zeros((2, 10, 5))
         value = 0.
@@ -52,14 +56,14 @@ class _TestMultiTag(unittest.TestCase):
                 for k in range(5):
                     value += 1
                     data[i, j, k] = value
-    
+
         self.data_array[:, :, :] = data
 
         event_positions = np.zeros((2, 3))
         event_positions[0, 0] = 0.0
         event_positions[0, 1] = 3.0
         event_positions[0, 2] = 3.4
-        
+
         event_positions[1, 0] = 0.0
         event_positions[1, 1] = 8.0
         event_positions[1, 2] = 2.3
@@ -76,18 +80,20 @@ class _TestMultiTag(unittest.TestCase):
         event_labels = ["event 1", "event 2"]
         dim_labels = ["dim 0", "dim 1", "dim 2"]
 
-        self.event_array = self.block.create_data_array("positions", "test", data=event_positions)
-        
-        self.extent_array = self.block.create_data_array("extents", "test", data=event_extents)
+        self.event_array = self.block.create_data_array("positions", "test",
+                                                        data=event_positions)
+
+        self.extent_array = self.block.create_data_array("extents", "test",
+                                                         data=event_extents)
         extent_set_dim = self.extent_array.append_set_dimension()
         extent_set_dim.labels = event_labels
         extent_set_dim = self.extent_array.append_set_dimension()
         extent_set_dim.labels = dim_labels
 
-        self.feature_tag = self.block.create_multi_tag("feature_tag", "events", self.event_array)
+        self.feature_tag = self.block.create_multi_tag("feature_tag", "events",
+                                                       self.event_array)
         self.feature_tag.extents = self.extent_array
         self.feature_tag.references.append(self.data_array)
-        
 
     def tearDown(self):
         del self.file.blocks[self.block.id]
@@ -96,7 +102,7 @@ class _TestMultiTag(unittest.TestCase):
     def test_multi_tag_eq(self):
         assert(self.my_tag == self.my_tag)
         assert(not self.my_tag == self.your_tag)
-        assert(not self.my_tag is None)
+        assert(self.my_tag is not None)
 
     def test_multi_tag_id(self):
         assert(self.my_tag.id is not None)
@@ -149,7 +155,9 @@ class _TestMultiTag(unittest.TestCase):
         assert(self.my_tag.positions is not None)
         old_positions = self.my_tag.positions
 
-        new_positions = self.block.create_data_array("pos", "position", DataType.Int16, (0, 0))
+        new_positions = self.block.create_data_array("pos", "position",
+                                                     nix.DataType.Int16,
+                                                     (0, 0))
         self.my_tag.positions = new_positions
         assert(self.my_tag.positions == new_positions)
 
@@ -161,7 +169,8 @@ class _TestMultiTag(unittest.TestCase):
     def test_multi_tag_extents(self):
         assert(self.my_tag.extents is None)
 
-        new_extents = self.block.create_data_array("ext", "extent", DataType.Int16, (0, 0))
+        new_extents = self.block.create_data_array("ext", "extent",
+                                                   nix.DataType.Int16, (0, 0))
         self.my_tag.extents = new_extents
         assert(self.my_tag.extents == new_extents)
 
@@ -171,10 +180,13 @@ class _TestMultiTag(unittest.TestCase):
     def test_multi_tag_references(self):
         assert(len(self.my_tag.references) == 0)
 
-        self.assertRaises(TypeError, lambda _: self.my_tag.references.append(100))
+        self.assertRaises(TypeError,
+                          lambda _: self.my_tag.references.append(100))
 
-        reference1 = self.block.create_data_array("reference1", "stimuli", DataType.Int16, (0, ))
-        reference2 = self.block.create_data_array("reference2", "stimuli", DataType.Int16, (0, ))
+        reference1 = self.block.create_data_array("reference1", "stimuli",
+                                                  nix.DataType.Int16, (0, ))
+        reference2 = self.block.create_data_array("reference2", "stimuli",
+                                                  nix.DataType.Int16, (0, ))
 
         self.my_tag.references.append(reference1)
         self.my_tag.references.append(reference2)
@@ -192,12 +204,14 @@ class _TestMultiTag(unittest.TestCase):
     def test_multi_tag_features(self):
         assert(len(self.my_tag.features) == 0)
 
-        data_array = self.block.create_data_array("feature", "stimuli", DataType.Int16, (0, ))
-        feature = self.my_tag.create_feature(data_array, LinkType.Untagged)
+        data_array = self.block.create_data_array("feature", "stimuli",
+                                                  nix.DataType.Int16, (0, ))
+        feature = self.my_tag.create_feature(data_array,
+                                             nix.LinkType.Untagged)
         assert(len(self.my_tag.features) == 1)
 
-        assert(feature      in self.my_tag.features)
-        assert(feature.id   in self.my_tag.features)
+        assert(feature in self.my_tag.features)
+        assert(feature.id in self.my_tag.features)
         assert("notexist" not in self.my_tag.features)
 
         assert(feature.id == self.my_tag.features[0].id)
@@ -219,11 +233,13 @@ class _TestMultiTag(unittest.TestCase):
         dim = da.append_sampled_dimension(sample_iv)
         dim.unit = 's'
 
-        pos = block.create_data_array('pos1', 'positions', data=np.array([0.]).reshape((1, 1)))
+        pos = block.create_data_array('pos1', 'positions',
+                                      data=np.array([0.]).reshape((1, 1)))
         pos.append_set_dimension()
         pos.append_set_dimension()
         pos.unit = 'ms'
-        ext = block.create_data_array('ext1', 'extents', data=np.array([2000.]).reshape((1, 1)))
+        ext = block.create_data_array('ext1', 'extents',
+                                      data=np.array([2000.]).reshape((1, 1)))
         ext.append_set_dimension()
         ext.append_set_dimension()
         ext.unit = 'ms'
@@ -236,14 +252,16 @@ class _TestMultiTag(unittest.TestCase):
         assert(tag.retrieve_data(0, 0).shape == (2000,))
         assert(np.array_equal(y[:2000], tag.retrieve_data(0, 0)[:]))
 
-        
     def test_multi_tag_feature_data(self):
-        index_data = self.block.create_data_array("indexed feature data", "test", dtype=DataType.Double, shape=(10, 10))
+        index_data = self.block.create_data_array("indexed feature data",
+                                                  "test",
+                                                  dtype=nix.DataType.Double,
+                                                  shape=(10, 10))
         dim1 = index_data.append_sampled_dimension(1.0)
         dim1.unit = "ms"
         dim2 = index_data.append_sampled_dimension(1.0)
         dim2.unit = "ms"
-        
+
         data1 = np.zeros((10, 10))
         value = 0.0
         total = 0.0
@@ -251,37 +269,40 @@ class _TestMultiTag(unittest.TestCase):
             value = 100 * i
             for j in range(10):
                 value += 1
-                data1[i,j] = value
-                total += data1[i,j]
-                
+                data1[i, j] = value
+                total += data1[i, j]
+
         index_data[:, :] = data1
 
-        tagged_data = self.block.create_data_array("tagged feature data", "test", dtype=DataType.Double, shape=(10, 20, 10))
+        tagged_data = self.block.create_data_array("tagged feature data",
+                                                   "test",
+                                                   dtype=nix.DataType.Double,
+                                                   shape=(10, 20, 10))
         dim1 = tagged_data.append_sampled_dimension(1.0)
         dim1.unit = "ms"
         dim2 = tagged_data.append_sampled_dimension(1.0)
         dim2.unit = "ms"
         dim3 = tagged_data.append_sampled_dimension(1.0)
         dim3.unit = "ms"
-        
+
         data2 = np.zeros((10, 20, 10))
         for i in range(10):
-            value = 100 * i;
+            value = 100 * i
             for j in range(20):
                 for k in range(10):
                     value += 1
-                    data2[i,j,k] = value
-                        
-        tagged_data[:,:,:] = data2
-        
-        index_feature = self.feature_tag.create_feature(index_data, LinkType.Indexed)
-        tagged_feature = self.feature_tag.create_feature(tagged_data, LinkType.Tagged)
-        untagged_feature = self.feature_tag.create_feature(index_data, LinkType.Untagged)
-        
-        # preparations done, actually test 
+                    data2[i, j, k] = value
+
+        tagged_data[:, :, :] = data2
+
+        self.feature_tag.create_feature(index_data, nix.LinkType.Indexed)
+        self.feature_tag.create_feature(tagged_data, nix.LinkType.Tagged)
+        self.feature_tag.create_feature(index_data, nix.LinkType.Untagged)
+
+        # preparations done, actually test
         # print(self.feature_tag.features)
         assert(len(self.feature_tag.features) == 3)
-        
+
         # indexed feature
         feat_data = self.feature_tag.retrieve_feature_data(0, 0)
         assert(len(feat_data.shape) == 2)
@@ -289,16 +310,16 @@ class _TestMultiTag(unittest.TestCase):
         assert(np.sum(feat_data) == 55)
 
         data_view = self.feature_tag.retrieve_feature_data(9, 0)
-        assert(np.sum(data_view[:,:]) == 9055)
-        
+        assert(np.sum(data_view[:, :]) == 9055)
+
         # untagged feature
         data_view = self.feature_tag.retrieve_feature_data(0, 2)
         assert(data_view.size == 100)
-            
+
         data_view = self.feature_tag.retrieve_feature_data(0, 2)
-        assert(data_view.size == 100);
-        assert(np.sum(data_view) == total) 
-        
+        assert(data_view.size == 100)
+        assert(np.sum(data_view) == total)
+
         # tagged feature
         data_view = self.feature_tag.retrieve_feature_data(0, 1)
         assert(len(data_view.shape) == 3)

--- a/nixio/test/test_property.py
+++ b/nixio/test/test_property.py
@@ -11,11 +11,9 @@ from __future__ import (absolute_import, division, print_function)
 import unittest
 
 import nixio as nix
-try:
-    nix.core
-    skip_cpp = False
-except AttributeError:
-    skip_cpp = True
+
+
+skip_cpp = not hasattr(nix, "core")
 
 
 class _TestProperty(unittest.TestCase):

--- a/nixio/test/test_property.py
+++ b/nixio/test/test_property.py
@@ -6,15 +6,15 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 
-from __future__ import (absolute_import, division, print_function)#, unicode_literals)
+from __future__ import (absolute_import, division, print_function)
 
 import unittest
 
-from nixio import *
+import nixio as nix
 try:
-    import nixio.core
+    nix.core
     skip_cpp = False
-except ImportError:
+except AttributeError:
     skip_cpp = True
 
 
@@ -23,15 +23,16 @@ class _TestProperty(unittest.TestCase):
     backend = None
 
     def setUp(self):
-        self.file    = File.open("unittest.h5", FileMode.Overwrite,
-                                 backend=self.backend)
+        self.file = nix.File.open("unittest.h5", nix.FileMode.Overwrite,
+                                  backend=self.backend)
         self.section = self.file.create_section("test section",
                                                 "recordingsession")
-        self.prop    = self.section.create_property("test property", Value(0))
-        self.prop_s  = self.section.create_property("test str",
-                                                    DataType.String)
-        self.other   = self.section.create_property("other property",
-                                                    DataType.Int64)
+        self.prop = self.section.create_property("test property",
+                                                 nix.Value(0))
+        self.prop_s = self.section.create_property("test str",
+                                                   nix.DataType.String)
+        self.other = self.section.create_property("other property",
+                                                  nix.DataType.Int64)
 
     def tearDown(self):
         del self.file.sections[self.section.id]
@@ -40,7 +41,7 @@ class _TestProperty(unittest.TestCase):
     def test_property_eq(self):
         assert(self.prop == self.prop)
         assert(not self.prop == self.other)
-        assert(not self.prop == None)
+        assert(self.prop is not None)
 
     def test_property_id(self):
         assert(self.prop.id is not None)
@@ -79,33 +80,33 @@ class _TestProperty(unittest.TestCase):
         self.prop.unit = None
 
     def test_property_values(self):
-        self.prop.values = [Value(10)]
+        self.prop.values = [nix.Value(10)]
 
-        assert(self.prop.data_type == DataType.Int64)
+        assert(self.prop.data_type == nix.DataType.Int64)
         assert(len(self.prop.values) == 1)
 
-        assert(self.prop.values[0] == Value(10))
-        assert(Value(10) in self.prop.values)
+        assert(self.prop.values[0] == nix.Value(10))
+        assert(nix.Value(10) in self.prop.values)
         assert(self.prop.values[0] == 10)
         assert(10 in self.prop.values)
-        assert(self.prop.values[0] != Value(1337))
-        assert(Value(1337) not in self.prop.values)
+        assert(self.prop.values[0] != nix.Value(1337))
+        assert(nix.Value(1337) not in self.prop.values)
         assert(self.prop.values[0] != 42)
         assert(42 not in self.prop.values)
 
         self.prop.delete_values()
         assert(len(self.prop.values) == 0)
 
-        self.prop_s.values = [Value("foo"), Value("bar")]
-        assert(self.prop_s.data_type == DataType.String)
+        self.prop_s.values = [nix.Value("foo"), nix.Value("bar")]
+        assert(self.prop_s.data_type == nix.DataType.String)
         assert(len(self.prop_s.values) == 2)
 
-        assert(self.prop_s.values[0] == Value("foo"))
-        assert(Value("foo") in self.prop_s.values)
+        assert(self.prop_s.values[0] == nix.Value("foo"))
+        assert(nix.Value("foo") in self.prop_s.values)
         assert(self.prop_s.values[0] == "foo")
         assert("foo" in self.prop_s.values)
-        assert(self.prop_s.values[0] != Value("bla"))
-        assert(Value("bla") not in self.prop_s.values)
+        assert(self.prop_s.values[0] != nix.Value("bla"))
+        assert(nix.Value("bla") not in self.prop_s.values)
         assert(self.prop_s.values[0] != "bla")
         assert("bla" not in self.prop_s.values)
 
@@ -113,10 +114,10 @@ class _TestProperty(unittest.TestCase):
 class TestValue(unittest.TestCase):
 
     def test_value_int(self):
-        value = Value(10)
-        other = Value(11)
+        value = nix.Value(10)
+        other = nix.Value(11)
 
-        assert(value.data_type == DataType.Int64)
+        assert(value.data_type == nix.DataType.Int64)
 
         assert(value == value)
         assert(value == 10)
@@ -125,15 +126,15 @@ class TestValue(unittest.TestCase):
         assert(value != 11)
 
         value.value = 20
-        assert(value == Value(20))
+        assert(value == nix.Value(20))
         assert(value == 20)
         assert(value.value == 20)
 
     def test_value_float(self):
-        value = Value(47.11)
-        other = Value(3.14)
+        value = nix.Value(47.11)
+        other = nix.Value(3.14)
 
-        assert(value.data_type == DataType.Double)
+        assert(value.data_type == nix.DataType.Double)
 
         assert(value == value)
         assert(value == 47.11)
@@ -142,30 +143,28 @@ class TestValue(unittest.TestCase):
         assert(value != 3.14)
 
         value.value = 66.6
-        assert(value == Value(66.6))
+        assert(value == nix.Value(66.6))
         assert(value == 66.6)
         assert(value.value == 66.6)
 
     def test_value_bool(self):
-        value = Value(True)
-        other = Value(False)
+        value = nix.Value(True)
+        other = nix.Value(False)
 
-        assert(value.data_type == DataType.Bool)
+        assert(value.data_type == nix.DataType.Bool)
 
         assert(value == value)
-        assert(value == True)
-
         assert(value != other)
-        assert(value != False)
+        assert(value)
 
         value.value = False
         assert(value == other)
 
     def test_value_str(self):
-        value = Value("foo")
-        other = Value("bar")
+        value = nix.Value("foo")
+        other = nix.Value("bar")
 
-        assert(value.data_type == DataType.String)
+        assert(value.data_type == nix.DataType.String)
 
         assert(value == value)
         assert(value == "foo")
@@ -174,12 +173,12 @@ class TestValue(unittest.TestCase):
         assert(value != "bar")
 
         value.value = "wrtlbrmpft"
-        assert(value == Value("wrtlbrmpft"))
+        assert(value == nix.Value("wrtlbrmpft"))
         assert(value == "wrtlbrmpft")
         assert(value.value == "wrtlbrmpft")
 
     def test_value_attrs(self):
-        value = Value(0)
+        value = nix.Value(0)
 
         value.reference = "a"
         assert(value.reference == "a")
@@ -206,4 +205,3 @@ class TestPropertyCPP(_TestProperty):
 class TestPropertyPy(_TestProperty):
 
     backend = "h5py"
-

--- a/nixio/test/test_proxy_list.py
+++ b/nixio/test/test_proxy_list.py
@@ -11,17 +11,15 @@ from __future__ import (absolute_import, division, print_function)
 import unittest
 
 import nixio as nix
-try:
-    nix.core
-    skip_cpp = False
-except AttributeError:
-    skip_cpp = True
 from nixio.util.proxy_list import ProxyList
 
 try:
     basestring = basestring
 except NameError:  # 'basestring' is undefined, must be Python 3
     basestring = (str, bytes)
+
+
+skip_cpp = not hasattr(nix, "core")
 
 
 class WithIdMock(object):

--- a/nixio/test/test_proxy_list.py
+++ b/nixio/test/test_proxy_list.py
@@ -6,22 +6,22 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 
-from __future__ import (absolute_import, division, print_function, unicode_literals)
+from __future__ import (absolute_import, division, print_function)
 
 import unittest
 
-from nixio import *
+import nixio as nix
 try:
-    import nixio.core
+    nix.core
     skip_cpp = False
-except ImportError:
+except AttributeError:
     skip_cpp = True
 from nixio.util.proxy_list import ProxyList
 
 try:
     basestring = basestring
 except NameError:  # 'basestring' is undefined, must be Python 3
-    basestring = (str,bytes)
+    basestring = (str, bytes)
 
 
 class WithIdMock(object):
@@ -38,7 +38,8 @@ class WithIdMock(object):
     def __hash__(self):
         """
         overwriting method __eq__ blocks inheritance of __hash__ in Python 3
-        hash has to be either explicitly inherited from parent class, implemented or escaped
+        hash has to be either explicitly inherited from parent class,
+        implemented or escaped.
         """
         return hash(self.id)
 
@@ -79,10 +80,14 @@ class TestProxyList(unittest.TestCase):
             assert(self.mock.list[i] == self.mock.list[i - length])
             assert(self.mock.list[str(i)] == self.mock.list[i])
 
-        self.assertRaises(KeyError, lambda : self.mock.list["notexist"])
-        self.assertRaises(KeyError, lambda : self.mock.list[-1 - length])
-        self.assertRaises(KeyError, lambda : self.mock.list[length])
-        self.assertRaises(TypeError, lambda : self.mock.list[3.14])
+        self.assertRaises(KeyError, lambda:
+                          self.mock.list["notexist"])
+        self.assertRaises(KeyError, lambda:
+                          self.mock.list[-1 - length])
+        self.assertRaises(KeyError, lambda:
+                          self.mock.list[length])
+        self.assertRaises(TypeError, lambda:
+                          self.mock.list[3.14])
 
     def test_proxy_list_delitem(self):
         del self.mock.list["4"]

--- a/nixio/test/test_section.py
+++ b/nixio/test/test_section.py
@@ -11,12 +11,9 @@ from __future__ import (absolute_import, division, print_function)
 import unittest
 
 import nixio as nix
-try:
-    nix.core
-    skip_cpp = False
-except AttributeError:
-    skip_cpp = True
-import nixio
+
+
+skip_cpp = not hasattr(nix, "core")
 
 
 class _TestSection(unittest.TestCase):
@@ -103,8 +100,8 @@ class _TestSection(unittest.TestCase):
 
         assert(len(self.section.sections) == 0)
 
-        self.section['easy subsection'] = nixio.S('electrode')
-        subject = self.section['subject'] = nixio.S('subject')
+        self.section['easy subsection'] = nix.S('electrode')
+        subject = self.section['subject'] = nix.S('subject')
 
         assert(self.section['subject'] == subject)
         assert(self.section['subject'].id == subject.id)

--- a/nixio/test/test_section.py
+++ b/nixio/test/test_section.py
@@ -6,15 +6,15 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 
-from __future__ import (absolute_import, division, print_function)#, unicode_literals)
+from __future__ import (absolute_import, division, print_function)
 
 import unittest
 
-from nixio import *
+import nixio as nix
 try:
-    import nixio.core
+    nix.core
     skip_cpp = False
-except ImportError:
+except AttributeError:
     skip_cpp = True
 import nixio
 
@@ -24,12 +24,12 @@ class _TestSection(unittest.TestCase):
     backend = None
 
     def setUp(self):
-        self.file    = File.open("unittest.h5", FileMode.Overwrite,
-                                 backend=self.backend)
+        self.file = nix.File.open("unittest.h5", nix.FileMode.Overwrite,
+                                  backend=self.backend)
         self.section = self.file.create_section("test section",
                                                 "recordingsession")
-        self.other   = self.file.create_section("other section",
-                                                "recordingsession")
+        self.other = self.file.create_section("other section",
+                                              "recordingsession")
 
     def tearDown(self):
         del self.file.sections[self.section.id]
@@ -39,7 +39,7 @@ class _TestSection(unittest.TestCase):
     def test_section_eq(self):
         assert(self.section == self.section)
         assert(not self.section == self.other)
-        assert(not self.section == None)
+        assert(self.section is not None)
 
     def test_section_id(self):
         assert(self.section.id is not None)
@@ -92,8 +92,8 @@ class _TestSection(unittest.TestCase):
 
         assert(len(self.section.sections) == 1)
 
-        assert(child      in self.section.sections)
-        assert(child.id   in self.section.sections)
+        assert(child in self.section.sections)
+        assert(child.id in self.section.sections)
         assert("notexist" not in self.section.sections)
 
         assert(child.id == self.section.sections[0].id)
@@ -105,14 +105,13 @@ class _TestSection(unittest.TestCase):
 
         self.section['easy subsection'] = nixio.S('electrode')
         subject = self.section['subject'] = nixio.S('subject')
-        
+
         assert(self.section['subject'] == subject)
         assert(self.section['subject'].id == subject.id)
         assert('easy subsection' in
                [v.name for k, v in self.section.sections.items()])
         assert('easy subsection' in self.section.sections)
         assert(self.section['easy subsection'].name == 'easy subsection')
-        #assert('easy subsection' in self.section)
 
     def test_section_find_sections(self):
         for i in range(2):
@@ -143,7 +142,7 @@ class _TestSection(unittest.TestCase):
     def test_section_properties(self):
         assert(len(self.section) == 0)
 
-        prop = self.section.create_property("test prop", DataType.String)
+        prop = self.section.create_property("test prop", nix.DataType.String)
 
         assert(len(self.section) == 1)
 
@@ -168,12 +167,12 @@ class _TestSection(unittest.TestCase):
         assert(prop.id == self.section.props[0].id)
         assert(prop.id == self.section.props[-1].id)
 
-        #easy prop creation
+        # easy prop creation
         self.section['ep_str'] = 'str'
         self.section['ep_int'] = 23
         self.section['ep_float'] = 42.0
         self.section['ep_list'] = [1, 2, 3]
-        self.section['ep_val'] = Value(1.0)
+        self.section['ep_val'] = nix.Value(1.0)
 
         self.section['ep_val'] = 2.0
 

--- a/nixio/test/test_section.py
+++ b/nixio/test/test_section.py
@@ -258,4 +258,3 @@ class TestSectionCPP(_TestSection):
 class TestSectionPy(_TestSection):
 
     backend = "h5py"
-

--- a/nixio/test/test_source.py
+++ b/nixio/test/test_source.py
@@ -11,11 +11,9 @@ from __future__ import (absolute_import, division, print_function)
 import unittest
 
 import nixio as nix
-try:
-    nix.core
-    skip_cpp = False
-except AttributeError:
-    skip_cpp = True
+
+
+skip_cpp = not hasattr(nix, "core")
 
 
 class _TestSource(unittest.TestCase):

--- a/nixio/test/test_source.py
+++ b/nixio/test/test_source.py
@@ -146,4 +146,3 @@ class TestSourceCPP(_TestSource):
 class TestSourcePy(_TestSource):
 
     backend = "h5py"
-

--- a/nixio/test/test_source.py
+++ b/nixio/test/test_source.py
@@ -6,15 +6,15 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 
-from __future__ import (absolute_import, division, print_function)#, unicode_literals)
+from __future__ import (absolute_import, division, print_function)
 
 import unittest
 
-from nixio import *
+import nixio as nix
 try:
-    import nixio.core
+    nix.core
     skip_cpp = False
-except ImportError:
+except AttributeError:
     skip_cpp = True
 
 
@@ -23,16 +23,16 @@ class _TestSource(unittest.TestCase):
     backend = None
 
     def setUp(self):
-        self.file   = File.open("unittest.h5", FileMode.Overwrite,
-                                backend=self.backend)
-        self.block  = self.file.create_block("test block", "recordingsession")
+        self.file = nix.File.open("unittest.h5", nix.FileMode.Overwrite,
+                                  backend=self.backend)
+        self.block = self.file.create_block("test block", "recordingsession")
         self.source = self.block.create_source("test source",
                                                "recordingchannel")
-        self.other  = self.block.create_source("other source", "sometype")
-        self.third  = self.block.create_source("third source", "sometype")
-        self.array  = self.block.create_data_array("test array", "test type",
-                                                   dtype=DataType.Double,
-                                                   shape=(1, 1))
+        self.other = self.block.create_source("other source", "sometype")
+        self.third = self.block.create_source("third source", "sometype")
+        self.array = self.block.create_data_array("test array", "test type",
+                                                  dtype=nix.DataType.Double,
+                                                  shape=(1, 1))
 
     def tearDown(self):
         del self.file.blocks[self.block.id]
@@ -41,7 +41,7 @@ class _TestSource(unittest.TestCase):
     def test_source_eq(self):
         assert(self.source == self.source)
         assert(not self.source == self.other)
-        assert(not self.source == None)
+        assert(self.source is not None)
 
     def test_source_id(self):
         assert(self.source.id is not None)
@@ -85,8 +85,8 @@ class _TestSource(unittest.TestCase):
 
         assert(len(self.source.sources) == 1)
 
-        assert(source      in self.source.sources)
-        assert(source.id   in self.source.sources)
+        assert(source in self.source.sources)
+        assert(source.id in self.source.sources)
         assert("notexist" not in self.source.sources)
 
         assert(source.id == self.source.sources[0].id)
@@ -97,15 +97,26 @@ class _TestSource(unittest.TestCase):
         assert(len(self.source.sources) == 0)
 
     def test_source_find_sources(self):
-        for i in range(2): self.source.create_source("level1-p0-s" + str(i), "dummy")
-        for i in range(2): self.source.sources[0].create_source("level2-p1-s" + str(i), "dummy")
-        for i in range(2): self.source.sources[1].create_source("level2-p2-s" + str(i), "dummy")
-        for i in range(2): self.source.sources[0].sources[0].create_source("level3-p1-s" + str(i), "dummy")
+        for i in range(2):
+            self.source.create_source("level1-p0-s" + str(i), "dummy")
+        for i in range(2):
+            self.source.sources[0].create_source("level2-p1-s" + str(i),
+                                                 "dummy")
+        for i in range(2):
+            self.source.sources[1].create_source("level2-p2-s" + str(i),
+                                                 "dummy")
+        for i in range(2):
+            self.source.sources[0].sources[0].create_source(
+                "level3-p1-s" + str(i), "dummy"
+            )
 
         assert(len(self.source.find_sources()) == 9)
         assert(len(self.source.find_sources(limit=1)) == 3)
-        assert(len(self.source.find_sources(filtr=lambda x : "level2-p1-s" in x.name)) == 2)
-        assert(len(self.source.find_sources(filtr=lambda x : "level2-p1-s" in x.name, limit=1)) == 0)
+        assert(len(self.source.find_sources(filtr=lambda x:
+                                            "level2-p1-s" in x.name)) == 2)
+        assert(len(self.source.find_sources(filtr=lambda x:
+                                            "level2-p1-s" in x.name,
+                                            limit=1)) == 0)
 
     def test_sources_extend(self):
         assert(len(self.array.sources) == 0)
@@ -115,9 +126,11 @@ class _TestSource(unittest.TestCase):
         assert(len(self.array.sources) == 3)
 
     def test_inverse_search(self):
-        da_one = self.block.create_data_array("foo", "data_array", data=range(10))
+        da_one = self.block.create_data_array("foo", "data_array",
+                                              data=range(10))
         da_one.sources.append(self.other)
-        da_two = self.block.create_data_array("foobar", "data_array", data=[1])
+        da_two = self.block.create_data_array("foobar", "data_array",
+                                              data=[1])
         da_two.sources.append(self.other)
 
         self.assertEqual(len(self.other.referring_data_arrays), 2)
@@ -130,7 +143,8 @@ class _TestSource(unittest.TestCase):
         self.assertEqual(len(self.other.referring_tags), 0)
         self.assertEqual(self.source.referring_tags[0].id, tag.id)
 
-        mtag = self.block.create_multi_tag("MultiTagName", "MultiTagType", da_one)
+        mtag = self.block.create_multi_tag("MultiTagName", "MultiTagType",
+                                           da_one)
         mtag.sources.append(self.source)
         self.assertEqual(len(self.source.referring_multi_tags), 1)
         self.assertEqual(len(self.other.referring_multi_tags), 0)

--- a/nixio/test/test_tag.py
+++ b/nixio/test/test_tag.py
@@ -6,15 +6,15 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 
-from __future__ import (absolute_import, division, print_function)#, unicode_literals)
+from __future__ import (absolute_import, division, print_function)
 
 import unittest
 import numpy as np
-from nixio import *
+import nixio as nix
 try:
-    import nixio.core
+    nix.core
     skip_cpp = False
-except ImportError:
+except AttributeError:
     skip_cpp = True
 
 
@@ -23,17 +23,20 @@ class _TestTag(unittest.TestCase):
     backend = None
 
     def setUp(self):
-        self.file     = File.open("unittest.h5", FileMode.Overwrite,
+        self.file = nix.File.open("unittest.h5", nix.FileMode.Overwrite,
                                   backend=self.backend)
-        self.block    = self.file.create_block("test block", "recordingsession")
+        self.block = self.file.create_block("test block", "recordingsession")
 
-        self.my_array = self.block.create_data_array("my array", "test", DataType.Int16, (1, ))
-        self.my_tag   = self.block.create_tag(
+        self.my_array = self.block.create_data_array("my array", "test",
+                                                     nix.DataType.Int16, (1, ))
+        self.my_tag = self.block.create_tag(
             "my tag", "tag", [0]
         )
         self.my_tag.references.append(self.my_array)
 
-        self.your_array = self.block.create_data_array("your array", "test", DataType.Int16, (1, ))
+        self.your_array = self.block.create_data_array(
+            "your array", "test", nix.DataType.Int16, (1, )
+        )
         self.your_tag = self.block.create_tag(
             "your tag", "tag", [0]
         )
@@ -46,7 +49,7 @@ class _TestTag(unittest.TestCase):
     def test_tag_eq(self):
         assert(self.my_tag == self.my_tag)
         assert(not self.my_tag == self.your_tag)
-        assert(not self.my_tag is None)
+        assert(self.my_tag is not None)
 
     def test_tag_id(self):
         assert(self.my_tag.id is not None)
@@ -110,10 +113,13 @@ class _TestTag(unittest.TestCase):
     def test_tag_references(self):
         assert(len(self.my_tag.references) == 1)
 
-        self.assertRaises(TypeError, lambda _: self.my_tag.references.append(100))
+        self.assertRaises(TypeError,
+                          lambda _: self.my_tag.references.append(100))
 
-        reference1 = self.block.create_data_array("reference1", "stimuli", DataType.Int16, (1, ))
-        reference2 = self.block.create_data_array("reference2", "stimuli", DataType.Int16, (1, ))
+        reference1 = self.block.create_data_array("reference1", "stimuli",
+                                                  nix.DataType.Int16, (1, ))
+        reference2 = self.block.create_data_array("reference2", "stimuli",
+                                                  nix.DataType.Int16, (1, ))
 
         self.my_tag.references.append(reference1)
         self.my_tag.references.append(reference2)
@@ -132,13 +138,14 @@ class _TestTag(unittest.TestCase):
     def test_tag_features(self):
         assert(len(self.my_tag.features) == 0)
 
-        data_array = self.block.create_data_array("feature", "stimuli", DataType.Int16, (1, ))
-        feature = self.my_tag.create_feature(data_array, LinkType.Untagged)
+        data_array = self.block.create_data_array("feature", "stimuli",
+                                                  nix.DataType.Int16, (1, ))
+        feature = self.my_tag.create_feature(data_array, nix.LinkType.Untagged)
 
         assert(len(self.my_tag.features) == 1)
 
-        assert(feature      in self.my_tag.features)
-        assert(feature.id   in self.my_tag.features)
+        assert(feature in self.my_tag.features)
+        assert(feature.id in self.my_tag.features)
         assert("notexist" not in self.my_tag.features)
 
         assert(feature.id == self.my_tag.features[0].id)
@@ -149,9 +156,11 @@ class _TestTag(unittest.TestCase):
         assert(len(self.my_tag.features) == 0)
 
     def test_tag_retrieve_feature_data(self):
-        number_feat = self.block.create_data_array("number feature", "test", data=10.)
+        number_feat = self.block.create_data_array("number feature", "test",
+                                                   data=10.)
         ramp_data = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
-        ramp_feat = self.block.create_data_array("ramp feature", "test", data=np.asarray(ramp_data))
+        ramp_feat = self.block.create_data_array("ramp feature", "test",
+                                                 data=np.asarray(ramp_data))
         ramp_feat.label = "voltage"
         ramp_feat.unit = "mV"
         dim = ramp_feat.append_sampled_dimension(1.0)
@@ -159,18 +168,18 @@ class _TestTag(unittest.TestCase):
 
         pos_tag = self.block.create_tag("feature test", "test", [5.0])
         pos_tag.units = ["ms"]
-        
-        f1 = pos_tag.create_feature(number_feat, LinkType.Untagged)
-        f2 = pos_tag.create_feature(ramp_feat, LinkType.Tagged)
-        f3 = pos_tag.create_feature(ramp_feat, LinkType.Untagged)
+
+        pos_tag.create_feature(number_feat, nix.LinkType.Untagged)
+        pos_tag.create_feature(ramp_feat, nix.LinkType.Tagged)
+        pos_tag.create_feature(ramp_feat, nix.LinkType.Untagged)
         assert(len(pos_tag.features) == 3)
 
         data1 = pos_tag.retrieve_feature_data(0)
         data2 = pos_tag.retrieve_feature_data(1)
         data3 = pos_tag.retrieve_feature_data(2)
-        
-        assert(data1.size == 1) 
-        assert(data2.size == 1) 
+
+        assert(data1.size == 1)
+        assert(data2.size == 1)
         assert(data3.size == len(ramp_data))
 
         # make the tag pointing to a slice
@@ -178,9 +187,9 @@ class _TestTag(unittest.TestCase):
         data1 = pos_tag.retrieve_feature_data(0)
         data2 = pos_tag.retrieve_feature_data(1)
         data3 = pos_tag.retrieve_feature_data(2)
-        
-        assert(data1.size == 1) 
-        assert(data2.size == 2) 
+
+        assert(data1.size == 1)
+        assert(data2.size == 2)
         assert(data3.size == len(ramp_data))
 
 

--- a/nixio/test/test_tag.py
+++ b/nixio/test/test_tag.py
@@ -11,11 +11,9 @@ from __future__ import (absolute_import, division, print_function)
 import unittest
 import numpy as np
 import nixio as nix
-try:
-    nix.core
-    skip_cpp = False
-except AttributeError:
-    skip_cpp = True
+
+
+skip_cpp = not hasattr(nix, "core")
 
 
 class _TestTag(unittest.TestCase):

--- a/nixio/test/test_tag.py
+++ b/nixio/test/test_tag.py
@@ -193,4 +193,3 @@ class TestTagCPP(_TestTag):
 class TestTagPy(_TestTag):
 
     backend = "h5py"
-

--- a/nixio/test/test_util.py
+++ b/nixio/test/test_util.py
@@ -62,7 +62,8 @@ class TestUtil(unittest.TestCase):
 
         atomics = units.split_compound(unit_1)
         assert(len(atomics) == 2)
-        # FIXME the following is not entirely correct should be Hz^-1, needs to be fixed in nix!
+        # FIXME the following is not entirely correct should be Hz^-1
+        # needs to be fixed in nix!
         assert(atomics[0] == "mV^2" and atomics[1] == "Hz^-1")
 
         atomics = units.split_compound(unit_2)
@@ -102,5 +103,3 @@ class TestUtil(unittest.TestCase):
 
         p, u, po = units.split(unit_3)
         assert(p == '' and u == 'Hz' and po == '-1')
-
-

--- a/nixio/test/test_util.py
+++ b/nixio/test/test_util.py
@@ -80,7 +80,8 @@ class TestUtil(unittest.TestCase):
         assert(units.scalable([base_unit], [scalable_2]))
         assert(units.scalable([base_unit], [base_unit]))
         assert(not units.scalable([base_unit], [inscalable]))
-        assert(units.scalable([base_unit, scalable_1], [base_unit, scalable_2]))
+        assert(units.scalable([base_unit, scalable_1],
+                              [base_unit, scalable_2]))
 
     def test_unit_scaling(self):
         base_unit = 'V'

--- a/nixio/util/inject.py
+++ b/nixio/util/inject.py
@@ -32,9 +32,10 @@ def inject(bases, dct):
     methods from the given dict 'dct'.
     """
     for base in bases:
-        for k,v in dct.items():
+        for k, v in dct.items():
             if k not in excludes:
                 setattr(base, k, v)
+
 
 inject((nixio.core.File,),  dict(FileMixin.__dict__))
 inject((nixio.core.Section,), dict(SectionMixin.__dict__))

--- a/nixio/util/proxy_list.py
+++ b/nixio/util/proxy_list.py
@@ -6,7 +6,7 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 
-from __future__ import (absolute_import, division, print_function, unicode_literals)
+from __future__ import (absolute_import, division, print_function)
 
 try:
     basestring = basestring
@@ -22,7 +22,7 @@ class ProxyList(object):
 
     def __init__(self, obj, counter, getter, index_getter, deleter):
         self.__counter = getattr(obj, counter)
-        self.__getter  = getattr(obj, getter)
+        self.__getter = getattr(obj, getter)
         self.__index_getter = getattr(obj, index_getter)
         self.__deleter = getattr(obj, deleter)
 
@@ -48,11 +48,15 @@ class ProxyList(object):
                 key = count + key
 
             if key >= count or key < 0:
-                raise KeyError("Index out of bounds: " + str(key))
+                raise KeyError("Index out of bounds: {}".format(key))
 
             return self.__index_getter(key)
         else:
-            raise TypeError("The key must be an int or a string but was: " + type(key))
+            raise TypeError(
+                "The key must be an int or a string but was: {}".format(
+                    type(key)
+                )
+            )
 
     def __delitem__(self, key):
         if hasattr(key, "id"):
@@ -94,7 +98,8 @@ class ProxyList(object):
 class RefProxyList(ProxyList):
 
     def __init__(self, obj, counter, getter, index_getter, deleter, appender):
-        super(RefProxyList, self).__init__(obj, counter, getter, index_getter, deleter)
+        super(RefProxyList, self).__init__(obj, counter, getter,
+                                           index_getter, deleter)
         self.__appender = getattr(obj, appender)
 
     def append(self, key):

--- a/nixio/value.py
+++ b/nixio/value.py
@@ -88,4 +88,3 @@ class Value(object):
             return self.value == other.value
         else:
             return self.value == other
-

--- a/scripts/dorelease.py
+++ b/scripts/dorelease.py
@@ -83,7 +83,7 @@ def update_readme():
 
     diff = diff_lines(oldrmtext, newrmtext)
 
-    if len(diff) == 0:
+    if not diff:
         print("No changes required in README.")
         wait_for_ret()
         return False

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,11 @@ from scripts.findboost import BoostPyLib
 from scripts.checknix import check_nix
 
 
+# Replaced StandardError with Exception since StandardError is removed in Py3.x
+class PackageNotFoundError(Exception):
+    pass
+
+
 with open('README.rst') as f:
     description_text = f.read()
 
@@ -47,9 +52,6 @@ if "dev" in VERSION:
     sys.stderr.write("{}WARNING: You are building a development version "
                      "of nixpy.{}\n".format(*colorcodes))
 
-# Replaced StandardError with Exception since StandardError is removed in Py3.x
-class PackageNotFoundError(Exception):
-    pass
 
 def pkg_config(*packages, **kw):
     flag_map = {'-I': 'include_dirs', '-L': 'library_dirs', '-l': 'libraries'}
@@ -63,7 +65,7 @@ def pkg_config(*packages, **kw):
     if status != 0:
         err_str = 'Some packages were not found: %s [%s]' % (pkg_string, out)
         if ignore_error:
-            sys.stderr.write('WARNING: ' + err_str + "\n")
+            sys.stderr.write('WARNING: {}\n'.format(err_str))
             out = ''
         else:
             raise PackageNotFoundError(err_str)
@@ -72,13 +74,13 @@ def pkg_config(*packages, **kw):
         kw.setdefault(flag_map.get(token[:2]), []).append(token[2:])
 
     # remove duplicated
-    # replaced .iteritems() with .items, since .iteritems() is not available in Py3.x
     # could lead to increased memory usage and computation time.
     for k, v in kw.items():
         del kw[k]
         kw[k] = list(set(v))
 
     return kw
+
 
 def get_wheel_data():
     data = []
@@ -88,6 +90,7 @@ def get_wheel_data():
             ('share/nixio/bin',
              [os.path.join(bin, f) for f in os.listdir(bin)]))
     return data
+
 
 nix_inc_dir = os.getenv('NIX_INCDIR', '/usr/local/include')
 nix_lib_dir = os.getenv('NIX_LIBDIR', '/usr/local/lib')
@@ -112,19 +115,21 @@ nixpy_sources = [
     'src/PyGroup.cpp'
 ]
 
-classifiers   = [
-                    'Development Status :: 5 - Production/Stable',
-                    'Programming Language :: Python',
-                    'Programming Language :: Python :: 2.6',
-                    'Programming Language :: Python :: 2.7',
-                    'Programming Language :: Python :: 3.4',
-                    'Programming Language :: Python :: 3.5',
-                    'Topic :: Scientific/Engineering'
+classifiers = [
+    'Development Status :: 5 - Production/Stable',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 2.6',
+    'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
+    'Topic :: Scientific/Engineering'
 ]
 
 boost_inc_dir = os.getenv('BOOST_INCDIR', '/usr/local/include')
 boost_lib_dir = os.getenv('BOOST_LIBDIR', '/usr/local/lib')
-lib_dirs = BoostPyLib.library_search_dirs([boost_lib_dir]) if not is_win else []
+lib_dirs = BoostPyLib.library_search_dirs([boost_lib_dir])\
+    if not is_win else []
 boost_libs = BoostPyLib.list_in_dirs(lib_dirs)
 boost_lib = BoostPyLib.find_lib_for_current_python(boost_libs)
 library_dirs = [boost_lib_dir, nix_lib_dir]
@@ -144,15 +149,18 @@ else:
 
 if with_nix:
     if boost_lib is None:
-        print("Could not find boost python version for %s.%s" % sys.version_info[0:2])
-        print("Available boost python libs:\n" + "\n".join(map(str, boost_libs)))
+        print("Could not find boost python version for {}.{}".format(
+            sys.version_info[0:2]))
+        print("Available boost python libs:")
+        print("\n".join(map(str, boost_libs)))
         sys.exit(-1)
 
     libraries.append(boost_lib.library_name)
 
     native_ext = Extension(
         'nixio.core',
-        extra_compile_args=['-std=c++11'] if not is_win else ['/DBOOST_PYTHON_STATIC_LIB', '/EHsc'],
+        extra_compile_args=['-std=c++11']
+        if not is_win else ['/DBOOST_PYTHON_STATIC_LIB', '/EHsc'],
         libraries=libraries,
         sources=nixpy_sources,
         runtime_library_dirs=library_dirs if not is_win else None,
@@ -168,24 +176,25 @@ else:
     print("Skipping NIX C++ bindings.")
     ext_modules = []
 
-setup(name             = 'nixio',
-      version          = VERSION,
-      author           = AUTHOR,
-      author_email     = CONTACT,
-      url              = HOMEPAGE,
-      description      = BRIEF,
-      long_description = description_text,
-      classifiers      = classifiers,
-      license          = 'BSD',
-      ext_modules      = ext_modules,
-      packages         = ['nixio', 'nixio.pycore', 'nixio.util', 'nixio.pycore.util', 'nixio.pycore.exceptions'],
-      scripts          = [],
-      tests_require    = ['nose'],
-      test_suite       = 'nose.collector',
-      install_requires = ['numpy', 'h5py'],
-      package_data     = {'nixio': [license_text, description_text]},
-      include_package_data = True,
-      zip_safe         = False,
-      data_files=get_wheel_data()
+setup(
+    name='nixio',
+    version=VERSION,
+    author=AUTHOR,
+    author_email=CONTACT,
+    url=HOMEPAGE,
+    description=BRIEF,
+    long_description=description_text,
+    classifiers=classifiers,
+    license='BSD',
+    ext_modules=ext_modules,
+    packages=['nixio', 'nixio.pycore', 'nixio.util',
+              'nixio.pycore.util', 'nixio.pycore.exceptions'],
+    scripts=[],
+    tests_require=['nose'],
+    test_suite='nose.collector',
+    install_requires=['numpy', 'h5py'],
+    package_data={'nixio': [license_text, description_text]},
+    include_package_data=True,
+    zip_safe=False,
+    data_files=get_wheel_data()
 )
-


### PR DESCRIPTION
Lots of PEP8 fixes everywhere.
All files (except `__init__.py`s) should be fully PEP8 compliant now.

Also:
- Changed the way the tests check for NIX backend availability. Instead of trying to `import nixio.core` and catching `ImportError`, simply check if NIX has the attribute (`hasattr(nix, "core")`)
- Removed star imports from tests. Now imports nixio as nix.