### PR TITLE
Open files using context manager

### DIFF
--- a/nixio/file.py
+++ b/nixio/file.py
@@ -37,6 +37,12 @@ class SectionProxyList(ProxyList):
 
 class FileMixin(object):
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
     @property
     def blocks(self):
         """

--- a/nixio/test/test_file.py
+++ b/nixio/test/test_file.py
@@ -132,6 +132,16 @@ class FileTestBase(unittest.TestCase):
         for idx in range(len(datablock.data_arrays)):
             self.assertEqual(danames[idx], datablock.data_arrays[idx].name)
 
+    def test_context_open(self):
+        fname = "contextopen.nix"
+        with nix.File.open(fname, nix.FileMode.Overwrite,
+                           backend=self.backend) as nf:
+            nf.create_block("blocky", "test-block")
+
+        with nix.File.open(fname, nix.FileMode.ReadOnly,
+                           backend=self.backend) as nf:
+            self.assertEqual(nf.blocks[0].name, "blocky")
+
 
 @unittest.skipIf(skip_cpp, "HDF5 backend not available.")
 class TestFileCPP(FileTestBase):


### PR DESCRIPTION
Files can now be opened using the `with` statement for context management.

Closes #310.