### PR TITLE
Fix for data indexing and slicing

### DIFF
--- a/nixio/pycore/h5dataset.py
+++ b/nixio/pycore/h5dataset.py
@@ -50,11 +50,10 @@ class H5DataSet(object):
                 return data
             datashape = data.shape
             sl = util.co_to_slice(count, offset)
-            if (isinstance(sl, tuple) and
-                    np.ndim(data) != len(sl) and
-                    count[-1] == 1):
-                    # data needs an extra dimension of size 1 to match slice
-                    data.resize(datashape + (1,))
+            if isinstance(sl, tuple) and np.ndim(data) < len(sl):
+                # data shape needs dimension padding to match dataset
+                # diimensionality
+                data.resize(count)
             self.dataset.read_direct(data, sl)
             # if data was resized, it should be returned to its original shape
             data.resize(datashape)

--- a/nixio/pycore/h5dataset.py
+++ b/nixio/pycore/h5dataset.py
@@ -52,7 +52,7 @@ class H5DataSet(object):
             sl = util.co_to_slice(count, offset)
             if isinstance(sl, tuple) and np.ndim(data) < len(sl):
                 # data shape needs dimension padding to match dataset
-                # diimensionality
+                # dimensionality
                 data.resize(count)
             self.dataset.read_direct(data, sl)
             # if data was resized, it should be returned to its original shape

--- a/nixio/test/test_data_array.py
+++ b/nixio/test/test_data_array.py
@@ -401,6 +401,29 @@ class DataArrayTestBase(unittest.TestCase):
         check_idx(Ellipsis)
         check_idx(slice(10, 15))
 
+    def test_data_array_multi_slicing(self):
+        shape = (5, 10, 15, 20)
+        da = self.block.create_data_array(
+            'test', 'test',
+            data=np.random.randint(65000, size=shape)
+        )
+        self.assertEqual(da[0, 0, 0, 0].shape, ())
+        self.assertEqual(da[0, 0, 0, :].shape, (20,))
+        self.assertEqual(da[0, 0, :, 0].shape, (15,))
+        self.assertEqual(da[0, 0, :, :].shape, (15, 20))
+        self.assertEqual(da[0, :, 0, 0].shape, (10,))
+        self.assertEqual(da[0, :, 0, :].shape, (10, 20))
+        self.assertEqual(da[0, :, :, 0].shape, (10, 15))
+        self.assertEqual(da[0, :, :, :].shape, (10, 15, 20))
+        self.assertEqual(da[:, 0, 0, 0].shape, (5,))
+        self.assertEqual(da[:, 0, 0, :].shape, (5, 20))
+        self.assertEqual(da[:, 0, :, 0].shape, (5, 15))
+        self.assertEqual(da[:, 0, :, :].shape, (5, 15, 20))
+        self.assertEqual(da[:, :, 0, 0].shape, (5, 10))
+        self.assertEqual(da[:, :, 0, :].shape, (5, 10, 20))
+        self.assertEqual(da[:, :, :, 0].shape, (5, 10, 15))
+        self.assertEqual(da[:, :, :, :].shape, shape)
+
 
 @unittest.skipIf(skip_cpp, "HDF5 backend not available.")
 class TestDataArrayCPP(DataArrayTestBase):


### PR DESCRIPTION
A relatively simple fix for the multidimension indexing/slicing issue (see #296).

The problem was in the dimensionality "fixing" that I had written for the cases where the number of dimensions to be returned were fewer than the number of dimensions of the underlying data. The old fix relied on padding dimensions and made incorrect assumptions about why the data dimensions didn't match.

Now we use the count tuple to set the shape of the data, since count always matches the shape of the data to be read. The returned data is then reshaped prior to returning from the function to fit the requested data shape.

I added a test, copied from @adityachivu's example in the issue.