### PR TITLE
Header attribute fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,11 @@ matrix:
         - python: "2.7_with_system_site_packages"
           env: COVERALLS=1 NIX_LIBDIR=./nix-build/inst/lib NIX_INCDIR=./nix-build/inst/include SETUP_ARG=--with-nix
         - python: "3.4"
-          env: NIX_LIBDIR=./nix-build/inst/lib NIX_INCDIR=./nix-build/inst/include
         - python: "2.7_with_system_site_packages"
-        - python: "3.4"
         - python: "3.5"
+          env: NIX_LIBDIR=./nix-build/inst/lib NIX_INCDIR=./nix-build/inst/include
+        - python: "3.5"
+        - python: "3.6"
 
 addons:
   apt:

--- a/nixio/pycore/file.py
+++ b/nixio/pycore/file.py
@@ -9,6 +9,7 @@ from __future__ import (absolute_import, division, print_function)
 import os
 import gc
 from warnings import warn
+import numpy as np
 
 import h5py
 
@@ -25,7 +26,8 @@ except ImportError:
     CFile = None
 
 
-FILE_FORMAT = "nix"
+# always encode to ascii for python2 and nix compatibility
+FILE_FORMAT = "nix".encode("ascii")
 HDF_FF_VERSION = (1, 1, 0)
 
 
@@ -193,6 +195,8 @@ class File(FileMixin):
         util.check_attr_type(v, tuple)
         for part in v:
             util.check_attr_type(part, int)
+        # convert to np.int32 since py3 defaults to 64
+        v = np.array(v, dtype=np.int32)
         self._root.set_attr("version", v)
 
     @property
@@ -203,7 +207,7 @@ class File(FileMixin):
 
         :type: str
         """
-        return self._root.get_attr("format")
+        return self._root.get_attr("format").encode("ascii")
 
     @format.setter
     def format(self, f):

--- a/nixio/test/test_file.py
+++ b/nixio/test/test_file.py
@@ -31,7 +31,7 @@ class _FileTest(unittest.TestCase):
         self.file.close()
 
     def test_file_format(self):
-        assert(self.file.format == "nix")
+        assert(self.file.format == "nix".encode("ascii"))
         assert(self.file.version == filepy.HDF_FF_VERSION)
 
     def test_file_timestamps(self):

--- a/scripts/findboost.py
+++ b/scripts/findboost.py
@@ -89,7 +89,8 @@ class BoostPyLib(object):
     @classmethod
     def find_lib_for_current_python(cls, libs):
         v_major, v_minor = sys.version_info[:2]
-        match = cls.find_lib_with_version(libs, (v_major, v_minor), unknown_is_match=v_major == 2)
+        match = cls.find_lib_with_version(libs, (v_major, v_minor),
+                                          unknown_is_match=v_major == 2)
         return match
 
     @staticmethod

--- a/scripts/findboost.py
+++ b/scripts/findboost.py
@@ -90,7 +90,8 @@ class BoostPyLib(object):
     def find_lib_for_current_python(cls, libs):
         v_major, v_minor = sys.version_info[:2]
         match = cls.find_lib_with_version(libs, (v_major, v_minor),
-                                          unknown_is_match=v_major == 2)
+                                          unknown_is_match=True)
+                                          # unknown_is_match=v_major == 2)
         return match
 
     @staticmethod

--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,7 @@ else:
 if with_nix:
     if boost_lib is None:
         print("Could not find boost python version for {}.{}".format(
-            sys.version_info[0:2]))
+            *sys.version_info[0:2]))
         print("Available boost python libs:")
         print("\n".join(map(str, boost_libs)))
         sys.exit(-1)


### PR DESCRIPTION
Header attributes were defaulting to python3 types (int64 and unicode string), while NIX expects the python2 defaults (int32 and ascii string).