### PR TITLE
tiny fixes to SampledDimenision util functions

### DIFF
--- a/nixio/pycore/dimensions.py
+++ b/nixio/pycore/dimensions.py
@@ -87,7 +87,7 @@ class SampledDimension(Dimension):
         """
         offset = self.offset if self.offset else 0
         sample = self.sampling_interval
-        index = round((position - offset) / sample)
+        index = int(round((position - offset) / sample))
         if index < 0:
             raise IndexError("Position is out of bounds of this dimension!")
         return index

--- a/nixio/pycore/dimensions.py
+++ b/nixio/pycore/dimensions.py
@@ -103,10 +103,11 @@ class SampledDimension(Dimension):
         :returns: The created axis
         :rtype: list
         """
-        offset = self.offset if self.offset else 0
+        offset = self.offset if self.offset else 0.0
         sample = self.sampling_interval
-        end = (count + start) * sample + offset
-        return tuple(np.arange(offset, end, sample))
+        start_val = start * sample + offset
+        end_val = (start + count) * sample + offset
+        return tuple(np.arange(start_val, end_val, sample))
 
     @property
     def label(self):

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -83,6 +83,7 @@ class DimensionTestBase(unittest.TestCase):
 
         assert(self.sample_dim.index_of(3.14) == 0)
         assert(self.sample_dim.index_of(23.) == 10)
+        assert(type(self.sample_dim.index_of(23.) == int))
 
         assert(self.sample_dim.position_at(0) == 3.)
         assert(self.sample_dim.position_at(200) == 200*2.+3.)

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -92,6 +92,10 @@ class DimensionTestBase(unittest.TestCase):
         assert(self.sample_dim.axis(10)[0] == 3.)
         assert(self.sample_dim.axis(10)[-1] == 9*2.+3.)
 
+        assert(len(self.sample_dim.axis(10, 2)) == 10)
+        assert(self.sample_dim.axis(10, 2)[0] == 2 * 2. + 3.)
+        assert(self.sample_dim.axis(10, 2)[-1] == (9 + 2) * 2. + 3.)
+
     def test_range_dimension(self):
         assert(self.range_dim.index == 3)
         assert(self.range_dim.dimension_type == nix.DimensionType.Range)


### PR DESCRIPTION
* fix axis function to work properly if count and start index are given
* ensure that index_of returns an int. previously this ``` array[dim.index_of(1.0) : dim.index_of(2.0)]``` did not work without  casting to int