### PR TITLE
Default Section type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
     - python: "3.7"
       os: linux
       env: pymajor=3 coveralls=1
+      dist: xenial
+      sudo: true
     - language: generic
       os: osx
       env: pymajor=2
@@ -34,7 +36,8 @@ addons:
       - libboost-all-dev
 
 before_install:
-  - export NIX_INCDIR=${nixprefix}/include
+  - nixprefix="/usr/local"
+  - export NIX_INCDIR=${nixprefix}/include/nixio-1.0
   - export NIX_LIBDIR=${nixprefix}/lib
   - export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${nixprefix}/lib/pkgconfig
   - if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
@@ -50,8 +53,7 @@ before_install:
   - pushd /tmp/libnix
   - mkdir build
   - pushd build
-  - nixprefix="/usr/local"
-  - cmake -DCMAKE_INSTALL_PREFIX=/usr/local ..
+  - cmake -DCMAKE_INSTALL_PREFIX=${nixprefix} ..
   - make
   - sudo make install
   - popd

--- a/nixio/section.py
+++ b/nixio/section.py
@@ -61,7 +61,7 @@ class Section(Entity):
         return newentity
 
     # Section
-    def create_section(self, name, type_, oid=None):
+    def create_section(self, name, type_="undefined", oid=None):
         """
         Creates a new subsection that is a child of this section entity.
 

--- a/nixio/test/xcompat/compile.py
+++ b/nixio/test/xcompat/compile.py
@@ -28,21 +28,18 @@ def cc(filenames, dest,
     compiler = ccompiler.new_compiler()
 
     distutils.sysconfig.customize_compiler(compiler)
-    if library_dirs:
-        [compiler.add_library_dir(libd) for libd in library_dirs]
-    if include_dirs:
-        [compiler.add_include_dir(incd) for incd in include_dirs]
-    if libraries:
-        [compiler.add_library(lib) for lib in libraries]
-    if runtime_lib_dirs and not WINDOWS:
-        [compiler.add_runtime_library_dir(rund) for rund in runtime_lib_dirs]
+    compiler.set_library_dirs(library_dirs)
+    compiler.set_include_dirs(include_dirs)
+    compiler.set_libraries(libraries)
+    compiler.set_runtime_library_dirs(runtime_lib_dirs)
 
     try:
-        for srcname in filenames:
-            execname, ext = os.path.splitext(srcname)
+        objnames = compiler.compile(filenames, output_dir=dest,
+                                    extra_postargs=compile_args)
+        for obj in objnames:
+            execname, ext = os.path.splitext(obj)
             compiler.link_executable(
-                [srcname], execname, output_dir=dest,
-                extra_postargs=compile_args,
+                [obj], execname, output_dir=dest,
                 target_lang="c++",
             )
     except (CompileError, LinkError):
@@ -54,7 +51,7 @@ def maketests(dest):
     scriptloc, _ = os.path.split(os.path.abspath(__file__))
     os.chdir(scriptloc)
     filenames = glob("*.cpp")
-    nix_inc_dir = os.getenv('NIX_INCDIR', '/usr/local/include')
+    nix_inc_dir = os.getenv('NIX_INCDIR', '/usr/local/include/nixio-1.0')
     nix_lib_dir = os.getenv('NIX_LIBDIR', '/usr/local/lib')
 
     boost_inc_dir = os.getenv('BOOST_INCDIR', '/usr/local/include')

--- a/scripts/dorelease.py
+++ b/scripts/dorelease.py
@@ -244,11 +244,9 @@ def main():
     chdir()
 
     if len(sys.argv) < 2:
-        die("Specify version (X.Y.Z)")
+        die("Specify version")
 
     newverstr = sys.argv[1]
-    parse_version_string(newverstr)
-
     prepline = "Preparing new release: {}".format(newverstr)
     banner = "="*len(prepline) + "\n" + prepline + "\n" + "="*len(prepline)
     banner = bold_begin + banner + bold_end


### PR DESCRIPTION
Allow Sections to be created without specifying a `type` property. This will give the Section the default type string `"undefined"`, which is the same behaviour as in odML.

Additional changes are for compiling and running crosscompatibility tests with C++ NIX.