### PR TITLE
[Section.parent] BFS to find on demand

### DIFF
--- a/nixio/pycore/entity_with_metadata.py
+++ b/nixio/pycore/entity_with_metadata.py
@@ -34,21 +34,7 @@ class EntityWithMetadata(NamedEntity):
         :type: Section
         """
         if "metadata" in self._h5group:
-            mdsection = Section(None, self._h5group.open_group("metadata"))
-            sectionid = mdsection.id
-
-            rootmd = self._h5group.file.open_group("metadata")
-            results = []
-            for sectgroup in rootmd:
-                sect = Section(None, sectgroup)
-                results.extend(
-                    sect.find_sections(filtr=lambda x: x.id == sectionid)
-                )
-            if results:
-                return results[0]
-            else:
-                raise RuntimeError("Invalid metadata found in {}".
-                                   format(self))
+            return Section(None, self._h5group.open_group("metadata"))
         else:
             return None
 


### PR DESCRIPTION
Instead of setting the parent link on access, which triggers a search every time a Section is instantiated, do it only on demand, when the parent property is requested.

Previously, the section parent link was set when accessing an object's metadata property. This is a problem when working with an object's metadata since every time something like `block.metadata` was accessed, it would run a search for the parent. Also, accessing the parent section is probably not very common task to begin with.

Now, the search is performed only when necessary.
The following script shows how the timings change:
```python
import nixio as nix
from uuid import uuid4
from timeit import timeit


def create_deep_metadata(nixfile):
    block = nixfile.blocks[0]
    block.metadata = nixfile.create_section(uuid4().hex, "s")
    for d in range(10):
        block.metadata = block.metadata.create_section(uuid4().hex, "s")


def access_metadata_parent(nixfile):
    block = nixfile.blocks[0]
    # get the block's metadata and start traversing up the metadata tree
    md = block.metadata
    while md is not None:
        md = md.parent


nixfile = nix.File.open("/tmp/foo.h5", nix.FileMode.Overwrite, backend="h5py")
block = nixfile.create_block("blk", "blk")
create_t = timeit("create_deep_metadata(nixfile)",
                  globals=globals(), number=10)
access_t = timeit("access_metadata_parent(nixfile)",
                  globals=globals(), number=10)
print("block.metadata access time:  {}".format(create_t))
print("metadata.parent access time: {}".format(access_t))
nixfile.close()
```

Results before change:
```
block.metadata access time:  4.213875255023595
metadata.parent access time: 0.7807838899898343
```

Results after change:
```
block.metadata access time:  0.1902368229930289
metadata.parent access time: 6.309163786005229
```

Closes #256.