### PR TITLE
Fix for value truncation when applying polynomial coefficients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ pip-log.txt
 *.log
 *.kate-swp
 *.swp
+*cache
 
 # idea / pycharm files
 .idea

--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -129,6 +129,10 @@ class DataSetMixin(object):
         count, offset, shape = self.__tuple_to_count_offset_shape(index)
         raw = np.empty(shape, dtype=self.dtype)
 
+        if hasattr(self, "polynom_coefficients") and self.polynom_coefficients:
+            # if there are coefficients, convert the dtype of the returned data
+            # array to double
+            raw.dtype = np.float64
         self._read_data(raw, count, offset)
 
         return raw

--- a/nixio/test/test_data_array.py
+++ b/nixio/test/test_data_array.py
@@ -117,6 +117,13 @@ class DataArrayTestBase(unittest.TestCase):
         self.array.polynom_coefficients = (1.1, 2.2)
         assert(self.array.polynom_coefficients == (1.1, 2.2))
 
+        data = [10, 29, 33]
+        intarray = self.block.create_data_array("intarray", "array",
+                                                nix.DataType.Int64,
+                                                data=data)
+        intarray.polynom_coefficients = (0.0, 0.1)
+        np.testing.assert_almost_equal(intarray[:], np.array(data) * 0.1)
+
         # TODO delete does not work
 
     def test_data_array_data(self):


### PR DESCRIPTION
Fix for issue #273.

### Bug description
When reading a DataArray, a numpy array is allocated with a data type that matches the DataArray. When the DataArray has polynomial coefficients defined and the resulting values of applying the coefficients to the raw data is outside the domain of the data type, the data values are truncated.

### Example
A data array with *Integer* dtype, internal value `[11]`, and polynomial coefficients `(0, 0.1)` will return the integer value `1` instead of `1.1`.

### Fix
Always return numpy arrays of type `float64` when a DataArray has any polynomial coefficients defined.

---
I'd be interested to know if anyone thinks we could be smarter about this. For instance, should we be testing if both data and coefficients are integers and not change the type?