### PR TITLE
Read package info from json file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: python
 
 env:
     global:
-        - NIX_BRANCH=master
+        - NIX_BRANCH=1.4
 
 matrix:
     include:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ recursive-include docs *
 graft src
 include CMakeLists.txt
 recursive-include scripts *
+include nixio/info.json

--- a/nixio/info.json
+++ b/nixio/info.json
@@ -1,0 +1,10 @@
+{
+    "VERSION": "1.4.dev",
+    "STATUS": "Release",
+    "RELEASE": "1.4.dev Release",
+    "AUTHOR": "Christian Kellner, Adrian Stoewer, Andrey Sobolev, Jan Grewe, Balint Morvai, Achilleas Koutsou",
+    "COPYRIGHT": "2014, German Neuroinformatics Node, Christian Kellner, Adrian Stoewer, Andrey Sobolev, Jan Grewe, Balint Morvai, Achilleas Koutsou",
+    "CONTACT": "dev@g-node.org",
+    "BRIEF": "Python bindings for NIX",
+    "HOMEPAGE": "https://github.com/G-Node/nixpy"
+}

--- a/nixio/info.py
+++ b/nixio/info.py
@@ -5,13 +5,20 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
+import os
+import json
 
-VERSION = '1.4.dev'
-STATUS = 'Release'
-RELEASE = '%s %s' % (VERSION, STATUS)
-AUTHOR = 'Christian Kellner, Adrian Stoewer, Andrey Sobolev, Jan Grewe,\
-Balint Morvai, Achilleas Koutsou'
-COPYRIGHT = '2014, German Neuroinformatics Node, ' + AUTHOR
-CONTACT = 'dev@g-node.org'
-BRIEF = 'Python bindings for NIX'
-HOMEPAGE = 'https://github.com/G-Node/nixpy'
+here = os.path.dirname(__file__)
+
+with open(os.path.join(here, "info.json")) as infofile:
+    infodict = json.load(infofile)
+
+
+VERSION = infodict["VERSION"]
+STATUS = infodict["STATUS"]
+RELEASE = infodict["RELEASE"]
+AUTHOR = infodict["AUTHOR"]
+COPYRIGHT = infodict["COPYRIGHT"]
+CONTACT = infodict["CONTACT"]
+BRIEF = infodict["BRIEF"]
+HOMEPAGE = infodict["HOMEPAGE"]

--- a/scripts/dorelease.py
+++ b/scripts/dorelease.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import re
-from subprocess import check_output, call, CalledProcessError
+from subprocess import check_output, call, CalledProcessError, DEVNULL
 from difflib import Differ
 import requests
 import json
@@ -188,7 +188,7 @@ def update_ci_confs(newver):
 
 def tag_head(newverstr):
     try:
-        tagrev = check_output(["git", "rev-parse", newverstr])
+        tagrev = check_output(["git", "rev-parse", newverstr], stderr=DEVNULL)
         headrev = check_output(["git", "rev-parse", "HEAD"])
         if tagrev != headrev:
             die("Tag or object named {} already exists "

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,7 @@ except ImportError:
 
 import sys
 import os
-
-from nixio.info import VERSION, AUTHOR, CONTACT, BRIEF, HOMEPAGE
+import json
 
 from scripts.findboost import BoostPyLib
 from scripts.checknix import check_nix
@@ -43,6 +42,17 @@ with open('LICENSE') as f:
 
 
 is_win = os.name == 'nt'
+
+# load info from nixio/info.json
+with open(os.path.join("nixio/info.json")) as infofile:
+    infodict = json.load(infofile)
+
+VERSION = infodict["VERSION"]
+AUTHOR = infodict["AUTHOR"]
+CONTACT = infodict["CONTACT"]
+BRIEF = infodict["BRIEF"]
+HOMEPAGE = infodict["HOMEPAGE"]
+
 
 if "dev" in VERSION:
     if is_win:


### PR DESCRIPTION
In the olden days, we had the `setup.py` parse the `info.py` with regular expressions to get the info.
At some point I changed this to a simple import, that worked as long as the package was installed using `pip install [...]` but failed if it was installed using `python setup.py install` and the system was missing any of the dependencies. This is because the setup essentially depended on importing the package itself and couldn't start the install process without importing the sources.

With this PR, we change both the `setup.py` and `info.py` to read the information from a JSON file that's packaged with the source files.


<details>
 <summary>Tested working using the following Dockerfile (click to expand)</summary>

```dockerfile
FROM debian:buster-slim

RUN apt update
RUN apt install -y python python3 git
RUN apt install -y python-pip python3-pip

RUN git clone --branch=setup-info https://github.com/achilleas-k/nixpy

WORKDIR nixpy

ENV inc=1

RUN python  setup.py install
RUN python3 setup.py install

RUN python  -c "import nixio as nix; print(nix.__version__)"
RUN python3 -c "import nixio as nix; print(nix.__version__)"
```
</details>