### PR TITLE
Retrieve feature and reference data by name or ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ pip-log.txt
 *kdev*
 Makefile
 
-# test file
-nixpy.py
-
+.DS_Store
+.cache
+.eggs
+.mypy_cache

--- a/nixio/pycore/tag.py
+++ b/nixio/pycore/tag.py
@@ -118,7 +118,12 @@ class BaseTag(EntityWithSources):
 
     def _get_feature_by_id(self, id_or_name):
         features = self._h5group.open_group("features")
-        return Feature(self, features.get_by_id(id_or_name))
+        try:
+            return Feature(self, features.get_by_id(id_or_name))
+        except ValueError:
+            for feat in self.features:
+                if feat.data.id == id_or_name or feat.data.name == id_or_name:
+                    return feat
 
     def _get_feature_by_pos(self, pos):
         features = self._h5group.open_group("features")

--- a/nixio/pycore/tag.py
+++ b/nixio/pycore/tag.py
@@ -271,7 +271,7 @@ class Tag(BaseTag, TagMixin):
         if len(references) == 0:
             raise OutOfBounds("There are no references in this tag!")
 
-        if refidx >= len(references):
+        if isinstance(refidx, int) and refidx >= len(references):
             raise OutOfBounds("Reference index out of bounds.")
 
         ref = references[refidx]

--- a/nixio/test/test_backend_compatibility.py
+++ b/nixio/test/test_backend_compatibility.py
@@ -31,6 +31,8 @@ all_attrs = [
 class BackendCompatibilityTestBase(unittest.TestCase):
 
     testfilename = "compattest.h5"
+    write_backend = None
+    read_backend = None
 
     def setUp(self):
         self.write_file = nix.File.open(self.testfilename,

--- a/nixio/test/test_multi_tag.py
+++ b/nixio/test/test_multi_tag.py
@@ -239,6 +239,16 @@ class MultiTagTestBase(unittest.TestCase):
         assert(feature.id == self.my_tag.features[0].id)
         assert(feature.id == self.my_tag.features[-1].id)
 
+        # id and name access
+        assert(feature.id == self.my_tag.features[feature.id].id)
+        assert(feature.id == self.my_tag.features[data_array.id].id)
+        assert(feature.id == self.my_tag.features[data_array.name].id)
+        assert(data_array == self.my_tag.features[data_array.id].data)
+        assert(data_array == self.my_tag.features[data_array.name].data)
+
+        assert(data_array.id in self.my_tag.features)
+        assert(data_array.name in self.my_tag.features)
+
         del self.my_tag.features[0]
 
         assert(len(self.my_tag.features) == 0)

--- a/nixio/test/test_multi_tag.py
+++ b/nixio/test/test_multi_tag.py
@@ -206,6 +206,17 @@ class MultiTagTestBase(unittest.TestCase):
         assert(reference1 in self.my_tag.references)
         assert(reference2 in self.my_tag.references)
 
+        # id and name access
+        assert(reference1 == self.my_tag.references[reference1.name])
+        assert(reference1 == self.my_tag.references[reference1.id])
+        assert(reference2 == self.my_tag.references[reference2.name])
+        assert(reference2 == self.my_tag.references[reference2.id])
+
+        assert(reference1.name in self.my_tag.references)
+        assert(reference2.name in self.my_tag.references)
+        assert(reference1.id in self.my_tag.references)
+        assert(reference2.id in self.my_tag.references)
+
         del self.my_tag.references[reference2]
         assert(self.my_tag.references[0] == reference1)
 

--- a/nixio/test/test_multi_tag.py
+++ b/nixio/test/test_multi_tag.py
@@ -288,6 +288,11 @@ class MultiTagTestBase(unittest.TestCase):
         assert(data.shape == (2000,))
         assert(np.array_equal(y[:2000], data[:]))
 
+        # get by id
+        data = mtag.retrieve_data(0, da.id)
+        assert(data.shape == (2000,))
+        assert(np.array_equal(y[:2000], data[:]))
+
         # multi dimensional data
         sample_iv = 1.0
         ticks = [1.2, 2.3, 3.4, 4.5, 6.7]

--- a/nixio/test/test_tag.py
+++ b/nixio/test/test_tag.py
@@ -125,9 +125,22 @@ class TagTestBase(unittest.TestCase):
         self.my_tag.references.append(reference1)
         self.my_tag.references.append(reference2)
 
+        assert(reference1.name in self.my_tag.references)
+
         assert(len(self.my_tag.references) == 3)
         assert(reference1 in self.my_tag.references)
         assert(reference2 in self.my_tag.references)
+
+        # id and name access
+        assert(reference1 == self.my_tag.references[reference1.name])
+        assert(reference1 == self.my_tag.references[reference1.id])
+        assert(reference2 == self.my_tag.references[reference2.name])
+        assert(reference2 == self.my_tag.references[reference2.id])
+
+        assert(reference1.name in self.my_tag.references)
+        assert(reference2.name in self.my_tag.references)
+        assert(reference1.id in self.my_tag.references)
+        assert(reference2.id in self.my_tag.references)
 
         del self.my_tag.references[reference2]
         assert(self.my_array in self.my_tag.references)

--- a/nixio/test/test_tag.py
+++ b/nixio/test/test_tag.py
@@ -213,6 +213,21 @@ class TagTestBase(unittest.TestCase):
         assert(len(segdata.shape) == 3)
         assert(segdata.shape == (1, 6, 2))
 
+        # retrieve data by id and name
+        posdata = postag.retrieve_data(da.name)
+        assert(len(posdata.shape) == 3)
+        assert(posdata.shape == (1, 1, 1))
+        segdata = segtag.retrieve_data(da.name)
+        assert(len(segdata.shape) == 3)
+        assert(segdata.shape == (1, 6, 2))
+
+        posdata = postag.retrieve_data(da.id)
+        assert(len(posdata.shape) == 3)
+        assert(posdata.shape == (1, 1, 1))
+        segdata = segtag.retrieve_data(da.id)
+        assert(len(segdata.shape) == 3)
+        assert(segdata.shape == (1, 6, 2))
+
     def test_tag_retrieve_feature_data(self):
         number_feat = self.block.create_data_array("number feature", "test",
                                                    data=10.)

--- a/nixio/test/test_tag.py
+++ b/nixio/test/test_tag.py
@@ -165,6 +165,16 @@ class TagTestBase(unittest.TestCase):
         assert(feature.id == self.my_tag.features[0].id)
         assert(feature.id == self.my_tag.features[-1].id)
 
+        # id and name access
+        assert(feature.id == self.my_tag.features[feature.id].id)
+        assert(feature.id == self.my_tag.features[data_array.id].id)
+        assert(feature.id == self.my_tag.features[data_array.name].id)
+        assert(data_array == self.my_tag.features[data_array.id].data)
+        assert(data_array == self.my_tag.features[data_array.name].data)
+
+        assert(data_array.id in self.my_tag.features)
+        assert(data_array.name in self.my_tag.features)
+
         del self.my_tag.features[0]
 
         assert(len(self.my_tag.features) == 0)


### PR DESCRIPTION
Followup to #259 (counterpart to G-Node/nix#669).

Adds tests for:
- Retrieving a Tag and MultiTag reference by the reference ID or name
- Retrieving a Tag and MultiTag feature by the linked DataArray ID or name
- Calling the retrieve_data function using the DataArray ID or name

Fixes:
- Feature getter did not allow accessing elements by DataArray ID or name
- Tag.retrieve_data function raised error when called with reference ID or name

Closes #279 