### PR TITLE
Catch out of bounds indexing errors in datasets

### DIFF
--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -128,6 +128,9 @@ class DataSetMixin(object):
             return np.array(self)
         # if we got to here we have a tuple with len >= 1
         count, offset, shape = self.__tuple_to_count_offset_shape(index)
+        if any(o+c > s for o, c, s in zip(offset, count, self.shape)):
+            raise IndexError("index is out of bounds")
+
         raw = np.empty(shape, dtype=self.dtype)
 
         if hasattr(self, "polynom_coefficients") and self.polynom_coefficients:

--- a/nixio/test/test_data_array.py
+++ b/nixio/test/test_data_array.py
@@ -424,6 +424,17 @@ class DataArrayTestBase(unittest.TestCase):
         self.assertEqual(da[:, :, :, 0].shape, (5, 10, 15))
         self.assertEqual(da[:, :, :, :].shape, shape)
 
+    def test_outofbounds_indexing(self):
+        # test out of bounds IndexError exception
+        oobtestda = self.block.create_data_array("oobdatatest",
+                                                 "data", data=[1, 2, 10])
+        with self.assertRaises(IndexError):
+            oobtestda[3]
+        with self.assertRaises(IndexError):
+            oobtestda[10]
+        with self.assertRaises(IndexError):
+            oobtestda[1:4]
+
 
 @unittest.skipIf(skip_cpp, "HDF5 backend not available.")
 class TestDataArrayCPP(DataArrayTestBase):


### PR DESCRIPTION
`DataSet.__getitem__` checks if the indexes or slices are out of bounds before calling the `read_data()` methods, in order to throw a more useful error message.

Fixes #299.