### PR TITLE
Remove C++ (HDF5 backend) tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,6 @@ install:
 script:
   - if [[ "${coveralls}" == 1 ]]; then
       coverage run --source=nixio setup.py test --addopts "--force-compat -s" && coverage report -m;
-    elif [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
-      python${pymajor} setup.py test --addopts "-k 'not test_nix_compatibility'";
     else
       python${pymajor} setup.py test --addopts "--force-compat -s";
     fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ image: Visual Studio 2017
 
 environment:
 
-  NIX_VERSION: 1.5.0
+  NIX_VERSION: 1.4.1
   DEPLOY_DIR: deploy
   NIX_DIR: C:\nix
   NIX_INCDIR: C:\nix\include

--- a/nixio/test/test_block.py
+++ b/nixio/test/test_block.py
@@ -14,10 +14,7 @@ import unittest
 import nixio as nix
 
 
-skip_cpp = not hasattr(nix, "core")
-
-
-class BlockTestBase(unittest.TestCase):
+class TestBlock(unittest.TestCase):
 
     backend = None
     testfilename = "blocktest.h5"
@@ -192,14 +189,3 @@ class BlockTestBase(unittest.TestCase):
         del self.block.groups[0]
 
         assert(len(self.block.groups) == 0)
-
-
-@unittest.skipIf(skip_cpp, "HDF5 backend not available.")
-class TestBlockCPP(BlockTestBase):
-
-    backend = "hdf5"
-
-
-class TestBlockPy(BlockTestBase):
-
-    backend = "h5py"

--- a/nixio/test/test_data_array.py
+++ b/nixio/test/test_data_array.py
@@ -15,16 +15,13 @@ import numpy as np
 
 import nixio as nix
 
-skip_cpp = not hasattr(nix, "core")
-
-
 try:
     basestring = basestring
 except NameError:  # 'basestring' is undefined, must be Python 3
     basestring = (str, bytes)
 
 
-class DataArrayTestBase(unittest.TestCase):
+class TestDataArray(unittest.TestCase):
 
     backend = None
     testfilename = "dataarraytest.h5"
@@ -434,17 +431,6 @@ class DataArrayTestBase(unittest.TestCase):
             oobtestda[10]
         with self.assertRaises(IndexError):
             oobtestda[1:4]
-
-
-@unittest.skipIf(skip_cpp, "HDF5 backend not available.")
-class TestDataArrayCPP(DataArrayTestBase):
-
-    backend = "hdf5"
-
-
-class TestDataArrayPy(DataArrayTestBase):
-
-    backend = "h5py"
 
     def test_data_array_numpy_indexing(self):
         data = np.random.rand(50)

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -15,15 +15,13 @@ import numpy as np
 import nixio as nix
 
 
-skip_cpp = not hasattr(nix, "core")
-
 test_range = tuple([float(i) for i in range(10)])
 test_sampl = 0.1
 test_label = "test label"
 test_labels = tuple([str(i) + "_label" for i in range(10)])
 
 
-class DimensionTestBase(unittest.TestCase):
+class TestDimension(unittest.TestCase):
 
     backend = None
     testfilename = "dimtest.h5"
@@ -139,14 +137,3 @@ class DimensionTestBase(unittest.TestCase):
         assert(da.dimensions[0].label == da.label)
         assert(da.dimensions[0].unit == da.unit)
         assert(np.all(da.dimensions[0].ticks == da[:]))
-
-
-@unittest.skipIf(skip_cpp, "HDF5 backend not available.")
-class TestDimensionsCPP(DimensionTestBase):
-
-    backend = "hdf5"
-
-
-class TestDimensionsPy(DimensionTestBase):
-
-    backend = "h5py"

--- a/nixio/test/test_feature.py
+++ b/nixio/test/test_feature.py
@@ -14,10 +14,7 @@ import unittest
 import nixio as nix
 
 
-skip_cpp = not hasattr(nix, "core")
-
-
-class FeatureTestBase(unittest.TestCase):
+class TestFeatures(unittest.TestCase):
 
     backend = None
     testfilename = "featuretest.h5"
@@ -79,14 +76,3 @@ class FeatureTestBase(unittest.TestCase):
                                                     nix.DataType.Float, (0, ))
         self.feature_1.data = new_data_ref
         assert(self.feature_1.data == new_data_ref)
-
-
-@unittest.skipIf(skip_cpp, "HDF5 backend not available.")
-class TestFeatureCPP(FeatureTestBase):
-
-    backend = "hdf5"
-
-
-class TestFeaturePy(FeatureTestBase):
-
-    backend = "h5py"

--- a/nixio/test/test_file.py
+++ b/nixio/test/test_file.py
@@ -18,10 +18,7 @@ import nixio.pycore.file as filepy
 from nixio.pycore.exceptions.exceptions import InvalidFile
 
 
-skip_cpp = not hasattr(nix, "core")
-
-
-class FileTestBase(unittest.TestCase):
+class TestFile(unittest.TestCase):
 
     backend = None
     testfilename = "filetest.h5"
@@ -135,18 +132,7 @@ class FileTestBase(unittest.TestCase):
             self.assertEqual(danames[idx], datablock.data_arrays[idx].name)
 
 
-@unittest.skipIf(skip_cpp, "HDF5 backend not available.")
-class TestFileCPP(FileTestBase):
-
-    backend = "hdf5"
-
-
-class TestFilePy(FileTestBase):
-
-    backend = "h5py"
-
-
-class TestFileVerPy(unittest.TestCase):
+class TestFileVer(unittest.TestCase):
 
     backend = "h5py"
     testfilename = "versiontest.h5"

--- a/nixio/test/test_group.py
+++ b/nixio/test/test_group.py
@@ -13,10 +13,7 @@ import unittest
 import nixio as nix
 
 
-skip_cpp = not hasattr(nix, "core")
-
-
-class GroupTestBase(unittest.TestCase):
+class TestGroups(unittest.TestCase):
 
     backend = None
     testfilename = "grouptest.h5"
@@ -202,14 +199,3 @@ class GroupTestBase(unittest.TestCase):
         self.assertRaises(RuntimeError, newgroup.tags.append, tg)
 
         del self.file.blocks[newblock.id]
-
-
-@unittest.skipIf(skip_cpp, "HDF5 backend not available.")
-class TestGroupCPP(GroupTestBase):
-
-    backend = "hdf5"
-
-
-class TestGroupPy(GroupTestBase):
-
-    backend = "h5py"

--- a/nixio/test/test_multi_tag.py
+++ b/nixio/test/test_multi_tag.py
@@ -15,10 +15,7 @@ import numpy as np
 import nixio as nix
 
 
-skip_cpp = not hasattr(nix, "core")
-
-
-class MultiTagTestBase(unittest.TestCase):
+class TestMultiTags(unittest.TestCase):
 
     backend = None
 
@@ -441,14 +438,3 @@ class MultiTagTestBase(unittest.TestCase):
             self.feature_tag.retrieve_feature_data(2, 1)
 
         self.assertRaises(IndexError,  out_of_bounds)
-
-
-@unittest.skipIf(skip_cpp, "HDF5 backend not available.")
-class TestMultiTagCPP(MultiTagTestBase):
-
-    backend = "hdf5"
-
-
-class TestMultiTagPy(MultiTagTestBase):
-
-    backend = "h5py"

--- a/nixio/test/test_property.py
+++ b/nixio/test/test_property.py
@@ -14,10 +14,7 @@ import unittest
 import nixio as nix
 
 
-skip_cpp = not hasattr(nix, "core")
-
-
-class PropertyTestBase(unittest.TestCase):
+class TestProperties(unittest.TestCase):
 
     backend = None
     testfilename = "proptest.h5"
@@ -207,14 +204,3 @@ class TestValue(unittest.TestCase):
 
         value.uncertainty = 0.5
         assert(value.uncertainty == 0.5)
-
-
-@unittest.skipIf(skip_cpp, "HDF5 backend not available.")
-class TestPropertyCPP(PropertyTestBase):
-
-    backend = "hdf5"
-
-
-class TestPropertyPy(PropertyTestBase):
-
-    backend = "h5py"

--- a/nixio/test/test_proxy_list.py
+++ b/nixio/test/test_proxy_list.py
@@ -19,9 +19,6 @@ except NameError:  # 'basestring' is undefined, must be Python 3
     basestring = (str, bytes)
 
 
-skip_cpp = not hasattr(nix, "core")
-
-
 class WithIdMock(object):
 
     def __init__(self, id):
@@ -62,7 +59,6 @@ class WithListMock(object):
         return self.__list
 
 
-@unittest.skipIf(skip_cpp, "HDF5 backend not available.")
 class TestProxyList(unittest.TestCase):
 
     def setUp(self):

--- a/nixio/test/test_section.py
+++ b/nixio/test/test_section.py
@@ -14,10 +14,7 @@ import unittest
 import nixio as nix
 
 
-skip_cpp = not hasattr(nix, "core")
-
-
-class SectionTestBase(unittest.TestCase):
+class TestSections(unittest.TestCase):
 
     backend = None
     testfilename = "sectiontest.h5"
@@ -246,14 +243,3 @@ class SectionTestBase(unittest.TestCase):
         self.assertEqual(len(self.other.referring_sources), 1)
         self.assertEqual(len(self.section.referring_sources), 0)
         self.assertEqual(self.other.referring_sources[0].id, src.id)
-
-
-@unittest.skipIf(skip_cpp, "HDF5 backend not available.")
-class TestSectionCPP(SectionTestBase):
-
-    backend = "hdf5"
-
-
-class TestSectionPy(SectionTestBase):
-
-    backend = "h5py"

--- a/nixio/test/test_source.py
+++ b/nixio/test/test_source.py
@@ -14,10 +14,7 @@ import unittest
 import nixio as nix
 
 
-skip_cpp = not hasattr(nix, "core")
-
-
-class SourceTestBase(unittest.TestCase):
+class TestSources(unittest.TestCase):
 
     backend = None
     testfilename = "sourcetest.h5"
@@ -150,14 +147,3 @@ class SourceTestBase(unittest.TestCase):
         self.assertEqual(len(self.source.referring_multi_tags), 1)
         self.assertEqual(len(self.other.referring_multi_tags), 0)
         self.assertEqual(self.source.referring_multi_tags[0].id, mtag.id)
-
-
-@unittest.skipIf(skip_cpp, "HDF5 backend not available.")
-class TestSourceCPP(SourceTestBase):
-
-    backend = "hdf5"
-
-
-class TestSourcePy(SourceTestBase):
-
-    backend = "h5py"

--- a/nixio/test/test_tag.py
+++ b/nixio/test/test_tag.py
@@ -14,10 +14,7 @@ import numpy as np
 import nixio as nix
 
 
-skip_cpp = not hasattr(nix, "core")
-
-
-class TagTestBase(unittest.TestCase):
+class TestTags(unittest.TestCase):
 
     backend = None
     testfilename = "tagtest.h5"
@@ -271,14 +268,3 @@ class TagTestBase(unittest.TestCase):
 
         assert(data1.size == 1)
         assert(data2.size == 2)
-
-
-@unittest.skipIf(skip_cpp, "HDF5 backend not available.")
-class TestTagCPP(TagTestBase):
-
-    backend = "hdf5"
-
-
-class TestTagPy(TagTestBase):
-
-    backend = "h5py"

--- a/nixio/test/xcompat/writefullfile.cpp
+++ b/nixio/test/xcompat/writefullfile.cpp
@@ -39,7 +39,7 @@ int main(int argc, char* argv[]) {
     block.forceCreatedAt(1500003000);
 
     int idx = 0;
-    char name [6];
+    char name [7];
     nix::Group group;
     for (auto bl : nf.blocks()) {
         sprintf(name, "grp%02d0", idx);


### PR DESCRIPTION
Another small round of test cleanup. I've removed the C++ test subclasses that would test the bindings, since they're no longer valid in this branch.

I'm also re-enabling the macOS NIX compatibility tests since we've found the issue. They should pass as soon as the NIX fix is merged.