### PR TITLE
Allow non-SI units in Properties and DataArrays

### DIFF
--- a/nixio/pycore/dimensions.py
+++ b/nixio/pycore/dimensions.py
@@ -168,7 +168,7 @@ class RangeDimension(Dimension):
         return newdim
 
     @property
-    def _alias(self):
+    def is_alias(self):
         """
         Return True if this dimension is an Alias Range dimension.
         Read-only property.
@@ -202,7 +202,7 @@ class RangeDimension(Dimension):
         the H5Group of the linked DataArray. Otherwise, it returns the H5Group
         representing the dimension.
         """
-        if self._alias:
+        if self.is_alias:
             gname = self._h5group.get_by_pos(0).name
             return self._h5group.open_group(gname)
         return self._h5group

--- a/nixio/pycore/exceptions/exceptions.py
+++ b/nixio/pycore/exceptions/exceptions.py
@@ -15,7 +15,7 @@ class UninitializedEntity(Exception):
                                                   *args, **kwargs)
 
 
-class InvalidUnit(Exception):
+class InvalidUnit(ValueError):
 
     def __init__(self, what, where):
         self.message = "InvalidUnit: {} evoked at: {}".format(what, where)

--- a/nixio/pycore/property.py
+++ b/nixio/pycore/property.py
@@ -61,6 +61,10 @@ class Property(Entity, PropertyMixin):
 
     @unit.setter
     def unit(self, u):
+        if u:
+            u = util.units.sanitizer(u)
+        if u == "":
+            u = None
         util.check_attr_type(u, str)
         self._h5dataset.set_attr("unit", u)
 

--- a/nixio/test/test_data_array.py
+++ b/nixio/test/test_data_array.py
@@ -14,7 +14,7 @@ import unittest
 import numpy as np
 
 import nixio as nix
-
+from nixio.pycore.exceptions import InvalidUnit
 
 skip_cpp = not hasattr(nix, "core")
 
@@ -98,6 +98,9 @@ class DataArrayTestBase(unittest.TestCase):
 
         self.array.unit = "mV"
         assert(self.array.unit == "mV")
+
+        self.array.unit = "0.5*ms"
+        assert(self.array.unit == "0.5*ms")
 
         self.array.unit = None
         assert(self.array.unit is None)
@@ -351,6 +354,18 @@ class DataArrayTestBase(unittest.TestCase):
                           lambda: array_2D.append_alias_range_dimension())
         assert(len(array_2D.dimensions) == 0)
         del self.block.data_arrays['array_2d']
+
+        # alias range dimension with non-SI unit
+        self.array.delete_dimensions()
+        self.array.unit = "10 * ms"
+        with self.assertRaises(ValueError):
+            self.array.append_alias_range_dimension()
+
+        self.array.delete_dimensions()
+        self.array.unit = None
+        self.array.append_alias_range_dimension()
+        with self.assertRaises(ValueError):
+            self.array.unit = "10 * ms"
 
     def test_data_array_sources(self):
         source1 = self.block.create_source("source1", "channel")

--- a/nixio/test/test_property.py
+++ b/nixio/test/test_property.py
@@ -80,6 +80,18 @@ class PropertyTestBase(unittest.TestCase):
         assert(self.prop.unit is None)
         self.prop.unit = None
 
+        # empty string units
+        self.prop.unit = ""
+        assert(self.prop.unit is None)
+        self.prop.unit = " "
+        assert(self.prop.unit is None)
+
+        # non-si units
+        self.prop.unit = "deg"
+        assert(self.prop.unit == "deg")
+        self.prop.unit = "mV/30"
+        assert(self.prop.unit == "mV/30")
+
     def test_property_values(self):
         self.prop.values = [nix.Value(10)]
 

--- a/src/PyExceptions.cpp
+++ b/src/PyExceptions.cpp
@@ -60,6 +60,10 @@ static void translateInvalidDimension(const nix::InvalidDimension &e) {
     PyErr_SetString(PyExc_ValueError, e.what());
 }
 
+static void translateInvalidUnit(const nix::InvalidUnit &e) {
+    PyErr_SetString(PyExc_ValueError, e.what());
+}
+
 static void translateInvalidRank(const nix::InvalidRank &e) {
     PyErr_SetString(PyExc_IndexError, e.what());
 }
@@ -71,6 +75,7 @@ void PyException::do_export() {
     register_exception_translator<nix::EmptyString>(&translateEmptyString);
     register_exception_translator<nix::InvalidRank>(&translateInvalidRank);
     register_exception_translator<nix::InvalidDimension>(&translateInvalidDimension);
+    register_exception_translator<nix::InvalidUnit>(&translateInvalidUnit);
     register_exception_translator<nix::IncompatibleDimensions>(&translateIncompatibleDimensions);
     register_exception_translator<nix::UnsortedTicks>(&translateUnsortedTicks);
     register_exception_translator<nix::UninitializedEntity>(&translateUninitializedEntity);


### PR DESCRIPTION
This PR:
- Allows any string to be set as a unit for Properties
- Allows any string to be set as a unit for DataArrays except when the DataArray has an AliasRangeDimension
    - Checks are performed both when setting a unit (checks for SI only if the DataArray has an AliasRangeDimension) and when adding an AliasRangeDimension (checks if the existing unit is SI)
- Sets a Property's or DataArray's unit to `None` if the unit is set to an empty string or a string that is only spaces.

Closes #278 and #269.