### PR TITLE
Use isinstance() for index type checks in DataArray

### DIFF
--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -10,6 +10,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import sys
+from numbers import Integral
 
 from nixio.dimension_type import DimensionType
 
@@ -257,20 +258,18 @@ class DataSetMixin(object):
 
     @staticmethod
     def __index_to_tuple(index):
-        tidx = type(index)
-
-        if tidx == tuple:
+        if isinstance(index, tuple):
             return index
-        elif tidx == int or tidx == slice:
+        elif isinstance(index, Integral) or isinstance(index, slice):
             return (index, )
-        elif tidx == type(Ellipsis):
+        elif isinstance(index, type(Ellipsis)):
             return ()
         else:
             raise IndexError("Unsupported index")
 
     @staticmethod
     def __complete_slices(shape, index):
-        if type(index) is slice:
+        if isinstance(index, slice):
             if index.step is not None:
                 raise IndexError('Invalid index, stepping unsupported')
             start = index.start
@@ -284,7 +283,7 @@ class DataSetMixin(object):
             elif stop < 0:
                 stop = shape + stop
             index = slice(start, stop, index.step)
-        elif type(index) is int:
+        elif isinstance(index, Integral):
             if index < 0:
                 index = shape + index
                 index = slice(index, index+1)

--- a/nixio/test/test_data_array.py
+++ b/nixio/test/test_data_array.py
@@ -14,7 +14,6 @@ import unittest
 import numpy as np
 
 import nixio as nix
-from nixio.pycore.exceptions import InvalidUnit
 
 skip_cpp = not hasattr(nix, "core")
 
@@ -388,6 +387,20 @@ class DataArrayTestBase(unittest.TestCase):
         del self.array.sources[source1]
         assert(len(self.array.sources) == 0)
 
+    def test_data_array_indexing(self):
+        data = np.random.rand(50)
+        da = self.block.create_data_array("random", "DataArray",
+                                          data=data)
+
+        np.testing.assert_almost_equal(data[:], da[:])
+
+        def check_idx(idx):
+            np.testing.assert_almost_equal(da[idx], data[idx])
+
+        check_idx(10)
+        check_idx(Ellipsis)
+        check_idx(slice(10, 15))
+
 
 @unittest.skipIf(skip_cpp, "HDF5 backend not available.")
 class TestDataArrayCPP(DataArrayTestBase):
@@ -398,3 +411,16 @@ class TestDataArrayCPP(DataArrayTestBase):
 class TestDataArrayPy(DataArrayTestBase):
 
     backend = "h5py"
+
+    def test_data_array_numpy_indexing(self):
+        data = np.random.rand(50)
+        da = self.block.create_data_array("random", "DataArray",
+                                          data=data)
+
+        def check_idx(idx):
+            np.testing.assert_almost_equal(da[idx], data[idx])
+
+        check_idx(np.int8(10))
+        check_idx(np.int16(20))
+        check_idx(np.int32(42))
+        check_idx(np.int64(9))


### PR DESCRIPTION
Numerical types are checked against the numbers.Integral abstract base class, which should match any integer type (including NumPy types).

NumPy types are only currently supported with the h5py backend, so we only test those in the Python version.