### PR TITLE
Delete all references when deleting objects from primary Container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ install:
 
 script:
   - if [[ "${coveralls}" == 1 ]]; then
-      coverage run --source=nixio setup.py test --addopts "--force-compat -s -nauto" && coverage report -m;
+      coverage run --source=nixio setup.py test --addopts "--force-compat -s" && coverage report -m;
     else
       python${pymajor} setup.py test --addopts "--force-compat -s -nauto";
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,3 +67,6 @@ script:
     else
       python${pymajor} setup.py test --addopts "--force-compat -s -nauto";
     fi
+
+after_success:
+  - if [[ "${coveralls}" == 1 ]]; then coveralls; fi

--- a/nixio/block.py
+++ b/nixio/block.py
@@ -284,7 +284,6 @@ class Block(Entity):
     @property
     def metadata(self):
         """
-
         Associated metadata of the entity. Sections attached to the entity via
         this attribute can provide additional annotations. This is an optional
         read-write property, and can be None if no metadata is available.

--- a/nixio/block.py
+++ b/nixio/block.py
@@ -24,7 +24,7 @@ from .multi_tag import MultiTag
 from .tag import Tag
 from .source import Source
 from . import util
-from .container import Container
+from .container import Container, SourceContainer
 from .section import Section
 
 
@@ -212,7 +212,7 @@ class Block(Entity):
         This is a read only attribute.
         """
         if self._sources is None:
-            self._sources = Container("sources", self, Source)
+            self._sources = SourceContainer("sources", self, Source)
         return self._sources
 
     @property

--- a/nixio/container.py
+++ b/nixio/container.py
@@ -101,7 +101,7 @@ class Container(object):
 class SectionContainer(Container):
     """
     SectionContainer extends Container with a new __delitem__ method.
-    When a Section is deleted, all child sources need to be deleted
+    When a Section is deleted, all child sections need to be deleted
     individually to make sure all their references are removed.
     """
     def __delitem__(self, item):

--- a/nixio/container.py
+++ b/nixio/container.py
@@ -154,10 +154,19 @@ class LinkContainer(Container):
 
     def __contains__(self, item):
         # need to redefine because of id indexing/linking
-        if isinstance(item, self._itemclass):
-            return item.id in self._backend
+        if hasattr(item, "id"):
+            if isinstance(item, self._itemclass):
+                return item.id in self._backend
+            # looks like a NIX object, but wrong type
+            raise TypeError(
+                "Wrong item type: {} required or the name or ID of one".format(
+                    self._itemclass.__name__)
+            )
+
         if util.is_uuid(item):
             return item in self._backend
+
+        # assume it's a name and scan through LinkContainer
         for grp in self._backend:
             if item == grp.get_attr("name"):
                 return True

--- a/nixio/container.py
+++ b/nixio/container.py
@@ -47,7 +47,16 @@ class Container(object):
         if not isinstance(item, Entity):
             item = self[item]
 
-        self._parent._h5group.delete_all(item.id)
+        if not isinstance(item, self._itemclass):
+            raise TypeError(
+                "Wrong item type: {} required or the name or ID of one".format(
+                    self._itemclass.__name__)
+            )
+
+        root = self._backend.h5root
+        if not root:
+            root = self._parent._h5group
+        root.delete_all([item.id])
 
     def __iter__(self):
         for group in self._backend:
@@ -89,6 +98,55 @@ class Container(object):
             yield item.id, item
 
 
+class SectionContainer(Container):
+    """
+    SectionContainer extends Container with a new __delitem__ method.
+    When a Section is deleted, all child sources need to be deleted
+    individually to make sure all their references are removed.
+    """
+    def __delitem__(self, item):
+        if not isinstance(item, Entity):
+            item = self[item]
+
+        if not isinstance(item, self._itemclass):
+            raise TypeError(
+                "Wrong item type: {} required or the name or ID of one".format(
+                    self._itemclass.__name__)
+            )
+
+        # collect all IDs under item and send them for deletion, starting from
+        # the root block
+        secids = [s.id for s in item.find_sections()]
+
+        root = self._backend.file
+        root.delete_all(secids)
+
+
+class SourceContainer(Container):
+    """
+    SourceContainer extends Container with a new __delitem__ method.
+    When a Source is deleted, all child sources need to be deleted individually
+    to make sure all their references are removed.
+    """
+    def __delitem__(self, item):
+        if not isinstance(item, Entity):
+            item = self[item]
+
+        if not isinstance(item, self._itemclass):
+            raise TypeError(
+                "Wrong item type: {} required or the name or ID of one".format(
+                    self._itemclass.__name__)
+            )
+
+        # collect all IDs under item and send them for deletion, starting from
+        # the root block
+        srcids = [s.id for s in item.find_sources()]
+        srcids.append(item.id)
+
+        root = self._backend.h5root
+        root.delete_all(srcids)
+
+
 class LinkContainer(Container):
     """
     A LinkContainer acts as an interface to container groups in the backend
@@ -122,6 +180,13 @@ class LinkContainer(Container):
     def __delitem__(self, item):
         if not isinstance(item, Entity):
             item = self[item]
+
+        if not isinstance(item, self._itemclass):
+            raise TypeError(
+                "Wrong item type: {} required or the name or ID of one".format(
+                    self._itemclass.__name__)
+            )
+
         self._backend.delete(item.id)
 
     def append(self, item):

--- a/nixio/container.py
+++ b/nixio/container.py
@@ -54,8 +54,14 @@ class Container(object):
             yield self._inst_item(group)
 
     def __contains__(self, item):
-        if isinstance(item, self._itemclass):
-            return item.name in self._backend
+        if hasattr(item, "id"):
+            if isinstance(item, self._itemclass):
+                return item.name in self._backend
+            # looks like a NIX object, but wrong type
+            raise TypeError(
+                "Wrong item type: {} required or the name or ID of one".format(
+                    self._itemclass.__name__)
+            )
         if util.is_uuid(item):
             try:
                 self._backend.get_by_id(item)

--- a/nixio/feature.py
+++ b/nixio/feature.py
@@ -37,6 +37,8 @@ class Feature(Entity):
 
     @property
     def data(self):
+        if "data" not in self._h5group:
+            raise RuntimeError("Feature.data: DataArray not found!")
         return DataArray(self._parent._parent,
                          self._h5group.open_group("data"))
 

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -20,7 +20,7 @@ import h5py
 from .hdf5.h5group import H5Group
 from .block import Block
 from .section import Section
-from .container import Container
+from .container import Container, SectionContainer
 from .exceptions import exceptions
 from . import util
 from .util import find as finders
@@ -358,7 +358,7 @@ class File(object):
         This is a read-only property.
         """
         if self._sections is None:
-            self._sections = Container("metadata", self, Section)
+            self._sections = SectionContainer("metadata", self, Section)
         return self._sections
 
 

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -300,8 +300,8 @@ class File(object):
         :type name: str
         :param type_: The type of the section.
         :type type_: str
-        :param oid: object id, UUID string as specified in RFC 4122. If no id is provided,
-                   an id will be generated and assigned.
+        :param oid: object id, UUID string as specified in RFC 4122. If no id
+                    is provided, an id will be generated and assigned.
         :type oid: str
 
         :returns: The newly created section.

--- a/nixio/hdf5/h5dataset.py
+++ b/nixio/hdf5/h5dataset.py
@@ -29,6 +29,7 @@ class H5DataSet(object):
                 name, shape=shape, dtype=dtype, chunks=True, maxshape=maxshape,
                 **comprargs
             )
+        self.h5obj = self.dataset
 
     @classmethod
     def create_from_h5obj(cls, h5obj):

--- a/nixio/hdf5/h5group.py
+++ b/nixio/hdf5/h5group.py
@@ -234,21 +234,19 @@ class H5Group(object):
         # visit_items visits each item only once, so instead of checking
         # whether each item is the one we're searching for, we check whether
         # it *contains* the one we're searching for
+        # We delete the child as soon as we find it; this doesn't cause
+        # iteration issues since it's deleted before descending into the
+        # children of the current group
 
-        parentgroups = dict()
-
-        def collect_id_parents(name, obj):
+        def delete_by_id(name, obj):
             if not isinstance(obj, h5py.Group):
                 return
             grp = self.create_from_h5obj(obj)
             for ch in grp:
                 if ch.get_attr("entity_id") == eid:
-                    parentgroups[grp] = ch.name
-                    break
+                    del grp[ch.name]
 
-        self._group.visititems(collect_id_parents)
-        for pg, chname in parentgroups.items():
-            del pg[chname]
+        self._group.visititems(delete_by_id)
 
     def set_attr(self, name, value):
         self._create_h5obj()

--- a/nixio/hdf5/h5group.py
+++ b/nixio/hdf5/h5group.py
@@ -239,17 +239,15 @@ class H5Group(object):
         return attr
 
     def find_children(self, filtr=None, limit=None):
-
         result = []
-        start_depth = len(self.group.name.split("/"))
 
         def match(name, obj):
-            curdepth = name.split("/")
-            if limit is not None and curdepth == start_depth + limit:
+            curdepth = len(name.split("/"))
+            if limit is not None and curdepth > limit:
                 return None
 
             h5grp = H5Group.create_from_h5obj(obj)
-            if filtr(h5grp):
+            if filtr is None or filtr(h5grp):
                 result.append(h5grp)
 
         self.group.visititems(match)

--- a/nixio/hdf5/h5group.py
+++ b/nixio/hdf5/h5group.py
@@ -227,8 +227,8 @@ class H5Group(object):
 
     def delete_all(self, eid):
         """
-        Deletes all references to a given object, identified by the entity_id,
-        below the current object.
+        Deletes all references to a given list of objects, identified by their
+        entity_id, below the current object.
         """
         # Use visit_items to traverse groups and check their children.
         # visit_items visits each item only once, so instead of checking
@@ -243,7 +243,7 @@ class H5Group(object):
                 return
             grp = self.create_from_h5obj(obj)
             for ch in grp:
-                if ch.get_attr("entity_id") == eid:
+                if ch.get_attr("entity_id") in eid:
                     del grp[ch.name]
 
         self._group.visititems(delete_by_id)
@@ -326,6 +326,7 @@ class H5Group(object):
             cls = Section
         else:
             raise InvalidEntity
+        # TODO: Fix this
         return cls(h5root)
 
     @property

--- a/nixio/hdf5/h5group.py
+++ b/nixio/hdf5/h5group.py
@@ -207,6 +207,9 @@ class H5Group(object):
         return self.get_by_name(name)
 
     def delete(self, id_or_name):
+        """
+        Deletes the child HDF5 group that matches the given name or id.
+        """
         if util.is_uuid(id_or_name):
             name = self.get_by_id_or_name(id_or_name).name
         else:
@@ -221,6 +224,25 @@ class H5Group(object):
             del self.parent.group[self.name]
             # del self.group
             self.group = None
+
+    def delete_all(self, eid):
+        """
+        Deletes all references to a given object, identified by the entity_id,
+        below the current object.
+        """
+        # Manually traverse tree and check entity_id
+        # H5Py visit and visit_items only visit each item once, so they wont
+        # find all links to the same object. This function checks if each group
+        # object with a matching entity_id. We can't use the name because the
+        # name of the object in the path depends on what kind of link it is.
+        for grp in self:
+            if not isinstance(grp, type(self)):
+                continue
+            if grp.get_attr("entity_id") == eid:
+                del self._group[grp.name]
+                return
+            else:
+                grp.delete_all(eid)
 
     def set_attr(self, name, value):
         self._create_h5obj()

--- a/nixio/hdf5/h5group.py
+++ b/nixio/hdf5/h5group.py
@@ -27,6 +27,7 @@ class H5Group(object):
         self.group = None
         if create or name in self._parent:
             self._create_h5obj()
+        self.h5obj = self.group
 
     def _create_h5obj(self):
         if self.name in self._parent:

--- a/nixio/multi_tag.py
+++ b/nixio/multi_tag.py
@@ -40,6 +40,8 @@ class MultiTag(BaseTag):
 
         :type: DataArray
         """
+        if "positions" not in self._h5group:
+            raise RuntimeError("MultiTag.positions: DataArray not found!")
         return DataArray(self._parent, self._h5group.open_group("positions"))
 
     @positions.setter

--- a/nixio/section.py
+++ b/nixio/section.py
@@ -13,7 +13,7 @@ except ImportError:
 from collections import Sequence, Iterable
 from six import string_types
 
-from .container import Container
+from .container import Container, SectionContainer
 from .datatype import DataType
 from .entity import Entity
 from .property import Property
@@ -360,7 +360,7 @@ class Section(Entity):
         :type: Container of Section
         """
         if self._sections is None:
-            self._sections = Container("sections", self, Section)
+            self._sections = SectionContainer("sections", self, Section)
         return self._sections
 
     def __eq__(self, other):

--- a/nixio/section.py
+++ b/nixio/section.py
@@ -184,7 +184,7 @@ class Section(Entity):
         properties = self._h5group.open_group("properties")
         inhprops = [Property(self, h5prop) for h5prop in properties]
         if self.link:
-            inhprops.append(self.link.inherited_properties())
+            inhprops.extend(self.link.inherited_properties())
         return inhprops
 
     @property

--- a/nixio/source.py
+++ b/nixio/source.py
@@ -10,7 +10,7 @@ from sys import maxsize as maxint
 
 from .import exceptions
 from .entity import Entity
-from .container import Container
+from .container import SourceContainer
 from . import util
 from .util import find as finders
 from .section import Section
@@ -99,7 +99,7 @@ class Source(Entity):
         This is a read only attribute.
         """
         if self._sources is None:
-            self._sources = Container("sources", self, Source)
+            self._sources = SourceContainer("sources", self, Source)
         return self._sources
 
     def __eq__(self, other):

--- a/nixio/source.py
+++ b/nixio/source.py
@@ -95,7 +95,7 @@ class Source(Entity):
         """
         A property containing child sources of a Source. Sources can be
         obtained via their name, index, id. Sources can be deleted from the
-        list.  Adding sources is done using the Blocks create_source method.
+        list. Adding sources is done using the Blocks create_source method.
         This is a read only attribute.
         """
         if self._sources is None:

--- a/nixio/test/test_container.py
+++ b/nixio/test/test_container.py
@@ -84,3 +84,103 @@ class TestContainer(unittest.TestCase):
         self.assertEqual(self.group.data_arrays[0]._parent, self.block)
         self.assertEqual(self.group.tags[0]._parent, self.block)
         self.assertEqual(self.group.multi_tags[0]._parent, self.block)
+
+    def test_bad_appends(self):
+        # use fresh file for this one
+        filename = os.path.join(self.tmpdir.path, "badappend.nix")
+        nf = nix.File.open(filename, nix.FileMode.Overwrite)
+
+        for blockname in ["a", "b"]:
+            block = nf.create_block(blockname, "block")
+
+            for groupname in ["a", "b"]:
+                group = block.create_group(blockname + groupname, "group")
+                for daname in ["a", "b"]:
+                    da = block.create_data_array(
+                        blockname + groupname + daname, "data", data=[0]
+                    )
+                    group.data_arrays.append(da)
+                    tag = block.create_tag(
+                        blockname + groupname + daname, "tag", position=[0]
+                    )
+                    group.tags.append(tag)
+
+        # check counts
+        self.assertEqual(len(nf.blocks), 2)
+        for bl in nf.blocks:
+            self.assertEqual(len(bl.groups), 2)
+            self.assertEqual(len(bl.data_arrays), 4)
+            self.assertEqual(len(bl.tags), 4)
+            for g in bl.groups:
+                self.assertEqual(len(g.data_arrays), 2)
+                self.assertEqual(len(g.tags), 2)
+
+        # cross-block append
+        with self.assertRaises(RuntimeError):
+            nf.blocks[0].groups[0].data_arrays.append(
+                nf.blocks[1].data_arrays[1]
+            )
+
+        # another
+        with self.assertRaises(RuntimeError):
+            nf.blocks[1].groups[0].tags.append(
+                nf.blocks[0].tags[1]
+            )
+
+        # append data array to group.tags
+        with self.assertRaises(TypeError):
+            nf.blocks[0].groups[0].tags.append(
+                nf.blocks[0].data_arrays[2]
+            )
+
+        # cross-block *and* incorrect type
+        with self.assertRaises(TypeError):
+            nf.blocks[0].groups[0].tags.append(
+                nf.blocks[1].data_arrays[2]
+            )
+
+        # let's do sources
+        for bl in nf.blocks:
+            for sourcename in ["a", "b"]:
+                src = bl.create_source(bl.name + sourcename, "source")
+                for chsourcename in ["a", "b", "c"]:
+                    src.create_source(bl.name + sourcename + chsourcename,
+                                      "source")
+
+        # check counts
+        for bl in nf.blocks:
+            self.assertEqual(len(bl.sources), 2)
+            for src in bl.sources:
+                self.assertEqual(len(src.sources), 3)
+
+        # cross-block source append
+        with self.assertRaises(RuntimeError):
+            nf.blocks[1].groups[0].sources.append(
+                nf.blocks[0].sources[1]
+            )
+
+        # cross-block source append (deep)
+        with self.assertRaises(RuntimeError):
+            nf.blocks[1].groups[0].sources.append(
+                nf.blocks[0].sources[1].sources[2]
+            )
+
+        # valid deep append
+        nf.blocks[0].groups[0].data_arrays[1].sources.append(
+            nf.blocks[0].sources[1].sources[2]
+        )
+
+        # bad membership test
+        with self.assertRaises(TypeError):
+            nf.blocks[1].data_arrays[1] in nf.blocks[0].tags
+
+        # another
+        with self.assertRaises(TypeError):
+            nf.blocks[1].data_arrays[1] in nf.blocks[0].groups[0]
+
+        # bad membership test on LinkContainer
+        with self.assertRaises(TypeError):
+            nf.blocks[1].data_arrays[1] in nf.blocks[0].groups[0].tags
+
+    def test_dangling_references(self):
+        pass

--- a/nixio/test/test_container.py
+++ b/nixio/test/test_container.py
@@ -183,4 +183,15 @@ class TestContainer(unittest.TestCase):
             nf.blocks[1].data_arrays[1] in nf.blocks[0].groups[0].tags
 
     def test_dangling_references(self):
-        pass
+        # delete data array from block and check group
+        daname = self.block.data_arrays[0].name
+        self.assertIn(self.block.data_arrays[0],
+                      self.block.groups[0].data_arrays)
+        self.assertIn(daname, self.block.groups[0].data_arrays)
+
+        self.assertEqual(self.block.groups[0].data_arrays[0].name,
+                         daname)
+
+        del self.block.data_arrays[daname]
+        self.assertNotIn(daname, self.block.data_arrays)
+        self.assertNotIn(daname, self.block.groups[0].data_arrays)

--- a/nixio/test/test_container.py
+++ b/nixio/test/test_container.py
@@ -433,3 +433,41 @@ class TestContainer(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             tag.features[dataname].data
+
+    def test_delete_links_section_link(self):
+        parsec = self.file.create_section("TopDog", "Root Section")
+        chsec = parsec.create_section("1Dog", "Level 1 section")
+        chchsec = chsec.create_section("2Dog", "Level 2 section")
+        chchchsec = chchsec.create_section("3Dog", "Level 3 section")
+
+        chchsec.create_property("2Prop", "Level 2 property")
+        chchchsec.create_property("3Prop", "Level 3 property")
+
+        chsecb = parsec.create_section("1Dog2", "Level 1 section")
+
+        # link chchchsec to chsecb and then delete it
+        chsecb.link = chchchsec
+
+        inhpropnames = [p.name for p in chsecb.inherited_properties()]
+        self.assertEqual(chchchsec, chsecb.link)
+        self.assertIn("3Prop", inhpropnames)
+
+        # delete chchchsec and check link and inherited props
+        del chchsec.sections["3Dog"]
+        inhpropnames = [p.name for p in chsecb.inherited_properties()]
+        self.assertIs(None, chsecb.link)
+        self.assertNotIn("3Prop", inhpropnames)
+
+        # link chchsec to chsecb then delete chsec (chchsec's parent)
+        chsecb.link = chchsec
+
+        inhpropnames = [p.name for p in chsecb.inherited_properties()]
+        self.assertEqual(chchsec, chsecb.link)
+        self.assertIn("2Prop", inhpropnames)
+
+        # delete chsec and check link and inherited props
+        del parsec.sections["1Dog"]
+        inhpropnames = [p.name for p in chsecb.inherited_properties()]
+        self.assertIs(None, chsecb.link)
+        self.assertNotIn("2Prop", inhpropnames)
+

--- a/nixio/test/test_container.py
+++ b/nixio/test/test_container.py
@@ -208,8 +208,7 @@ class TestContainer(unittest.TestCase):
                       self.block.groups[-1].tags)
         self.assertIn(tagname, self.block.groups[0].tags)
 
-        self.assertEqual(self.block.groups[-1].tags[-1].name,
-                         tagname)
+        self.assertEqual(self.block.groups[-1].tags[-1].name, tagname)
 
         del self.block.tags[tagname]
         self.assertNotIn(tagname, self.block.tags)
@@ -400,3 +399,37 @@ class TestContainer(unittest.TestCase):
         self.tag.metadata = sectionc
         del grandparentc.sections[parentc.name]
         self.assertIsNone(self.tag.metadata)
+
+    def test_delete_links_tag_features(self):
+        posname = "new-mt-positions"
+        pos = self.block.create_data_array(posname, "to-be-deleted", data=[0])
+
+        tagname = "new-tag"
+        tag = self.block.create_tag(tagname, "to-be-deleted",
+                                    position=[1, 3, 10])
+        self.block.groups[0].tags.append(tag)
+
+        mtagname = "new-multi-tag"
+        mtag = self.block.create_multi_tag(mtagname, "to-be-deleted",
+                                           positions=pos)
+        self.block.groups[0].multi_tags.append(mtag)
+
+        dataname = "new-da-feat-a"
+        feat_da = self.block.create_data_array(dataname, "to-be-deleted",
+                                               data=[10])
+
+
+        feat = tag.create_feature(feat_da, nix.LinkType.Indexed)
+
+        self.assertIn(dataname, self.block.data_arrays)
+        self.assertIn(dataname, tag.features)
+
+        del self.block.data_arrays[dataname]
+
+        self.assertNotIn(dataname, self.block.data_arrays)
+
+        with self.assertRaises(RuntimeError):
+            self.assertNotIn(dataname, tag.features)
+
+        with self.assertRaises(RuntimeError):
+            tag.features[dataname].data

--- a/nixio/test/test_file.py
+++ b/nixio/test/test_file.py
@@ -128,7 +128,7 @@ class TestFile(unittest.TestCase):
             self.assertEqual(danames[idx], datablock.data_arrays[idx].name)
 
     def test_context_open(self):
-        fname = "contextopen.nix"
+        fname = os.path.join(self.tmpdir.path, "contextopen.nix")
         with nix.File.open(fname, nix.FileMode.Overwrite) as nf:
             nf.create_block("blocky", "test-block")
 

--- a/nixio/test/test_section.py
+++ b/nixio/test/test_section.py
@@ -269,3 +269,23 @@ class TestSections(unittest.TestCase):
         self.assertEqual(len(self.other.referring_sources), 1)
         self.assertEqual(len(self.section.referring_sources), 0)
         self.assertEqual(self.other.referring_sources[0].id, src.id)
+
+
+    def test_section_link(self):
+        self.section.create_property("PropOnSection", "value")
+
+        self.assertIn("PropOnSection", self.section)
+        self.assertEqual("value", self.section["PropOnSection"])
+
+        self.assertNotIn("PropOnSection", self.other)
+        with self.assertRaises(KeyError):
+            self.other["PropOnSection"]
+
+        self.other.link = self.section
+
+        self.assertNotIn("PropOnSection", self.other)
+        with self.assertRaises(KeyError):
+            self.other["PropOnSection"]
+
+        inhpropnames = [p.name for p in self.other.inherited_properties()]
+        self.assertIn("PropOnSection", inhpropnames)


### PR DESCRIPTION
When objects can be referenced from multiple locations (e.g., a LinkContainer in a Group, a Source in a data object's `sources`, an object's `metadata`, etc), removing them requires scanning through the tree for references to the same object and deleting them. This PR adds a `delete_all` method to the `H5Group` backend class and uses it through the `__delitem__` methods in the Container class and its derivatives. The `delete_all` method scans through the HDF5 file and removes all groups which match a given set of entity IDs.

The `__delitem__` methods have slight variations depending on the type of Container:
- In the base **Container** class, it simply scans the object tree, starting from the parent Block, and deletes all references to the object being deleted.
- In the **SourceContainer** class, it uses `find_sources` to collect the IDs of all children of the Source that's being deleted, and sends those IDs to the `delete_all` method in the backend, starting from the parent Block.
- Similarly, in the **SectionContainer** class, it uses `find_sections` to collect the IDs of all children of the Section that's being deleted, and sends those IDs to the `delete_all` method in the backend, starting from the File root.

_Tests with all the weird cases are included_