### PR TITLE
Retrieve data overloads

### DIFF
--- a/nixio/pycore/multi_tag.py
+++ b/nixio/pycore/multi_tag.py
@@ -137,9 +137,6 @@ class MultiTag(BaseTag, MultiTagMixin):
                 extents and posidx >= extents.data_extent[0]):
             raise OutOfBounds("Index out of bounds of positions or extents!")
 
-        if refidx >= len(references):
-            raise OutOfBounds("Reference index out of bounds.")
-
         ref = references[refidx]
         dimcount = len(ref.dimensions)
         if len(positions.data_extent) == 1 and dimcount != 1:
@@ -166,9 +163,17 @@ class MultiTag(BaseTag, MultiTagMixin):
             raise OutOfBounds(
                 "There are no features associated with this tag!"
             )
-        if featidx > self._feature_count():
-            raise OutOfBounds("Feature index out of bounds.")
-        feat = self.features[featidx]
+
+        try:
+            feat = self.features[featidx]
+        except KeyError:
+            feat = None
+            for f in self.features:
+                if f.data.name == featidx or f.data.id == featidx:
+                    feat = f
+                    break
+            if feat is None:
+                raise
         da = feat.data
         if da is None:
             raise UninitializedEntity()

--- a/nixio/pycore/tag.py
+++ b/nixio/pycore/tag.py
@@ -287,9 +287,17 @@ class Tag(BaseTag, TagMixin):
             raise OutOfBounds(
                 "There are no features associated with this tag!"
             )
-        if featidx > self._feature_count():
-            raise OutOfBounds("Feature index out of bounds.")
-        feat = self.features[featidx]
+
+        try:
+            feat = self.features[featidx]
+        except KeyError:
+            feat = None
+            for f in self.features:
+                if f.data.name == featidx or f.data.id == featidx:
+                    feat = f
+                    break
+            if feat is None:
+                raise
         da = feat.data
         if da is None:
             raise UninitializedEntity()

--- a/nixio/test/test_multi_tag.py
+++ b/nixio/test/test_multi_tag.py
@@ -250,6 +250,11 @@ class _TestMultiTag(unittest.TestCase):
         assert(tag.retrieve_data(0, 0).shape == (2000,))
         assert(np.array_equal(y[:2000], tag.retrieve_data(0, 0)[:]))
 
+        # get by name
+        data = tag.retrieve_data(0, da.name)
+        assert(data.shape == (2000,))
+        assert(np.array_equal(y[:2000], data[:]))
+
     def test_multi_tag_feature_data(self):
         index_data = self.block.create_data_array("indexed feature data",
                                                   "test",
@@ -323,6 +328,23 @@ class _TestMultiTag(unittest.TestCase):
         assert(len(data_view.shape) == 3)
 
         data_view = self.feature_tag.retrieve_feature_data(1, 1)
+        assert(len(data_view.shape) == 3)
+
+        # === retrieve by name ===
+        # indexed feature
+        feat_data = self.feature_tag.retrieve_feature_data(0, index_data.name)
+        assert(len(feat_data.shape) == 2)
+        assert(feat_data.size == 10)
+        assert(np.sum(feat_data) == 55)
+
+        data_view = self.feature_tag.retrieve_feature_data(9, index_data.name)
+        assert(np.sum(data_view[:, :]) == 9055)
+
+        # tagged feature
+        data_view = self.feature_tag.retrieve_feature_data(0, tagged_data.name)
+        assert(len(data_view.shape) == 3)
+
+        data_view = self.feature_tag.retrieve_feature_data(1, tagged_data.name)
         assert(len(data_view.shape) == 3)
 
         def out_of_bounds():

--- a/nixio/test/test_tag.py
+++ b/nixio/test/test_tag.py
@@ -190,6 +190,13 @@ class _TestTag(unittest.TestCase):
         assert(data2.size == 2)
         assert(data3.size == len(ramp_data))
 
+        # get by name
+        data1 = pos_tag.retrieve_feature_data(number_feat.name)
+        data2 = pos_tag.retrieve_feature_data(ramp_feat.name)
+
+        assert(data1.size == 1)
+        assert(data2.size == 2)
+
 
 @unittest.skipIf(skip_cpp, "HDF5 backend not available.")
 class TestTagCPP(_TestTag):

--- a/src/PyMultiTag.cpp
+++ b/src/PyMultiTag.cpp
@@ -89,6 +89,22 @@ boost::optional<Feature> getFeatureByPos(const MultiTag& st, size_t index) {
     return f ? boost::optional<Feature>(f) : boost::none;
 }
 
+DataView retrieveDataIdx(const MultiTag& st, size_t position_index, size_t reference_index) {
+    return st.retrieveData(position_index, reference_index);
+}
+
+DataView retrieveDataStr(const MultiTag& st, size_t position_index, const std::string &name_or_id) {
+    return st.retrieveData(position_index, name_or_id);
+}
+
+DataView retrieveFeatureDataIdx(const MultiTag& st, size_t position_index, size_t feature_index) {
+    return st.retrieveFeatureData(position_index, feature_index);
+}
+
+DataView retrieveFeatureDataStr(const MultiTag& st, size_t position_index, const std::string &name_or_id) {
+    return st.retrieveFeatureData(position_index, name_or_id);
+}
+
 void PyMultiTag::do_export() {
 
     PyEntityWithSources<base::IMultiTag>::do_export("MultiTag");
@@ -125,8 +141,10 @@ void PyMultiTag::do_export() {
         .def("_delete_feature_by_id", REMOVER(std::string, MultiTag, deleteFeature))
 
         // Data access
-        .def("retrieve_data", &MultiTag::retrieveData)
-        .def("retrieve_feature_data", &MultiTag::retrieveFeatureData)
+        .def("retrieve_data", &retrieveDataIdx)
+        .def("retrieve_data", &retrieveDataStr)
+        .def("retrieve_feature_data", &retrieveFeatureDataIdx)
+        .def("retrieve_feature_data", &retrieveFeatureDataStr)
 
         // Other
         .def("__str__", &toStr<MultiTag>)

--- a/src/PyTag.cpp
+++ b/src/PyTag.cpp
@@ -79,6 +79,22 @@ boost::optional<Feature> getFeatureByPos(const Tag& st, size_t index) {
     return f ? boost::optional<Feature>(f) : boost::none;
 }
 
+DataView retrieveDataIdx(const Tag& st, size_t reference_index) {
+    return st.retrieveData(reference_index);
+}
+
+DataView retrieveDataStr(const Tag& st, const std::string &name_or_id) {
+    return st.retrieveData(name_or_id);
+}
+
+DataView retrieveFeatureDataIdx(const Tag& st, size_t feature_index) {
+    return st.retrieveFeatureData(feature_index);
+}
+
+DataView retrieveFeatureDataStr(const Tag& st, const std::string &name_or_id) {
+    return st.retrieveFeatureData(name_or_id);
+}
+
 void PyTag::do_export() {
 
     PyEntityWithSources<base::ITag>::do_export("Tag");
@@ -114,8 +130,10 @@ void PyTag::do_export() {
         .def("_get_feature_by_pos", &getFeatureByPos)
         .def("_delete_feature_by_id", REMOVER(std::string, Tag, deleteFeature))
         // Data access
-        .def("retrieve_data", &Tag::retrieveData)
-        .def("retrieve_feature_data", &Tag::retrieveFeatureData)
+        .def("retrieve_data", &retrieveDataIdx)
+        .def("retrieve_data", &retrieveDataStr)
+        .def("retrieve_feature_data", &retrieveFeatureDataIdx)
+        .def("retrieve_feature_data", &retrieveFeatureDataStr)
         // Other
         .def("__str__", &toStr<Tag>)
         .def("__repr__", &toStr<Tag>)


### PR DESCRIPTION
Counterpart to G-Node/nix#669.

Handles retrieving data and references by name in Tags and MultiTags in both PyCore and the NIX bindings.

Includes tests for retrieving data by name.