### PR TITLE
Slice data by index or dimensional data

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ environment:
   matrix:
     # Python 2.7 32 bit
     - PYTHON: "C:\\Python27"
+      pyver: 2
       bits: 32
       withnix: "--without-nix"
     # - PYTHON: "C:\\Python27"
@@ -21,6 +22,7 @@ environment:
 
     # Python 3.6 32 bit
     - PYTHON: "C:\\Python36"
+      pyver: 3
       bits: 32
       withnix: "--without-nix"
     # - PYTHON: "C:\\Python36"
@@ -29,6 +31,7 @@ environment:
 
     # Python 2.7 64 bit
     - PYTHON: "C:\\Python27-x64"
+      pyver: 2
       bits: 64
       withnix: "--without-nix"
     # - PYTHON: "C:\\Python27-x64"
@@ -37,6 +40,7 @@ environment:
 
     # Python 3.6 64 bit
     - PYTHON: "C:\\Python36-x64"
+      pyver: 3
       bits: 64
       withnix: "--without-nix"
       RDP: "no"
@@ -64,6 +68,10 @@ install:
             $env:vcvars = "x86"
             $env:avjob = "job=Environment%3A%20PLATFORM%3Dx86%2C%20CONFIGURATION%3DRelease"
             $env:avfname = "nix-$env:NIX_VERSION-win32.exe"
+        }
+    - ps: |
+        if ($env:pyver -eq "2") {
+            python -m pip install enum34
         }
 
     - ps: |

--- a/nixio/__init__.py
+++ b/nixio/__init__.py
@@ -20,6 +20,7 @@ from nixio.value import Value, DataType
 from nixio.dimension_type import DimensionType
 from nixio.link_type import LinkType
 from nixio.compression import Compression
+from nixio.pycore.data_array import DataSliceMode
 
 from nixio.section import S
 

--- a/nixio/pycore/data_array.py
+++ b/nixio/pycore/data_array.py
@@ -252,9 +252,7 @@ class DataArray(EntityWithSources, DataSet, DataArrayMixin):
                                  len(extents), datadim
                              ))
         if mode == DataSliceMode.Index:
-            data = np.empty(extents)
-            self._read_data(data, extents, positions)
-            return data
+            return DataView(self, extents, positions)
         elif mode == DataSliceMode.Data:
             return self._get_slice_bydim(positions, extents)
         else:
@@ -272,6 +270,4 @@ class DataArray(EntityWithSources, DataSet, DataArrayMixin):
             elif dim.dimension_type == DimensionType.Set:
                 dpos.append(int(pos))
                 dext.append(int(ext))
-        data = np.empty(dext)
-        self._read_data(data, dext, dpos)
-        return data
+        return DataView(self, dext, dpos)

--- a/nixio/pycore/data_array.py
+++ b/nixio/pycore/data_array.py
@@ -10,7 +10,9 @@ import numpy as np
 from enum import Enum
 
 from .entity_with_sources import EntityWithSources
-from ..data_array import DataArrayMixin, DataSetMixin
+from ..data_array import DataArrayMixin
+from .data_view import DataView
+from .data_set import DataSet
 from ..value import DataType
 from .dimensions import (SampledDimension, RangeDimension, SetDimension,
                          DimensionType)
@@ -22,46 +24,6 @@ from .exceptions import InvalidUnit
 class DataSliceMode(Enum):
     Index = 1
     Data = 2
-
-
-class DataSet(DataSetMixin):
-
-    def _write_data(self, data, count, offset):
-        dataset = self._h5group.get_dataset("data")
-        dataset.write_data(data, count, offset)
-
-    def _read_data(self, data, count, offset):
-        dataset = self._h5group.get_dataset("data")
-        dataset.read_data(data, count, offset)
-
-    @property
-    def data_extent(self):
-        """
-        The size of the data.
-
-        :type: set of int
-        """
-        dataset = self._h5group.get_dataset("data")
-        return dataset.shape
-
-    @data_extent.setter
-    def data_extent(self, extent):
-        dataset = self._h5group.get_dataset("data")
-        dataset.shape = extent
-
-    @property
-    def data_type(self):
-        """
-        The data type of the data stored in the DataArray. This is a read only
-        property.
-
-        :type: DataType
-        """
-        return self._get_dtype()
-
-    def _get_dtype(self):
-        dataset = self._h5group.get_dataset("data")
-        return dataset.dtype
 
 
 class DataArray(EntityWithSources, DataSet, DataArrayMixin):

--- a/nixio/pycore/data_set.py
+++ b/nixio/pycore/data_set.py
@@ -1,0 +1,41 @@
+from ..data_array import DataSetMixin
+
+
+class DataSet(DataSetMixin):
+
+    def _write_data(self, data, count, offset):
+        dataset = self._h5group.get_dataset("data")
+        dataset.write_data(data, count, offset)
+
+    def _read_data(self, data, count, offset):
+        dataset = self._h5group.get_dataset("data")
+        dataset.read_data(data, count, offset)
+
+    @property
+    def data_extent(self):
+        """
+        The size of the data.
+
+        :type: set of int
+        """
+        dataset = self._h5group.get_dataset("data")
+        return dataset.shape
+
+    @data_extent.setter
+    def data_extent(self, extent):
+        dataset = self._h5group.get_dataset("data")
+        dataset.shape = extent
+
+    @property
+    def data_type(self):
+        """
+        The data type of the data stored in the DataArray. This is a read only
+        property.
+
+        :type: DataType
+        """
+        return self._get_dtype()
+
+    def _get_dtype(self):
+        dataset = self._h5group.get_dataset("data")
+        return dataset.dtype

--- a/nixio/pycore/data_view.py
+++ b/nixio/pycore/data_view.py
@@ -7,7 +7,7 @@
 # LICENSE file in the root of the Project.
 import numpy as np
 
-from .data_array import DataSet
+from .data_set import DataSet
 from .exceptions import OutOfBounds
 
 

--- a/nixio/pycore/dimensions.py
+++ b/nixio/pycore/dimensions.py
@@ -90,7 +90,7 @@ class SampledDimension(Dimension):
         index = round((position - offset) / sample)
         if index < 0:
             raise IndexError("Position is out of bounds of this dimension!")
-        return index
+        return int(index)
 
     def axis(self, count, start=0):
         """
@@ -242,7 +242,7 @@ class RangeDimension(Dimension):
 
         ticks = np.array(ticks)
         pidxs = np.flatnonzero((ticks - position) >= 0)
-        return pidxs[0]
+        return int(pidxs[0])
 
     def tick_at(self, index):
         """

--- a/nixio/test/test_data_array.py
+++ b/nixio/test/test_data_array.py
@@ -458,3 +458,42 @@ class TestDataArrayPy(DataArrayTestBase):
         check_idx(np.int16(20))
         check_idx(np.int32(42))
         check_idx(np.int64(9))
+
+    def test_get_slice(self):
+        data2d = np.random.random((100, 2))
+        da2d = self.block.create_data_array("get_slice 2d", "Data",
+                                            data=data2d)
+        da2d.append_range_dimension(np.linspace(10, 19.8, 50))
+        da2d.append_set_dimension()
+        data = da2d[10:30, 1:2]
+        islice = da2d.get_slice((10, 1), (20, 1),
+                                mode=nix.DataSliceMode.Index)
+        np.testing.assert_almost_equal(data, islice)
+        dslice = da2d.get_slice((12.0, 1), (4.0, 1),
+                                mode=nix.DataSliceMode.Data)
+        np.testing.assert_almost_equal(data, dslice)
+
+        data3d = np.random.random((30, 30, 5))
+        da3d = self.block.create_data_array("get_slice 3d", "Data",
+                                            data=data3d)
+        sd = da3d.append_sampled_dimension(0.1)
+        sd.offset = 0.5
+        da3d.append_sampled_dimension(2.0)
+        da3d.append_set_dimension()
+
+        data = data3d[5:15, 20:25, 3:5]
+        islice = da3d.get_slice((5, 20, 3), (10, 5, 2),
+                                mode=nix.DataSliceMode.Index)
+        np.testing.assert_almost_equal(data, islice)
+        dslice = da3d.get_slice((1.0, 40.0, 3), (1.0, 10.0, 2),
+                                mode=nix.DataSliceMode.Data)
+        np.testing.assert_almost_equal(data, dslice)
+
+        with self.assertRaises(IndexError):
+            da2d.get_slice((0, 0, 0), (10, 10, 10))
+
+        with self.assertRaises(IndexError):
+            da2d.get_slice((0, 0), (10,))
+
+        with self.assertRaises(IndexError):
+            da3d.get_slice((0, 0, 0), (3, 9, 40, 1))

--- a/setup.py
+++ b/setup.py
@@ -206,7 +206,7 @@ setup(
     tests_require=['pytest'],
     test_suite='pytest',
     setup_requires=['pytest-runner'],
-    install_requires=['numpy', 'h5py'],
+    install_requires=['numpy', 'h5py', 'enum34;python_version<"3.4"'],
     package_data={'nixio': [license_text, description_text]},
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
This PR brings the ability to retrieve a data slice from a DataArray based on either indexes (like regular slicing) or based on the dimensional data of the array. The method is currently called `get_slice()` but I'm open to suggestions for renaming it. I'd also rename the accompanying enum, `DataSliceMode`, to match whatever we end up calling the method, if we do rename it.

There's a small test that's based on [my comment](https://github.com/G-Node/nixpy/issues/298#issuecomment-397801984) from the issue where we talked about this feature. Have a look at that and let me know if I missed anything.

Also, as discussed, the method returns a DataView. This required splitting out the definition of the DataSet from the data_array file.

A small fix is also included in this PR: The dimension.index_of() methods would return floats sometimes. They now both return integers explicitly.

Closes #298 