### PR TITLE
[dev] SampledDimension.axis bug fix

### DIFF
--- a/nixio/container.py
+++ b/nixio/container.py
@@ -1,5 +1,8 @@
 from .entity import Entity
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 from . import util
 
 

--- a/nixio/data_view.py
+++ b/nixio/data_view.py
@@ -7,8 +7,10 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 import numpy as np
-from collections import Iterable
-
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 from .data_set import DataSet
 from .exceptions import OutOfBounds
 

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -112,10 +112,11 @@ class SampledDimension(Dimension):
         :returns: The created axis
         :rtype: list
         """
-        offset = self.offset if self.offset else 0
+        offset = self.offset if self.offset else 0.0
         sample = self.sampling_interval
-        end = (count + start) * sample + offset
-        return tuple(np.arange(offset, end, sample))
+        start_val = start * sample + offset
+        end_val = (start + count) * sample + offset
+        return tuple(np.arange(start_val, end_val, sample))
 
     @property
     def label(self):

--- a/nixio/property.py
+++ b/nixio/property.py
@@ -7,7 +7,10 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 
-from collections import Sequence, Iterable
+try:
+    from collections.abc import Sequence, Iterable
+except ImportError:
+    from collections import Sequence, Iterable
 from enum import Enum
 from numbers import Number
 from six import string_types

--- a/nixio/section.py
+++ b/nixio/section.py
@@ -10,7 +10,10 @@ try:
     from sys import maxint
 except ImportError:
     from sys import maxsize as maxint
-from collections import Sequence, Iterable
+try:
+    from collections.abc import Sequence, Iterable
+except ImportError:
+    from collections import Sequence, Iterable
 from six import string_types
 
 from .container import Container, SectionContainer

--- a/nixio/test/test_nix_compatibility.py
+++ b/nixio/test/test_nix_compatibility.py
@@ -7,7 +7,10 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 import os
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 from six import string_types
 from subprocess import Popen, PIPE
 import numpy as np

--- a/nixio/util/units.py
+++ b/nixio/util/units.py
@@ -9,7 +9,10 @@
 
 from six import string_types
 import re
-from collections import Sequence
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 from ..exceptions import InvalidUnit
 
 

--- a/nixio/validate.py
+++ b/nixio/validate.py
@@ -123,7 +123,7 @@ class Validate:
                                      "polynomial coefficients are missing")
         if np.any(poly):
             if not ex_origin:
-                da_error_list.append("Polynomial coefficients exist" 
+                da_error_list.append("Polynomial coefficients exist"
                                      " but expansion origins are missing")
 
         self.errors['blocks'][blk_idx]['data_arrays'][da_idx]['errors'] = da_error_list


### PR DESCRIPTION
Counterpart to PR #339 (same fix in v1.4). The calculation for the axis of a sampled dimension was ignoring the start value.