### PR TITLE
Fix for retrieve_data when MultiTag positions array is 1D

### DIFF
--- a/nixio/multi_tag.py
+++ b/nixio/multi_tag.py
@@ -138,7 +138,10 @@ class MultiTag(BaseTag):
                 ext_size[1] > len(data.dimensions)):
             raise incdim_exception
 
-        dimpos = positions[index, 0:len(data.dimensions)]
+        if len(pos_size) == 1:
+            dimpos = positions[0:len(data.dimensions)]
+        else:
+            dimpos = positions[index, 0:len(data.dimensions)]
         units = self.units
         starts, stops = list(), list()
         for idx in range(dimpos.size):

--- a/nixio/test/test_multi_tag.py
+++ b/nixio/test/test_multi_tag.py
@@ -337,6 +337,25 @@ class TestMultiTags(unittest.TestCase):
         assert(len(segdata.shape) == 3)
         assert(segdata.shape == (1, 4, 1))
 
+        # retrieve all positions for all references
+        for ridx, ref in enumerate(mtag.references):
+            for pidx, p in enumerate(mtag.positions):
+                mtag.retrieve_data(pidx, ridx)
+
+    def test_multi_tag_retrieve_data_1d(self):
+        # MultiTags to vectors behave a bit differently
+        # Testing separately
+        oneddata = self.block.create_data_array("1dda", "data",
+                                                data=list(range(100)))
+        oneddata.append_sampled_dimension(0.1)
+        onedpos = self.block.create_data_array("1dpos", "positions",
+                                               data=[1, 9, 34])
+        onedmtag = self.block.create_multi_tag("2dmt", "mtag",
+                                               positions=onedpos)
+        onedmtag.references.append(oneddata)
+        for pidx, p in enumerate(onedmtag.positions):
+            onedmtag.retrieve_data(pidx, 0)
+
     def test_multi_tag_feature_data(self):
         index_data = self.block.create_data_array("indexed feature data",
                                                   "test",


### PR DESCRIPTION
1D position arrays are handled as a special case. This used to work
before because the DataArray would allow indexing with more indexes than
the length of the array itself. The new DataArray indexing function
doesn't allow this and tries to follow numpy array indexing rules.

Test added to catch regression.