### PR TITLE
FIXES: Order tracking, (Multi)Tag.retrieve_data, and header format string type

### DIFF
--- a/nixio/pycore/dimensions.py
+++ b/nixio/pycore/dimensions.py
@@ -5,7 +5,7 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
-from __future__ import (absolute_import, division, print_function)
+from __future__ import (absolute_import, division)
 from numbers import Number
 
 import numpy as np
@@ -20,7 +20,6 @@ class Dimension(object):
     def __init__(self, h5group, index):
         from nixio.pycore.h5group import H5Group
         if not isinstance(h5group, H5Group):
-            print(h5group)
             raise Exception
         self._h5group = h5group
         self.dim_index = index

--- a/nixio/pycore/file.py
+++ b/nixio/pycore/file.py
@@ -9,6 +9,7 @@ from __future__ import (absolute_import, division, print_function)
 import os
 import gc
 from warnings import warn
+import numpy as np
 
 import h5py
 
@@ -25,7 +26,8 @@ except ImportError:
     CFile = None
 
 
-FILE_FORMAT = "nix"
+# always encode to ascii for python2 and nix compatibility
+FILE_FORMAT = "nix".encode("ascii")
 HDF_FF_VERSION = (1, 1, 0)
 
 
@@ -193,6 +195,8 @@ class File(FileMixin):
         util.check_attr_type(v, tuple)
         for part in v:
             util.check_attr_type(part, int)
+        # convert to np.int32 since py3 defaults to 64
+        v = np.array(v, dtype=np.int32)
         self._root.set_attr("version", v)
 
     @property
@@ -203,7 +207,7 @@ class File(FileMixin):
 
         :type: str
         """
-        return self._root.get_attr("format")
+        return self._root.get_attr("format").encode("ascii")
 
     @format.setter
     def format(self, f):

--- a/nixio/pycore/file.py
+++ b/nixio/pycore/file.py
@@ -26,8 +26,7 @@ except ImportError:
     CFile = None
 
 
-# always encode to ascii for python2 and nix compatibility
-FILE_FORMAT = "nix".encode("ascii")
+FILE_FORMAT = "nix"
 HDF_FF_VERSION = (1, 1, 0)
 
 
@@ -170,7 +169,7 @@ class File(FileMixin):
 
     def _check_header(self, mode):
         if self.format != FILE_FORMAT:
-            raise exceptions.InvalidFile()
+            raise exceptions.InvalidFile
 
         if mode == FileMode.ReadWrite:
             if not can_write(self):
@@ -207,12 +206,12 @@ class File(FileMixin):
 
         :type: str
         """
-        return self._root.get_attr("format").encode("ascii")
+        return self._root.get_attr("format")
 
     @format.setter
     def format(self, f):
         util.check_attr_type(f, str)
-        self._root.set_attr("format", f)
+        self._root.set_attr("format", f.encode("ascii"))
 
     @property
     def created_at(self):

--- a/nixio/pycore/h5group.py
+++ b/nixio/pycore/h5group.py
@@ -190,7 +190,7 @@ class H5Group(object):
         # Using low level interface to specify iteration order
         name, _ = self.group.id.links.iterate(lambda n: n,
                                               idx_type=h5py.h5.INDEX_CRT_ORDER,
-                                              order=h5py.h5.ITER_NATIVE,
+                                              order=h5py.h5.ITER_INC,
                                               idx=pos)
         return self.get_by_name(name)
 

--- a/nixio/pycore/multi_tag.py
+++ b/nixio/pycore/multi_tag.py
@@ -73,7 +73,7 @@ class MultiTag(BaseTag, MultiTagMixin):
         extents = self.extents
 
         pos_size = positions.data_extent if positions else tuple()
-        ext_size = extents.data_extent if extents else tuple
+        ext_size = extents.data_extent if extents else tuple()
 
         if not positions or index >= pos_size[0]:
             raise OutOfBounds("Index out of bounds of positions!")

--- a/nixio/pycore/multi_tag.py
+++ b/nixio/pycore/multi_tag.py
@@ -122,6 +122,8 @@ class MultiTag(BaseTag, MultiTagMixin):
                 c = self._pos_to_idx(offset.item(idx) + extent.item(idx),
                                      unit, dim) - offsets[idx]
                 counts.append(c if c > 1 else 1)
+        else:
+            counts = [1]*len(data.dimensions)
 
         return offsets, counts
 

--- a/nixio/pycore/multi_tag.py
+++ b/nixio/pycore/multi_tag.py
@@ -14,7 +14,7 @@ from .data_view import DataView
 from ..link_type import LinkType
 from .exceptions import (OutOfBounds, IncompatibleDimensions,
                          UninitializedEntity)
-import numpy as np
+
 
 class MultiTag(BaseTag, MultiTagMixin):
 
@@ -102,7 +102,7 @@ class MultiTag(BaseTag, MultiTagMixin):
                 "dimensionality of data",
                 "MultiTag._get_offset_and_count"
             )
-        
+
         offset = positions[index, 0:len(data.dimensions)]
         units = self.units
         for idx in range(offset.size):

--- a/nixio/pycore/tag.py
+++ b/nixio/pycore/tag.py
@@ -177,7 +177,7 @@ class BaseTag(EntityWithSources):
         else:  # dimtype == DimensionType.Range:
             if dimunit and unit is not None:
                 try:
-                    scaling = util.scaling(unit, dimunit)
+                    scaling = util.units.scaling(unit, dimunit)
                 except InvalidUnit:
                     raise IncompatibleDimensions(
                         "Provided units are not scalable!",
@@ -254,8 +254,7 @@ class Tag(BaseTag, TagMixin):
             if idx < len(extent):
                 ext = extent[idx]
                 c = self._pos_to_idx(pos + ext, unit, dim) - o
-                if c > 1:
-                    count.append(c if c > 1 else 1)
+                count.append(c if c > 1 else 1)
             else:
                 count.append(1)
         return tuple(offset), tuple(count)

--- a/nixio/pycore/tag.py
+++ b/nixio/pycore/tag.py
@@ -49,7 +49,8 @@ class BaseTag(EntityWithSources):
             for u in units:
                 util.check_attr_type(u, str)
                 u = util.units.sanitizer(u)
-                if not (util.units.is_si(u) or util.units.is_compound(u)):
+                if not (util.units.is_si(u) or util.units.is_compound(u)
+                        or u == "none"):
                     raise InvalidUnit(
                         "{} is not SI or composite of SI units".format(u),
                         "{}.units".format(type(self).__name__)

--- a/nixio/pycore/tag.py
+++ b/nixio/pycore/tag.py
@@ -141,7 +141,10 @@ class BaseTag(EntityWithSources):
     @staticmethod
     def _pos_to_idx(pos, unit, dim):
         dimtype = dim.dimension_type
-        dimunit = dim.unit
+        if dimtype == DimensionType.Set:
+            dimunit = None
+        else:
+            dimunit = dim.unit
         scaling = 1.0
         if dimtype == DimensionType.Sample:
             if not dimunit and unit is not None:
@@ -161,7 +164,7 @@ class BaseTag(EntityWithSources):
 
             index = dim.index_of(pos * scaling)
         elif dimtype == DimensionType.Set:
-            if unit:
+            if unit and unit != "none":
                 raise IncompatibleDimensions(
                     "Cannot apply a position with unit to a SetDimension",
                     "Tag._pos_to_idx"

--- a/nixio/test/test_file.py
+++ b/nixio/test/test_file.py
@@ -31,7 +31,7 @@ class _FileTest(unittest.TestCase):
         self.file.close()
 
     def test_file_format(self):
-        assert(self.file.format == "nix")
+        assert(self.file.format == "nix".encode("ascii"))
         assert(self.file.version == filepy.HDF_FF_VERSION)
 
     def test_file_timestamps(self):

--- a/nixio/test/test_file.py
+++ b/nixio/test/test_file.py
@@ -32,7 +32,7 @@ class _FileTest(unittest.TestCase):
         self.file.close()
 
     def test_file_format(self):
-        assert(self.file.format == "nix".encode("ascii"))
+        assert(self.file.format == "nix")
         assert(self.file.version == filepy.HDF_FF_VERSION)
 
     def test_file_timestamps(self):

--- a/nixio/test/test_multi_tag.py
+++ b/nixio/test/test_multi_tag.py
@@ -270,12 +270,12 @@ class _TestMultiTag(unittest.TestCase):
         ticks = [1.2, 2.3, 3.4, 4.5, 6.7]
         unit = "ms"
         pos = self.block.create_data_array("pos", "test",
-                                           data=np.random.random((2, 3, 2)))
+                                           data=np.random.random((2, 3)))
         pos.append_set_dimension()
         pos.append_set_dimension()
         pos.append_set_dimension()
         ext = self.block.create_data_array("ext", "test",
-                                           data=np.random.random((2, 3, 2)))
+                                           data=np.random.random((2, 3)))
         ext.append_set_dimension()
         ext.append_set_dimension()
         ext.append_set_dimension()

--- a/nixio/test/test_multi_tag.py
+++ b/nixio/test/test_multi_tag.py
@@ -24,6 +24,10 @@ class _TestMultiTag(unittest.TestCase):
     backend = None
 
     def setUp(self):
+        iv = 1.0
+        ticks = [1.2, 2.3, 3.4, 4.5, 6.7]
+        unit = "ms"
+
         self.file = nix.File.open("unittest.h5", nix.FileMode.Overwrite,
                                   backend=self.backend)
         self.block = self.file.create_block("test block", "recordingsession")
@@ -56,6 +60,13 @@ class _TestMultiTag(unittest.TestCase):
                     data[i, j, k] = value
 
         self.data_array[:, :, :] = data
+
+        set_dim = self.data_array.append_set_dimension()
+        set_dim.labels = ["label_a", "label_b"]
+        sampled_dim = self.data_array.append_sampled_dimension(iv)
+        sampled_dim.unit = unit
+        range_dim = self.data_array.append_range_dimension(ticks)
+        range_dim.unit = unit
 
         event_positions = np.zeros((2, 3))
         event_positions[0, 0] = 0.0
@@ -254,6 +265,12 @@ class _TestMultiTag(unittest.TestCase):
         data = tag.retrieve_data(0, da.name)
         assert(data.shape == (2000,))
         assert(np.array_equal(y[:2000], data[:]))
+
+        # multi dimensional data (created in setUp)
+        mtag = self.feature_tag
+        rdata = mtag.retrieve_data(0, 0)
+        assert(len(rdata.shape) == 3)
+        assert(rdata.shape == (1, 6, 2))
 
     def test_multi_tag_feature_data(self):
         index_data = self.block.create_data_array("indexed feature data",

--- a/nixio/test/test_multi_tag.py
+++ b/nixio/test/test_multi_tag.py
@@ -253,24 +253,59 @@ class _TestMultiTag(unittest.TestCase):
         ext.append_set_dimension()
         ext.unit = 'ms'
 
-        tag = block.create_multi_tag("sin1", "tag", pos)
-        tag.extents = ext
-        tag.units = ['ms']
-        tag.references.append(da)
+        mtag = block.create_multi_tag("sin1", "tag", pos)
+        mtag.extents = ext
+        mtag.units = ['ms']
+        mtag.references.append(da)
 
-        assert(tag.retrieve_data(0, 0).shape == (2000,))
-        assert(np.array_equal(y[:2000], tag.retrieve_data(0, 0)[:]))
+        assert(mtag.retrieve_data(0, 0).shape == (2000,))
+        assert(np.array_equal(y[:2000], mtag.retrieve_data(0, 0)[:]))
 
         # get by name
-        data = tag.retrieve_data(0, da.name)
+        data = mtag.retrieve_data(0, da.name)
         assert(data.shape == (2000,))
         assert(np.array_equal(y[:2000], data[:]))
 
-        # multi dimensional data (created in setUp)
-        mtag = self.feature_tag
-        rdata = mtag.retrieve_data(0, 0)
-        assert(len(rdata.shape) == 3)
-        assert(rdata.shape == (1, 6, 2))
+        # multi dimensional data
+        ticks = [1.2, 2.3, 3.4, 4.5, 6.7]
+        unit = "ms"
+        pos = self.block.create_data_array("pos", "test",
+                                           data=np.random.random((2, 3, 2)))
+        pos.append_set_dimension()
+        pos.append_set_dimension()
+        pos.append_set_dimension()
+        ext = self.block.create_data_array("ext", "test",
+                                           data=np.random.random((2, 3, 2)))
+        ext.append_set_dimension()
+        ext.append_set_dimension()
+        ext.append_set_dimension()
+        units = ["none", "ms", "ms"]
+        data = np.random.random((2, 10, 5))
+        da = self.block.create_data_array("dimtest", "test",
+                                          data=data)
+        setdim = da.append_set_dimension()
+        setdim.labels = ["Label A", "Label B"]
+        samdim = da.append_sampled_dimension(sample_iv)
+        samdim.unit = unit
+        randim = da.append_range_dimension(ticks)
+        randim.unit = unit
+
+        postag = self.block.create_multi_tag("postag", "event", pos)
+        postag.references.append(da)
+        postag.units = units
+
+        segtag = self.block.create_multi_tag("region", "segment", pos)
+        segtag.references.append(da)
+        segtag.extent = ext
+        segtag.units = units
+
+        posdata = postag.retrieve_data(0, 0)
+        assert(len(posdata.shape) == 3)
+        assert(posdata.shape == (1, 1, 1))
+
+        segdata = segtag.retrieve_data(0, 0)
+        assert(len(segdata.shape) == 3)
+        assert(segdata.shape == (1, 6, 2))
 
     def test_multi_tag_feature_data(self):
         index_data = self.block.create_data_array("indexed feature data",

--- a/nixio/test/test_multi_tag.py
+++ b/nixio/test/test_multi_tag.py
@@ -231,7 +231,6 @@ class _TestMultiTag(unittest.TestCase):
         assert(len(self.my_tag.features) == 0)
 
     def test_multi_tag_retrieve_data(self):
-
         sample_iv = 0.001
         x = np.arange(0, 10, sample_iv)
         y = np.sin(2*np.pi*x)
@@ -267,24 +266,25 @@ class _TestMultiTag(unittest.TestCase):
         assert(np.array_equal(y[:2000], data[:]))
 
         # multi dimensional data
+        sample_iv = 1.0
         ticks = [1.2, 2.3, 3.4, 4.5, 6.7]
         unit = "ms"
         pos = self.block.create_data_array("pos", "test",
-                                           data=np.random.random((2, 3)))
-        pos.append_set_dimension()
+                                           data=[[1, 1, 1],
+                                                 [1, 1, 1]])
         pos.append_set_dimension()
         pos.append_set_dimension()
         ext = self.block.create_data_array("ext", "test",
-                                           data=np.random.random((2, 3)))
-        ext.append_set_dimension()
+                                           data=[[2, 5, 2],
+                                                 [0, 4, 1]])
         ext.append_set_dimension()
         ext.append_set_dimension()
         units = ["none", "ms", "ms"]
-        data = np.random.random((2, 10, 5))
+        data = np.random.random((3, 10, 5))
         da = self.block.create_data_array("dimtest", "test",
                                           data=data)
         setdim = da.append_set_dimension()
-        setdim.labels = ["Label A", "Label B"]
+        setdim.labels = ["Label A", "Label B", "Label D"]
         samdim = da.append_sampled_dimension(sample_iv)
         samdim.unit = unit
         randim = da.append_range_dimension(ticks)
@@ -296,16 +296,26 @@ class _TestMultiTag(unittest.TestCase):
 
         segtag = self.block.create_multi_tag("region", "segment", pos)
         segtag.references.append(da)
-        segtag.extent = ext
+        segtag.extents = ext
         segtag.units = units
 
         posdata = postag.retrieve_data(0, 0)
         assert(len(posdata.shape) == 3)
         assert(posdata.shape == (1, 1, 1))
+        assert(np.isclose(posdata[0, 0, 0], data[1, 1, 0]))
+
+        posdata = postag.retrieve_data(1, 0)
+        assert(len(posdata.shape) == 3)
+        assert(posdata.shape == (1, 1, 1))
+        assert(np.isclose(posdata[0, 0, 0], data[1, 1, 0]))
 
         segdata = segtag.retrieve_data(0, 0)
         assert(len(segdata.shape) == 3)
-        assert(segdata.shape == (1, 6, 2))
+        assert(segdata.shape == (2, 5, 2))
+
+        segdata = segtag.retrieve_data(1, 0)
+        assert(len(segdata.shape) == 3)
+        assert(segdata.shape == (1, 4, 1))
 
     def test_multi_tag_feature_data(self):
         index_data = self.block.create_data_array("indexed feature data",

--- a/nixio/test/test_tag.py
+++ b/nixio/test/test_tag.py
@@ -153,6 +153,40 @@ class _TestTag(unittest.TestCase):
 
         assert(len(self.my_tag.features) == 0)
 
+    def test_tag_retrieve_data(self):
+        sample_iv = 1.0
+        ticks = [1.2, 2.3, 3.4, 4.5, 6.7]
+        unit = "ms"
+        pos = [0.0, 2.0, 3.4]
+        ext = [0.0, 6.0, 2.3]
+        units = ["none", "ms", "ms"]
+        data = np.random.random((2, 10, 5))
+        da = self.block.create_data_array("dimtest", "test",
+                                          data=data)
+        setdim = da.append_set_dimension()
+        setdim.labels = ["Label A", "Label B"]
+        samdim = da.append_sampled_dimension(sample_iv)
+        samdim.unit = unit
+        randim = da.append_range_dimension(ticks)
+        randim.unit = unit
+
+        postag = self.block.create_tag("postag", "event", pos)
+        postag.references.append(da)
+        postag.units = units
+
+        segtag = self.block.create_tag("region", "segment", pos)
+        segtag.references.append(da)
+        segtag.extent = ext
+        segtag.units = units
+
+        posdata = postag.retrieve_data(0)
+        assert(len(posdata.shape) == 3)
+        assert(posdata.shape == (1, 1, 1))
+
+        segdata = segtag.retrieve_data(0)
+        assert(len(segdata.shape) == 3)
+        assert(segdata.shape == (1, 6, 2))
+
     def test_tag_retrieve_feature_data(self):
         number_feat = self.block.create_data_array("number feature", "test",
                                                    data=10.)

--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,7 @@ else:
 if with_nix:
     if boost_lib is None:
         print("Could not find boost python version for {}.{}".format(
-            sys.version_info[0:2]))
+            *sys.version_info[0:2]))
         print("Available boost python libs:")
         print("\n".join(map(str, boost_libs)))
         sys.exit(-1)


### PR DESCRIPTION
Fixed the order tracking issue. The iteration order was set to `NATIVE` instead of `INC`(reasing).

This PR includes the header changes from PR #266 and fixes the issue (tested locally for combinations of python2 and python3).

It also PARTIALLY includes PR #263, but the issue is not completely resolved yet.