### PR TITLE
[v1.4] Change collections ABC imports to new module

### DIFF
--- a/nixio/pycore/section.py
+++ b/nixio/pycore/section.py
@@ -7,7 +7,10 @@
 # LICENSE file in the root of the Project.
 from __future__ import (absolute_import, division, print_function)
 
-from collections import Sequence
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 from ..section import SectionMixin
 from .entity import NamedEntity

--- a/nixio/pycore/util/units.py
+++ b/nixio/pycore/util/units.py
@@ -9,7 +9,10 @@
 from __future__ import (absolute_import, division, print_function)
 
 import re
-from collections import Sequence
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 from ..exceptions import InvalidUnit
 
 


### PR DESCRIPTION
Importing abstract base classes directly from collections will cause an
error in Python 3.8. Currently, in 3.7, it raises a warning. In 3.8,
they will have to be imported from collections.abc.

Wrapping in exception catcher for compatibility with older versions.