### PR TITLE
Codestyle cleanup and compatibility test selection changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,9 +77,9 @@ install:
 
 script:
   - if [[ "${coveralls}" == 1 ]]; then
-      coverage run --source=nixio setup.py test --addopts "--force-compat -s" && coverage report -m;
+      coverage run --source=nixio setup.py test --addopts "--nix-compat -s" && coverage report -m;
     else
-      python${pymajor} setup.py test --addopts "--force-compat -s -nauto";
+      python${pymajor} setup.py test --addopts "--nix-compat -s -nauto";
     fi
 
 after_success:

--- a/conftest.py
+++ b/conftest.py
@@ -4,15 +4,12 @@ from nixio.test.xcompat.compile import maketests
 
 
 BINDIR = tempfile.mkdtemp(prefix="nixpy-tests-")
-xcavail = maketests(BINDIR)
 
 
 def pytest_addoption(parser):
-    parser.addoption("--force-compat", action="store_true", default=False,
-                     help=("Force run compatibility tests. "
-                           "If they fail to compile (e.g., missing NIX) "
-                           "the tests wont pass.")
-                     )
+    parser.addoption("--nix-compat", action="store_true", default=False,
+                     help=("Run nix compatibility tests "
+                           "(requires NIX library)"))
 
 
 @pytest.fixture
@@ -21,14 +18,13 @@ def bindir(request):
 
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption("--force-compat"):
-        print("Forcing compatibility tests")
+    if config.getoption("--nix-compat"):
+        print("Compiling NIX compatibility tests")
+        maketests(BINDIR)
         return
-    if not xcavail:
-        print("Skipping compatibility tests")
-        skip_compat = pytest.mark.skip(
-            reason="Compatibility tests require the NIX library"
-        )
-        for item in items:
-            if "compatibility" in item.keywords:
-                item.add_marker(skip_compat)
+    skip_compat = pytest.mark.skip(
+        reason="Use --nix-compat option to run compatibility tests"
+    )
+    for item in items:
+        if "compatibility" in item.keywords:
+            item.add_marker(skip_compat)

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,34 @@
+import pytest
+import tempfile
+from nixio.test.xcompat.compile import maketests
+
+
+BINDIR = tempfile.mkdtemp(prefix="nixpy-tests-")
+xcavail = maketests(BINDIR)
+
+
 def pytest_addoption(parser):
-    parser.addoption("--force-compat",
-                     action="store_true",
-                     default=False,
-                     help=("Force cross-compatibility tests. "
-                           "Raise error instead of skipping."))
+    parser.addoption("--force-compat", action="store_true", default=False,
+                     help=("Force run compatibility tests. "
+                           "If they fail to compile (e.g., missing NIX) "
+                           "the tests wont pass.")
+                     )
+
+
+@pytest.fixture
+def bindir(request):
+    return BINDIR
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--force-compat"):
+        print("Forcing compatibility tests")
+        return
+    if not xcavail:
+        print("Skipping compatibility tests")
+        skip_compat = pytest.mark.skip(
+            reason="Compatibility tests require the NIX library"
+        )
+        for item in items:
+            if "compatibility" in item.keywords:
+                item.add_marker(skip_compat)

--- a/nixio/__init__.py
+++ b/nixio/__init__.py
@@ -32,9 +32,9 @@ from .compression import Compression
 # version
 from .info import VERSION as __version__
 
-__all__ = ("File", "Block", "Group", "DataArray", "DataFrame", "Tag", "MultiTag", "Source",
-           "Section", "S", "Feature", "Property", "OdmlType",
-           "SampledDimension", "RangeDimension", "SetDimension",
+__all__ = ("File", "Block", "Group", "DataArray", "DataFrame", "Tag",
+           "MultiTag", "Source", "Section", "S", "Feature", "Property",
+           "OdmlType", "SampledDimension", "RangeDimension", "SetDimension",
            "FileMode", "DataSliceMode", "DataType", "DimensionType",
            "LinkType", "Compression")
 __author__ = ('Christian Kellner, Adrian Stoewer, Andrey Sobolev, Jan Grewe, '

--- a/nixio/block.py
+++ b/nixio/block.py
@@ -14,7 +14,10 @@ except ImportError:
 import numpy as np
 from inspect import isclass
 from six import string_types
-from collections import OrderedDict  # using it for python2.7
+try:
+    from collections.abc import OrderedDict
+except ImportError:
+    from collections import OrderedDict
 import sys
 
 from .util import find as finders
@@ -194,12 +197,13 @@ class Block(Entity):
                           col_dtypes=None, data=None,
                           compression=Compression.No):
 
-        if isinstance(col_dict, dict) and not \
-                isinstance(col_dict, OrderedDict) and sys.version_info[0] < 3:
+        if (isinstance(col_dict, dict)
+                and not isinstance(col_dict, OrderedDict)
+                and sys.version_info[0] < 3):
             raise TypeError("Python 2 users should use name_list "
-                      "or OrderedDict created with LIST and TUPLES"
-                      " to create DataFrames as the order "
-                      "of the columns cannot be maintained in Py2")
+                            "or OrderedDict created with LIST and TUPLES "
+                            "to create DataFrames as the order "
+                            "of the columns cannot be maintained in Py2")
 
         if data is not None:
             shape = len(data)
@@ -210,14 +214,18 @@ class Block(Entity):
         if col_dict is None:
             if col_names is not None:
                 if col_dtypes is not None:
-                    col_dict = OrderedDict((str(nam), dt)
-                                    for nam, dt in zip(col_names, col_dtypes))
+                    col_dict = OrderedDict(
+                        (str(nam), dt)
+                        for nam, dt in zip(col_names, col_dtypes)
+                    )
                 elif col_dtypes is None and data is not None:
                     col_dtypes = []
                     for x in data[0]:
                         col_dtypes.append(type(x))
-                    col_dict = OrderedDict((str(nam), dt)
-                                    for nam, dt in zip(col_names, col_dtypes))
+                    col_dict = OrderedDict(
+                        (str(nam), dt)
+                        for nam, dt in zip(col_names, col_dtypes)
+                    )
                 else:  # col_dtypes is None and data is None
                     raise (ValueError,
                            "The data type of each column have to be specified")
@@ -233,7 +241,8 @@ class Block(Entity):
                             col_dict = OrderedDict(zip(cn, raw_dt_list))
 
                 else:
-            # data is None or type(data[0]) != np.void /data_type doesnt matter
+                    # data is None or type(data[0]) != np.void
+                    # data_type doesnt matter
                     raise (ValueError,
                            "No information about column names is provided!")
 

--- a/nixio/test/test_nix_compatibility.py
+++ b/nixio/test/test_nix_compatibility.py
@@ -506,8 +506,10 @@ def test_full_file(tmpdir):
     group.data_arrays.append(da)
 
     df = block.create_data_frame("adataframe", "4-column df",
-                                 col_dict=OrderedDict([('name', str), ('id',
-                                   int), ('time', float), ('Adjusted', bool)]),
+                                 col_dict=OrderedDict([('name', str),
+                                                       ('id', int),
+                                                       ('time', float),
+                                                       ('Adjusted', bool)]),
                                  data=[["Bob", 9, 11.28, False],
                                        ["Jane", 10, 14.37, True]])
     df.append_rows([["Alice", 2, 3.7, False]])

--- a/nixio/test/xcompat/compile.py
+++ b/nixio/test/xcompat/compile.py
@@ -28,10 +28,14 @@ def cc(filenames, dest,
     compiler = ccompiler.new_compiler()
 
     distutils.sysconfig.customize_compiler(compiler)
-    compiler.set_library_dirs(library_dirs)
-    compiler.set_include_dirs(include_dirs)
-    compiler.set_libraries(libraries)
-    compiler.set_runtime_library_dirs(runtime_lib_dirs)
+    if library_dirs:
+        compiler.set_library_dirs(library_dirs)
+    if include_dirs:
+        compiler.set_include_dirs(include_dirs)
+    if libraries:
+        compiler.set_libraries(libraries)
+    if runtime_lib_dirs:
+        compiler.set_runtime_library_dirs(runtime_lib_dirs)
 
     try:
         objnames = compiler.compile(filenames, output_dir=dest,
@@ -51,14 +55,28 @@ def maketests(dest):
     scriptloc, _ = os.path.split(os.path.abspath(__file__))
     os.chdir(scriptloc)
     filenames = glob("*.cpp")
-    nix_inc_dir = os.getenv('NIX_INCDIR', '/usr/local/include/nixio-1.0')
-    nix_lib_dir = os.getenv('NIX_LIBDIR', '/usr/local/lib')
 
-    boost_inc_dir = os.getenv('BOOST_INCDIR', '/usr/local/include')
-    boost_lib_dir = os.getenv('BOOST_LIBDIR', '/usr/local/lib')
-    library_dirs = [boost_lib_dir, nix_lib_dir]
-    include_dirs = [boost_inc_dir, nix_inc_dir, 'src']
-    runtime_dirs = ["/usr/local/lib"]
+    # look for libs and headers in both /usr/ and /usr/local/
+    library_dirs = ["/usr/lib", "/usr/local/lib"]
+    libenv = os.getenv("NIX_LIBDIR", None)
+    if libenv:
+        library_dirs.append(libenv)
+
+    include_dirs = ["/usr/include/", "/usr/local/include",
+                    "/usr/include/nixio-1.0", "/usr/local/include/nixio-1.0",
+                    "src"]
+    incenv = os.getenv("NIX_INCDIR", None)
+    if incenv:
+        include_dirs.append(libenv)
+
+    boost_libenv = os.getenv("BOOST_LIBDIR", None)
+    if boost_libenv:
+        library_dirs.append(boost_libenv)
+    boost_incenv = os.getenv("BOOST_INCDIR", None)
+    if boost_incenv:
+        include_dirs.append(boost_incenv)
+
+    runtime_dirs = ["/usr/lib", "/usr/local/lib"]
     llp = os.getenv("LD_LIBRARY_PATH", None)
     if llp is not None:
         runtime_dirs.append(llp)

--- a/nixio/validate.py
+++ b/nixio/validate.py
@@ -1,7 +1,10 @@
 from __future__ import (absolute_import, division, print_function)
 import numpy as np
 from .util import units
-from collections import OrderedDict
+try:
+    from collections.abc import OrderedDict
+except ImportError:
+    from collections import OrderedDict
 
 
 class Validate:


### PR DESCRIPTION
### Run compatibility tests only when requested

The compatibility tests are no longer run by default when NIX is detected. They can be run by specifying --nix-compat. If specified, the tests are compiled and any errors will cause failure of the
compatibility tests. If the option is not specified, the tests are skipped, even if NIX is available.

Compatibility tests were always compiled when NIX was available, even when they are unselected, and compilation would slow down the tests. With this change, they are only compiled and run when explicitly enabled.