### PR TITLE
Data compression

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include LICENSE README.rst Win32.md
+include LICENSE README.rst
 recursive-include docs *
 graft src
 include CMakeLists.txt

--- a/nixio/__init__.py
+++ b/nixio/__init__.py
@@ -19,6 +19,7 @@ from nixio.pycore.file import File, FileMode
 from nixio.value import Value, DataType
 from nixio.dimension_type import DimensionType
 from nixio.link_type import LinkType
+from nixio.compression import Compression
 
 from nixio.section import S
 

--- a/nixio/block.py
+++ b/nixio/block.py
@@ -8,13 +8,13 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-import nixio.util.find as finders
-from nixio.util.proxy_list import ProxyList
+from .util import find as finders
+from .util.proxy_list import ProxyList
 import numpy as np
 
 try:
     from sys import maxint
-except:
+except ImportError:
     from sys import maxsize as maxint
 
 

--- a/nixio/block.py
+++ b/nixio/block.py
@@ -10,6 +10,7 @@ from __future__ import (absolute_import, division, print_function)
 
 from .util import find as finders
 from .util.proxy_list import ProxyList
+from .compression import Compression
 import numpy as np
 
 try:
@@ -64,8 +65,8 @@ class GroupProxyList(ProxyList):
 
 class BlockMixin(object):
 
-    def create_data_array(self, name, array_type,
-                          dtype=None, shape=None, data=None):
+    def create_data_array(self, name, array_type, dtype=None, shape=None,
+                          data=None, compression=Compression.Auto):
         """
         Create a new data array for this block. Either ``shape``
         or ``data`` must be given. If both are given their shape must agree.
@@ -82,6 +83,8 @@ class BlockMixin(object):
         :type shape: tuple of int or long
         :param data: Data to write after storage has been created
         :type data: array-like data
+        :param compression: En-/disable dataset compression.
+        :type compression: :class:`~nixio.Compression`
 
         :returns: The newly created data array.
         :rtype: :class:`~nixio.DataArray`
@@ -101,7 +104,8 @@ class BlockMixin(object):
                     raise ValueError("Shape must equal data.shape")
             else:
                 shape = data.shape
-        da = self._create_data_array(name, array_type, dtype, shape)
+        da = self._create_data_array(name, array_type, dtype, shape,
+                                     compression)
         if data is not None:
             da.write_direct(data)
         return da

--- a/nixio/compression.py
+++ b/nixio/compression.py
@@ -1,0 +1,5 @@
+# TODO: Convert to enum
+class Compression(object):
+    No = "None"
+    DeflateNormal = "DeflateNormal"
+    Auto = "Auto"

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -13,7 +13,7 @@ from nixio.util.proxy_list import ProxyList
 
 try:
     from sys import maxint
-except:
+except ImportError:
     from sys import maxsize as maxint
 
 

--- a/nixio/pycore/block.py
+++ b/nixio/pycore/block.py
@@ -37,7 +37,7 @@ class Block(EntityWithMetadata, BlockMixin):
         if name in data_arrays:
             raise exceptions.DuplicateName("create_data_array")
         da = DataArray._create_new(self, data_arrays, name, type_,
-                                   data_type, shape)
+                                   data_type, shape, compression)
         return da
 
     def _get_data_array_by_id(self, id_or_name):

--- a/nixio/pycore/block.py
+++ b/nixio/pycore/block.py
@@ -31,7 +31,7 @@ class Block(EntityWithMetadata, BlockMixin):
         return newentity
 
     # DataArray
-    def _create_data_array(self, name, type_, data_type, shape):
+    def _create_data_array(self, name, type_, data_type, shape, compression):
         util.check_entity_name_and_type(name, type_)
         data_arrays = self._h5group.open_group("data_arrays")
         if name in data_arrays:

--- a/nixio/pycore/block.py
+++ b/nixio/pycore/block.py
@@ -16,18 +16,21 @@ from .multi_tag import MultiTag
 from .tag import Tag
 from .source import Source
 from . import util
+from ..compression import Compression
 
 
 class Block(EntityWithMetadata, BlockMixin):
 
-    def __init__(self, nixparent, h5group):
+    def __init__(self, nixparent, h5group, compression=Compression.Auto):
         super(Block, self).__init__(nixparent, h5group)
+        self._compr = compression
         # TODO: Validation for containers
 
     @classmethod
-    def _create_new(cls, nixparent, h5parent, name, type_):
+    def _create_new(cls, nixparent, h5parent, name, type_, compression):
         newentity = super(Block, cls)._create_new(nixparent, h5parent,
                                                   name, type_)
+        newentity._compr = compression
         return newentity
 
     # DataArray
@@ -36,6 +39,8 @@ class Block(EntityWithMetadata, BlockMixin):
         data_arrays = self._h5group.open_group("data_arrays")
         if name in data_arrays:
             raise exceptions.DuplicateName("create_data_array")
+        if compression == Compression.Auto:
+            compression = self._compr
         da = DataArray._create_new(self, data_arrays, name, type_,
                                    data_type, shape, compression)
         return da

--- a/nixio/pycore/data_array.py
+++ b/nixio/pycore/data_array.py
@@ -10,6 +10,7 @@ from numbers import Number
 from .entity_with_sources import EntityWithSources
 from ..data_array import DataArrayMixin, DataSetMixin
 from ..value import DataType
+from ..compression import Compression
 from .dimensions import (SampledDimension, RangeDimension, SetDimension,
                          DimensionType)
 from . import util
@@ -63,10 +64,12 @@ class DataArray(EntityWithSources, DataSet, DataArrayMixin):
         super(DataArray, self).__init__(nixparent, h5group)
 
     @classmethod
-    def _create_new(cls, nixparent, h5parent, name, type_, data_type, shape):
+    def _create_new(cls, nixparent, h5parent, name, type_, data_type, shape,
+                    compression):
         newentity = super(DataArray, cls)._create_new(nixparent, h5parent,
                                                       name, type_)
-        newentity._h5group.create_dataset("data", shape, data_type)
+        newentity._h5group.create_dataset("data", shape, data_type,
+                                          compression)
         return newentity
 
     def _read_data(self, data, count, offset):

--- a/nixio/pycore/h5dataset.py
+++ b/nixio/pycore/h5dataset.py
@@ -15,7 +15,8 @@ from . import util
 
 class H5DataSet(object):
 
-    def __init__(self, parent, name, dtype=None, shape=None):
+    def __init__(self, parent, name, dtype=None, shape=None,
+                 compression=False):
         self._parent = parent
         self.name = name
         if (dtype is None) or (shape is None):
@@ -24,10 +25,13 @@ class H5DataSet(object):
             maxshape = (None,) * len(shape)
             if dtype == DataType.String:
                 dtype = util.vlen_str_dtype
-            self.dataset = self._parent.require_dataset(name, shape=shape,
-                                                        dtype=dtype,
-                                                        chunks=True,
-                                                        maxshape=maxshape)
+            comprargs = dict()
+            if compression:
+                comprargs = {"compression": "gzip", "compression_opts": 6}
+            self.dataset = self._parent.require_dataset(
+                name, shape=shape, dtype=dtype, chunks=True, maxshape=maxshape,
+                **comprargs
+            )
 
     @classmethod
     def create_from_h5obj(cls, h5obj):

--- a/nixio/pycore/h5group.py
+++ b/nixio/pycore/h5group.py
@@ -70,7 +70,7 @@ class H5Group(object):
         self._create_h5obj()
         return H5Group(self.group, name, create)
 
-    def create_dataset(self, name, shape, dtype):
+    def create_dataset(self, name, shape, dtype, compression=False):
         """
         Creates a dataset object under the current group with a given name,
         shape, and type.
@@ -78,10 +78,11 @@ class H5Group(object):
         :param name: the name of the dataset
         :param shape: tuple representing the shape of the dataset
         :param dtype: the type of the data for this dataset (DataType)
+        :param compression: whether to compress the data (default: False)
         :return: a new H5DataSet object
         """
         self._create_h5obj()
-        return H5DataSet(self.group, name, dtype, shape)
+        return H5DataSet(self.group, name, dtype, shape, compression)
 
     def get_dataset(self, name):
         """
@@ -99,15 +100,16 @@ class H5Group(object):
         else:
             raise notfound
 
-    def write_data(self, name, data, dtype=None):
+    def write_data(self, name, data, dtype=None, compression=False):
         """
         Writes the data to a Dataset contained in the group with the
-        given name.  Creates the Dataset if necessary.
+        given name. Creates the Dataset if necessary.
 
         :param name: name of the Dataset object
         :param data: the data to write
         :param dtype: optionally specify the data type, otherwise it will be
         automatically determined by the data
+        :param compression: whether to compress the data (default: False)
         """
         shape = np.shape(data)
         if self.has_data(name):
@@ -116,7 +118,7 @@ class H5Group(object):
         else:
             if dtype is None:
                 dtype = DataType.get_dtype(data[0])
-            dset = self.create_dataset(name, shape, dtype)
+            dset = self.create_dataset(name, shape, dtype, compression)
 
         dset.write_data(data)
 

--- a/src/PyBlock.cpp
+++ b/src/PyBlock.cpp
@@ -40,8 +40,9 @@ boost::optional<DataArray> getDataArrayByPos(const Block& block, size_t index) {
 }
 
 DataArray createDataArray(Block& block, const std::string &name, const std::string &type,
-                          DataType data_type, const NDSize &shape) {
-    return block.createDataArray(name, type, data_type, shape);
+                          DataType data_type, const NDSize &shape,
+                          const std::string &compression) {
+    return block.createDataArray(name, type, data_type, shape, pyCompressionToNix(compression));
 }
 
 // getter for MultiTag

--- a/src/PyFile.cpp
+++ b/src/PyFile.cpp
@@ -23,11 +23,7 @@ using namespace boost::python;
 namespace nixpy {
 
 
-//File open(std::string path, FileMode mode = FileMode::ReadWrite) {
-//    return File::open(path, mode);
-//}
-
-File open(std::string path, std::string mode = "a") {
+File open(std::string path, std::string mode = "a", std::string compression = "Auto") {
     FileMode nixmode;
     if (mode == "a") {
         nixmode = FileMode::ReadWrite;
@@ -38,10 +34,10 @@ File open(std::string path, std::string mode = "a") {
     } else {
         // TODO: Raise error
     }
-    return File::open(path, nixmode);
+    return File::open(path, nixmode, "hdf5", pyCompressionToNix(compression));
 }
 
-BOOST_PYTHON_FUNCTION_OVERLOADS(open_overloads, open, 1, 2)
+BOOST_PYTHON_FUNCTION_OVERLOADS(open_overloads, open, 1, 3)
 
 // getter for Block
 

--- a/src/transmorgify.hpp
+++ b/src/transmorgify.hpp
@@ -190,6 +190,20 @@ struct ndsize_transmogrify {
     }
 };
 
+// One-way converter function from Python Compression enum to nix::Compression
+// No magic
+
+static nix::Compression pyCompressionToNix(const std::string &compression)
+{
+    if (compression == "Auto")
+        return nix::Compression::Auto;
+    if (compression == "DeflateNormal")
+        return nix::Compression::DeflateNormal;
+    if (compression == "None")
+        return nix::Compression::None;
+    throw std::runtime_error("Invalid string for Compression.");
+};
+
 }
 
 #endif // NIXPY_TRANSMORGIFY_H


### PR DESCRIPTION
This PR adds compression support for data.

Counterpart to G-Node/nix#695.

Some notes:
- I created a Compression class to work as a "fake enum". It's just a static class with the three members as strings. I did this for consistency with the other enums like LinkType and DataType and because it's simpler for passing them into the bindings as strings. I'm planning on turning these into proper enums at some point (when the bindings are removed at the latest).
    - I didn't bother to make a proper "converter" for the enum in the bindings. There's just a function (defined in transmorgify.hpp) that does a one-way conversion from the Python string to the appropriate nix::Compression enum value.
- I followed the way the global option works in NIX: If a file is opened with compression on and the data array is created without specifying, it defaults to on. The compression option is only saved in the file (and block) attribute for the lifetime of the file object (it's not stored anywhere).
- I didn't include any tests but I wrote a pair of little scripts: a python script for creating files and a bash script that runs through and checks the resulting files with h5ls. Check them out [here](https://gist.github.com/achilleas-k/23b1ec83a10950f2454dc16297c9d638).


Closes #277 