### PR TITLE
Bugfix: Set dimension.index properly on __init__

### DIFF
--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -28,7 +28,7 @@ class DimensionContainer(Container):
             DimensionType.Sample: SampledDimension,
             DimensionType.Set: SetDimension,
         }[item.get_attr("dimension_type")]
-        idx = item.get_attr("index")
+        idx = item.name
         return cls(item, idx)
 
 
@@ -36,7 +36,7 @@ class Dimension(object):
 
     def __init__(self, h5group, index):
         self._h5group = h5group
-        self.dim_index = index
+        self.dim_index = int(index)
 
     @classmethod
     def _create_new(cls, parent, index):
@@ -58,11 +58,6 @@ class Dimension(object):
     @property
     def index(self):
         return self.dim_index
-
-    @index.setter
-    def index(self, idx):
-        util.check_attr_type(idx, int)
-        self.dim_index = idx
 
 
 class SampledDimension(Dimension):

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -42,6 +42,7 @@ class TestDimension(unittest.TestCase):
     def test_set_dimension(self):
         assert(self.set_dim.index == 1)
         assert(self.set_dim.dimension_type == nix.DimensionType.Set)
+        assert(self.array.dimensions[0].index == 1)
 
         assert(self.set_dim.labels == ())
         self.set_dim.labels = test_labels
@@ -50,6 +51,7 @@ class TestDimension(unittest.TestCase):
     def test_sample_dimension(self):
         assert(self.sample_dim.index == 2)
         assert(self.sample_dim.dimension_type == nix.DimensionType.Sample)
+        assert(self.array.dimensions[1].index == 2)
 
         assert(self.sample_dim.label is None)
         self.sample_dim.label = test_label
@@ -89,6 +91,7 @@ class TestDimension(unittest.TestCase):
     def test_range_dimension(self):
         assert(self.range_dim.index == 3)
         assert(self.range_dim.dimension_type == nix.DimensionType.Range)
+        assert(self.array.dimensions[2].index == 3)
 
         assert(self.range_dim.label is None)
         self.range_dim.label = test_label


### PR DESCRIPTION
DimensionContainer failed to set the dimension properly when
initialising a Dimension that was being loaded from the file. It was
looking for an "index" attribute and was returning None. Should be using
the name of the HDF5 Group object.

Added tests to catch regressions.

Wrapping index in int() when returning and when setting the object
attribute to catch unwanted behaviour.