### PR TITLE
Add NIXPY_H5_BACKEND for runtime backend selection

### DIFF
--- a/nixio/pycore/file.py
+++ b/nixio/pycore/file.py
@@ -146,6 +146,8 @@ class File(FileMixin):
         :return: nixio.File object
         """
         if backend is None:
+            backend = os.getenv("NIXPY_H5_BACKEND")
+        if backend is None:
             if CFile is None:
                 backend = "h5py"
             else:


### PR DESCRIPTION
If no backend has been set in code we can overwrite the default
backend via the NIXPY_H5_BACKEND env variable. Useful for testing
scripts/code against both backends without modifying existing
code.

NB: relies on os.getenv to return NONE for unknown variables, which
it should for both 2.7 and 3.