### PR TITLE
[h5dataset] Fix for reading empty datasets

### DIFF
--- a/nixio/pycore/h5dataset.py
+++ b/nixio/pycore/h5dataset.py
@@ -43,7 +43,7 @@ class H5DataSet(object):
             self.dataset[:] = data
 
     def read_data(self, data, count=None, offset=None):
-        if 0 in data.shape or len(data.shape) == 0:
+        if 0 in self.dataset.shape or len(self.dataset.shape) == 0:
             return
         if count and offset:
             if sum(count) == 0 and len(data) == 0:

--- a/nixio/pycore/h5dataset.py
+++ b/nixio/pycore/h5dataset.py
@@ -43,6 +43,8 @@ class H5DataSet(object):
             self.dataset[:] = data
 
     def read_data(self, data, count=None, offset=None):
+        if 0 in data.shape or len(data.shape) == 0:
+            return
         if count and offset:
             if sum(count) == 0 and len(data) == 0:
                 return data


### PR DESCRIPTION
Datasets with empty shape or 0 in any dimension break h5py.
We just return the empty array when there's such data.