### PR TITLE
FIX Alias Range Dimension handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
           os: linux
         - python: "3.5"
           os: linux
+        - python: "3.6"
+          os: linux
         # - language: generic
         #   os: osx
         #   before_install:

--- a/nixio/pycore/data_array.py
+++ b/nixio/pycore/data_array.py
@@ -141,8 +141,7 @@ class DataArray(EntityWithSources, DataSet, DataArrayMixin):
             raise ValueError("Cannot append additional alias dimension. "
                              "There must only be one!")
         dimgroup = self._h5group.open_group("dimensions")
-        data = self._h5group.group["data"]
-        return RangeDimension._create_new(dimgroup, 1, data)
+        return RangeDimension._create_new_alias(dimgroup, 1, self)
 
     def delete_dimensions(self):
         """

--- a/nixio/pycore/dimensions.py
+++ b/nixio/pycore/dimensions.py
@@ -158,6 +158,15 @@ class RangeDimension(Dimension):
                                                  shape=np.shape(ticks),
                                                  dtype=DataType.Double)
         ticksds.write_data(ticks)
+        newdim._alias = False
+        return newdim
+
+    @classmethod
+    def _create_new_alias(cls, parent, index, da):
+        newdim = super(RangeDimension, cls)._create_new(parent, index)
+        newdim.dimension_type = DimensionType.Range
+        newdim._h5group.create_link(da, da.id)
+        newdim._alias = True
         return newdim
 
     @property

--- a/nixio/pycore/dimensions.py
+++ b/nixio/pycore/dimensions.py
@@ -183,6 +183,14 @@ class RangeDimension(Dimension):
         ticksds.write_data(ticks)
 
     @property
+    def _group(self):
+        return self._intgroup
+
+    @_group.setter
+    def _group(self, grp):
+        self._intgroup = grp
+
+    @property
     def label(self):
         return self._h5group.get_attr("label")
 

--- a/nixio/pycore/file.py
+++ b/nixio/pycore/file.py
@@ -284,6 +284,9 @@ class File(FileMixin):
         except ValueError:
             return False
 
+    def flush(self):
+        self._h5file.flush()
+
     def close(self):
         """
         Closes an open file.

--- a/nixio/test/test_backend_compatibility.py
+++ b/nixio/test/test_backend_compatibility.py
@@ -29,7 +29,7 @@ all_attrs = [
 
 
 @unittest.skipIf(skip, "HDF5 backend not available.")
-class _TestBackendCompatibility(unittest.TestCase):
+class BackendCompatibilityTestBase(unittest.TestCase):
 
     testfilename = "compattest.h5"
 
@@ -527,13 +527,13 @@ class _TestBackendCompatibility(unittest.TestCase):
         self.assertEqual(wfile.updated_at, rfile.updated_at)
 
 
-class TestWriteCPPReadPy(_TestBackendCompatibility):
+class TestWriteCPPReadPy(BackendCompatibilityTestBase):
 
     write_backend = "hdf5"
     read_backend = "h5py"
 
 
-class TestWritePyReadCPP(_TestBackendCompatibility):
+class TestWritePyReadCPP(BackendCompatibilityTestBase):
 
     write_backend = "h5py"
     read_backend = "hdf5"

--- a/nixio/test/test_backend_compatibility.py
+++ b/nixio/test/test_backend_compatibility.py
@@ -5,8 +5,7 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
-
-from __future__ import (absolute_import, division, print_function)
+from __future__ import (absolute_import, division)
 import os
 
 import unittest

--- a/nixio/test/test_backend_compatibility.py
+++ b/nixio/test/test_backend_compatibility.py
@@ -111,6 +111,7 @@ class BackendCompatibilityTestBase(unittest.TestCase):
             blk.definition = "definition block " + str(idx)
             blk.force_created_at(np.random.randint(1000000000))
 
+        self.write_file.flush()
         self.check_compatibility()
 
     def test_groups(self):
@@ -120,6 +121,7 @@ class BackendCompatibilityTestBase(unittest.TestCase):
             grp.definition = "group definition " + str(idx*10)
             grp.force_created_at(np.random.randint(1000000000))
 
+        self.write_file.flush()
         self.check_compatibility()
 
     def test_data_arrays(self):
@@ -140,6 +142,7 @@ class BackendCompatibilityTestBase(unittest.TestCase):
             if (idx % 3) == 0:
                 da.polynom_coefficients = tuple(np.random.random(3))
 
+        self.write_file.flush()
         self.check_compatibility()
         wdata = blk.data_arrays
         rdata = self.read_file.blocks[0].data_arrays
@@ -183,6 +186,7 @@ class BackendCompatibilityTestBase(unittest.TestCase):
             if (idx % 3) == 0:
                 grp.tags.append(tag)
 
+        self.write_file.flush()
         self.check_compatibility()
         wtags = blk.tags
         rtags = self.read_file.blocks[0].tags
@@ -206,6 +210,7 @@ class BackendCompatibilityTestBase(unittest.TestCase):
             if (idx % 2) == 0:
                 grp.multi_tags.append(mtag)
 
+        self.write_file.flush()
         self.check_compatibility()
         wmts = blk.multi_tags
         rmts = self.read_file.blocks[0].multi_tags
@@ -238,6 +243,7 @@ class BackendCompatibilityTestBase(unittest.TestCase):
 
         # TODO: Nested sources
 
+        self.write_file.flush()
         self.check_compatibility()
 
     def test_dimensions(self):
@@ -274,6 +280,7 @@ class BackendCompatibilityTestBase(unittest.TestCase):
         da_multi_dim.append_set_dimension()
         da_multi_dim.append_range_dimension(np.random.random(10))
 
+        self.write_file.flush()
         self.check_compatibility()
 
         for idx in range(len(blk.data_arrays)):
@@ -299,6 +306,7 @@ class BackendCompatibilityTestBase(unittest.TestCase):
             da_feat.append_sampled_dimension(1.0)
             tag_feat.create_feature(da_feat, linktypes[idx % 3])
 
+        self.write_file.flush()
         self.check_compatibility()
 
         wtag = self.write_file.blocks[0].tags[0]
@@ -319,6 +327,7 @@ class BackendCompatibilityTestBase(unittest.TestCase):
         self.check_attributes(wfdata, rfdata)
         np.testing.assert_almost_equal(wfdata[:], rfdata[:])
 
+        self.write_file.flush()
         self.check_recurse(wtag.references, rtag.references)
 
     def test_multi_tag_features(self):
@@ -389,6 +398,7 @@ class BackendCompatibilityTestBase(unittest.TestCase):
         feature_tag.create_feature(tagged_data, nix.LinkType.Tagged)
         feature_tag.create_feature(index_data, nix.LinkType.Untagged)
 
+        self.write_file.flush()
         self.check_compatibility()
 
         wmtag = self.write_file.blocks[0].multi_tags[0]
@@ -445,6 +455,7 @@ class BackendCompatibilityTestBase(unittest.TestCase):
         mtag.units = ["ms"]
         mtag.references.append(da)
 
+        self.write_file.flush()
         self.check_compatibility()
 
         for wmtag, rmtag in zip(self.write_file.blocks[0].multi_tags,
@@ -470,6 +481,7 @@ class BackendCompatibilityTestBase(unittest.TestCase):
         sec.props[0].mapping = "mapping"
         sec.props[1].definition = "def"
 
+        self.write_file.flush()
         self.check_compatibility()
 
         wsec = self.write_file.sections[0]
@@ -480,11 +492,13 @@ class BackendCompatibilityTestBase(unittest.TestCase):
             self.check_attributes(wprop, rprop)
 
         sec.props[0].values = [nix.Value(101)]
+        self.write_file.flush()
         for wprop, rprop in zip(wsec.props, rsec.props):
             self.check_attributes(wprop, rprop)
 
         sec.props[1].values = [nix.Value("foo"), nix.Value("bar"),
                                nix.Value("baz")]
+        self.write_file.flush()
         for wprop, rprop in zip(wsec.props, rsec.props):
             self.check_attributes(wprop, rprop)
 
@@ -506,6 +520,7 @@ class BackendCompatibilityTestBase(unittest.TestCase):
         block = self.write_file.create_block("block", "section test")
         block.metadata = self.write_file.sections[0].sections[0].sections[0]
 
+        self.write_file.flush()
         self.check_compatibility()
 
         wblock = self.write_file.blocks[0]
@@ -515,6 +530,7 @@ class BackendCompatibilityTestBase(unittest.TestCase):
         self.assertEqual(wblock.metadata.parent, rblock.metadata.parent)
 
     def test_file(self):
+        self.write_file.flush()
         self.check_compatibility()
 
         wfile = self.write_file

--- a/nixio/test/test_backend_compatibility.py
+++ b/nixio/test/test_backend_compatibility.py
@@ -244,7 +244,7 @@ class _TestBackendCompatibility(unittest.TestCase):
     def test_dimensions(self):
         blk = self.write_file.create_block("testblock", "dimtest")
 
-        da_set = blk.create_data_array("da with seet", "datype",
+        da_set = blk.create_data_array("da with set", "datype",
                                        data=np.random.random(20))
         da_set.append_set_dimension()
         da_set.dimensions[0].labels = ["label one", "label two"]
@@ -262,6 +262,12 @@ class _TestBackendCompatibility(unittest.TestCase):
         smpldim.unit = "mV"
 
         da_sample.dimensions[0].label = "sample dim label"
+
+        da_alias = blk.create_data_array("da with alias", "datype",
+                                         data=np.random.random(19))
+        da_alias.unit = "F"
+        da_alias.label = "fee fi fo fum"
+        da_alias.append_alias_range_dimension()
 
         da_multi_dim = blk.create_data_array("da with multiple", "datype",
                                              data=np.random.random(30))

--- a/nixio/test/test_block.py
+++ b/nixio/test/test_block.py
@@ -17,7 +17,7 @@ import nixio as nix
 skip_cpp = not hasattr(nix, "core")
 
 
-class _TestBlock(unittest.TestCase):
+class BlockTestBase(unittest.TestCase):
 
     backend = None
     testfilename = "blocktest.h5"
@@ -195,11 +195,11 @@ class _TestBlock(unittest.TestCase):
 
 
 @unittest.skipIf(skip_cpp, "HDF5 backend not available.")
-class TestBlockCPP(_TestBlock):
+class TestBlockCPP(BlockTestBase):
 
     backend = "hdf5"
 
 
-class TestBlockPy(_TestBlock):
+class TestBlockPy(BlockTestBase):
 
     backend = "h5py"

--- a/nixio/test/test_data_array.py
+++ b/nixio/test/test_data_array.py
@@ -25,7 +25,7 @@ except NameError:  # 'basestring' is undefined, must be Python 3
     basestring = (str, bytes)
 
 
-class _TestDataArray(unittest.TestCase):
+class DataArrayTestBase(unittest.TestCase):
 
     backend = None
     testfilename = "dataarraytest.h5"
@@ -368,11 +368,11 @@ class _TestDataArray(unittest.TestCase):
 
 
 @unittest.skipIf(skip_cpp, "HDF5 backend not available.")
-class TestDataArrayCPP(_TestDataArray):
+class TestDataArrayCPP(DataArrayTestBase):
 
     backend = "hdf5"
 
 
-class TestDataArrayPy(_TestDataArray):
+class TestDataArrayPy(DataArrayTestBase):
 
     backend = "h5py"

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -23,7 +23,7 @@ test_label = "test label"
 test_labels = tuple([str(i) + "_label" for i in range(10)])
 
 
-class _TestDimensions(unittest.TestCase):
+class DimensionTestBase(unittest.TestCase):
 
     backend = None
     testfilename = "dimtest.h5"
@@ -131,11 +131,11 @@ class _TestDimensions(unittest.TestCase):
 
 
 @unittest.skipIf(skip_cpp, "HDF5 backend not available.")
-class TestDimensionsCPP(_TestDimensions):
+class TestDimensionsCPP(DimensionTestBase):
 
     backend = "hdf5"
 
 
-class TestDimensionsPy(_TestDimensions):
+class TestDimensionsPy(DimensionTestBase):
 
     backend = "h5py"

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -138,7 +138,7 @@ class DimensionTestBase(unittest.TestCase):
         assert(len(da.dimensions) == 1)
         assert(da.dimensions[0].label == da.label)
         assert(da.dimensions[0].unit == da.unit)
-        assert(np.all(da.dimensions[0].ticks == da))
+        assert(np.all(da.dimensions[0].ticks == da[:]))
 
 
 @unittest.skipIf(skip_cpp, "HDF5 backend not available.")

--- a/nixio/test/test_feature.py
+++ b/nixio/test/test_feature.py
@@ -17,7 +17,7 @@ import nixio as nix
 skip_cpp = not hasattr(nix, "core")
 
 
-class _TestFeature(unittest.TestCase):
+class FeatureTestBase(unittest.TestCase):
 
     backend = None
     testfilename = "featuretest.h5"
@@ -82,11 +82,11 @@ class _TestFeature(unittest.TestCase):
 
 
 @unittest.skipIf(skip_cpp, "HDF5 backend not available.")
-class TestFeatureCPP(_TestFeature):
+class TestFeatureCPP(FeatureTestBase):
 
     backend = "hdf5"
 
 
-class TestFeaturePy(_TestFeature):
+class TestFeaturePy(FeatureTestBase):
 
     backend = "h5py"

--- a/nixio/test/test_file.py
+++ b/nixio/test/test_file.py
@@ -20,7 +20,7 @@ from nixio.pycore.exceptions.exceptions import InvalidFile
 skip_cpp = not hasattr(nix, "core")
 
 
-class _FileTest(unittest.TestCase):
+class FileTestBase(unittest.TestCase):
 
     backend = None
     testfilename = "filetest.h5"
@@ -134,17 +134,17 @@ class _FileTest(unittest.TestCase):
 
 
 @unittest.skipIf(skip_cpp, "HDF5 backend not available.")
-class FileTestCPP(_FileTest):
+class TestFileCPP(FileTestBase):
 
     backend = "hdf5"
 
 
-class FileTestPy(_FileTest):
+class TestFilePy(FileTestBase):
 
     backend = "h5py"
 
 
-class FileVerTestPy(unittest.TestCase):
+class TestFileVerPy(unittest.TestCase):
 
     backend = "h5py"
     testfilename = "versiontest.h5"

--- a/nixio/test/test_group.py
+++ b/nixio/test/test_group.py
@@ -16,7 +16,7 @@ import nixio as nix
 skip_cpp = not hasattr(nix, "core")
 
 
-class _TestGroup(unittest.TestCase):
+class GroupTestBase(unittest.TestCase):
 
     backend = None
     testfilename = "grouptest.h5"
@@ -205,11 +205,11 @@ class _TestGroup(unittest.TestCase):
 
 
 @unittest.skipIf(skip_cpp, "HDF5 backend not available.")
-class TestGroupCPP(_TestGroup):
+class TestGroupCPP(GroupTestBase):
 
     backend = "hdf5"
 
 
-class TestGroupPy(_TestGroup):
+class TestGroupPy(GroupTestBase):
 
     backend = "h5py"

--- a/nixio/test/test_multi_tag.py
+++ b/nixio/test/test_multi_tag.py
@@ -18,7 +18,7 @@ import nixio as nix
 skip_cpp = not hasattr(nix, "core")
 
 
-class _TestMultiTag(unittest.TestCase):
+class MultiTagTestBase(unittest.TestCase):
 
     backend = None
 
@@ -418,11 +418,11 @@ class _TestMultiTag(unittest.TestCase):
 
 
 @unittest.skipIf(skip_cpp, "HDF5 backend not available.")
-class TestMultiTagCPP(_TestMultiTag):
+class TestMultiTagCPP(MultiTagTestBase):
 
     backend = "hdf5"
 
 
-class TestMultiTagPy(_TestMultiTag):
+class TestMultiTagPy(MultiTagTestBase):
 
     backend = "h5py"

--- a/nixio/test/test_property.py
+++ b/nixio/test/test_property.py
@@ -17,7 +17,7 @@ import nixio as nix
 skip_cpp = not hasattr(nix, "core")
 
 
-class _TestProperty(unittest.TestCase):
+class PropertyTestBase(unittest.TestCase):
 
     backend = None
     testfilename = "proptest.h5"
@@ -198,11 +198,11 @@ class TestValue(unittest.TestCase):
 
 
 @unittest.skipIf(skip_cpp, "HDF5 backend not available.")
-class TestPropertyCPP(_TestProperty):
+class TestPropertyCPP(PropertyTestBase):
 
     backend = "hdf5"
 
 
-class TestPropertyPy(_TestProperty):
+class TestPropertyPy(PropertyTestBase):
 
     backend = "h5py"

--- a/nixio/test/test_section.py
+++ b/nixio/test/test_section.py
@@ -17,7 +17,7 @@ import nixio as nix
 skip_cpp = not hasattr(nix, "core")
 
 
-class _TestSection(unittest.TestCase):
+class SectionTestBase(unittest.TestCase):
 
     backend = None
     testfilename = "sectiontest.h5"
@@ -249,11 +249,11 @@ class _TestSection(unittest.TestCase):
 
 
 @unittest.skipIf(skip_cpp, "HDF5 backend not available.")
-class TestSectionCPP(_TestSection):
+class TestSectionCPP(SectionTestBase):
 
     backend = "hdf5"
 
 
-class TestSectionPy(_TestSection):
+class TestSectionPy(SectionTestBase):
 
     backend = "h5py"

--- a/nixio/test/test_source.py
+++ b/nixio/test/test_source.py
@@ -17,7 +17,7 @@ import nixio as nix
 skip_cpp = not hasattr(nix, "core")
 
 
-class _TestSource(unittest.TestCase):
+class SourceTestBase(unittest.TestCase):
 
     backend = None
     testfilename = "sourcetest.h5"
@@ -153,11 +153,11 @@ class _TestSource(unittest.TestCase):
 
 
 @unittest.skipIf(skip_cpp, "HDF5 backend not available.")
-class TestSourceCPP(_TestSource):
+class TestSourceCPP(SourceTestBase):
 
     backend = "hdf5"
 
 
-class TestSourcePy(_TestSource):
+class TestSourcePy(SourceTestBase):
 
     backend = "h5py"

--- a/nixio/test/test_tag.py
+++ b/nixio/test/test_tag.py
@@ -17,7 +17,7 @@ import nixio as nix
 skip_cpp = not hasattr(nix, "core")
 
 
-class _TestTag(unittest.TestCase):
+class TagTestBase(unittest.TestCase):
 
     backend = None
     testfilename = "tagtest.h5"
@@ -236,11 +236,11 @@ class _TestTag(unittest.TestCase):
 
 
 @unittest.skipIf(skip_cpp, "HDF5 backend not available.")
-class TestTagCPP(_TestTag):
+class TestTagCPP(TagTestBase):
 
     backend = "hdf5"
 
 
-class TestTagPy(_TestTag):
+class TestTagPy(TagTestBase):
 
     backend = "h5py"

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,4 +16,4 @@ description-file = README.rst
 test=pytest
 
 [tool:pytest]
-addopts = --verbose -k "not (_Test or _File)"
+addopts = --verbose -k "not Base"

--- a/src/PyFile.cpp
+++ b/src/PyFile.cpp
@@ -101,6 +101,7 @@ void PyFile::do_export() {
         // Open and close
         .def("is_open", &File::isOpen, doc::file_is_open)
         .def("close", &File::close, doc::file_close)
+        .def("flush", &File::flush)
         .def("open", open, open_overloads())
         .staticmethod("open")
         // Other


### PR DESCRIPTION
This PR is primarily to fix the handling of Alias Range Dimensions in pycore but also includes some other cleanup and maintenance changes.
 
The alias dimension handling wasn't creating a link to the data array as specified by the NIX specification. Instead it was making a copy and so the two backends were behaving differently and has this small incompatibility.

Here's a nice script that creates a file with an alias dimension using both backends and then compares them using vimdiff:

```bash
#!/usr/bin/env bash

cat > createaliasdim.py << EOF
import nixio as nix
import numpy as np
import sys


writer = sys.argv[1]

# let's make up some data
event_times = np.array([1, 2, 3, 5, 8, 13, 21])

f = nix.File.open("alias_test.nix", nix.FileMode.Overwrite, writer)
b = f.create_block("test", "test")
da = b.create_data_array("the name of the data array", "nix.irregular",
                         data=event_times)
da.unit = 's'
da.label = 'this is a label'
da.append_alias_range_dimension()

f.close()
EOF

set -e

python createaliasdim.py hdf5
mv alias_test.nix alias_test_hdf5.nix

python createaliasdim.py h5py
mv alias_test.nix alias_test_h5py.nix

vimdiff <(h5dump alias_test_hdf5.nix) <(h5dump alias_test_h5py.nix)
```

NOTE: I notice there's still a lot of places where one backend will create UTF8 strings while the other does ASCII. I'm opening an issue to go through all of pycore and fix this.

NOTE2: Don't be put off by the large number of affected files. This PR also includes a small change in the naming convention for tests.