### PR TITLE
Retrieve rename

### DIFF
--- a/docs/source/examples/multipleROIs.py
+++ b/docs/source/examples/multipleROIs.py
@@ -62,7 +62,7 @@ def plot_data(tag):
 def plot_roi_data(tag):
     position_count = tag.positions.shape[0]
     for p in range(position_count):
-        roi_data = tag.retrieve_data(p, 0)[:]
+        roi_data = tag.tagged_data(p, 0)[:]
         roi_data = np.array(roi_data, dtype='uint8')
         ax = plt.gcf().add_subplot(position_count, 1, p+1)
         image = img.fromarray(roi_data)

--- a/docs/source/examples/spikeFeatures.py
+++ b/docs/source/examples/spikeFeatures.py
@@ -59,7 +59,7 @@ def plot_data(tag):
 
     feature_data_array = tag.features[0].data
     snippets = tag.features[0].data[:]
-    single_snippet = tag.retrieve_feature_data(3, 0)[:]
+    single_snippet = tag.feature_data(3, 0)[:]
 
     snippet_time_dim = feature_data_array.dimensions[1]
     snippet_time = snippet_time_dim.axis(feature_data_array.data_extent[1])

--- a/docs/source/examples/untaggedFeature.py
+++ b/docs/source/examples/untaggedFeature.py
@@ -52,7 +52,7 @@ def plot_data(tag):
     stimulus_onset = tag.position
     stimulus_duration = tag.extent
 
-    stimulus = tag.retrieve_feature_data(0)
+    stimulus = tag.feature_data(0)
     stimulus_array = tag.features[0].data
 
     stim_time_dim = stimulus_array.dimensions[0]

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -349,7 +349,7 @@ In NIX we accept only SI units (plus dB, %) wherever units can be
 given. We also accept compound units like *mV/cm*. Units are most of
 the times handled transparently. That is, when you tag a region of
 data that has been specified with a time axis in seconds and use
-e.g. the *tag.retrieve_data* method to get this data slice, the API
+e.g. the *tag.tagged_data* method to get this data slice, the API
 will handle unit scaling. The correct data will be returned even if
 the tag's position is given in *ms*.
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -37,8 +37,8 @@ List of Tutorials
 
 * Retrieve data 
  
-  * :ref:`retrieve_tagged_data`
-  * :ref:`retrieve_feature_data`
+  * :ref:`tagged_data`
+  * :ref:`feature_data`
 
 * Additional information
 
@@ -262,7 +262,7 @@ Source code for this example: :download:`spikeTagging.py <examples/spikeTagging.
 :ref:`toc`
 
 
-.. _retrieve_tagged_data:
+.. _tagged_data:
 
 Retrieving tagged regions
 """""""""""""""""""""""""
@@ -388,7 +388,7 @@ Source code for this example: :download:`spikeFeatures.py <examples/spikeFeature
 :ref:`toc`
 
 
-.. _retrieve_feature_data:
+.. _feature_data:
 
 Retrieving feature data
 """""""""""""""""""""""

--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -6,6 +6,7 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
+import warnings
 from numbers import Number
 from enum import Enum
 
@@ -320,7 +321,6 @@ class DataArray(Entity, DataSet):
 
         :type: :class:`~nixio.data_array.DataArray`
         """
-        import warnings
         warnings.warn("Call to deprecated property DataArray.data",
                       category=DeprecationWarning)
         return self

--- a/nixio/multi_tag.py
+++ b/nixio/multi_tag.py
@@ -169,6 +169,9 @@ class MultiTag(BaseTag):
         return tuple(slice(start, stop) for start, stop in zip(starts, stops))
 
     def retrieve_data(self, posidx, refidx):
+        return self.tagged_data(posidx, refidx)
+
+    def tagged_data(self, posidx, refidx):
         references = self.references
         positions = self.positions
         extents = self.extents
@@ -185,14 +188,14 @@ class MultiTag(BaseTag):
             raise IncompatibleDimensions(
                 "Number of dimensions in position or extent do not match "
                 "dimensionality of data",
-                "MultiTag.retrieve_data")
+                "MultiTag.tagged_data")
         if len(positions.data_extent) > 1:
             if (positions.data_extent[1] > dimcount or
                     extents and extents.data_extent[1] > dimcount):
                 raise IncompatibleDimensions(
                     "Number of dimensions in position or extent do not match "
                     "dimensionality of data",
-                    "MultiTag.retrieve_data")
+                    "MultiTag.tagged_data")
         slices = self._calc_data_slices(ref, posidx)
 
         if not self._slices_in_data(ref, slices):
@@ -201,6 +204,9 @@ class MultiTag(BaseTag):
         return DataView(ref, slices)
 
     def retrieve_feature_data(self, posidx, featidx):
+        return self.feature_data(posidx, featidx)
+
+    def feature_data(self, posidx, featidx):
         if len(self.features) == 0:
             raise OutOfBounds(
                 "There are no features associated with this tag!"

--- a/nixio/multi_tag.py
+++ b/nixio/multi_tag.py
@@ -6,6 +6,7 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
+import warnings
 from .tag import BaseTag, FeatureContainer
 from .container import LinkContainer
 from .feature import Feature
@@ -169,6 +170,9 @@ class MultiTag(BaseTag):
         return tuple(slice(start, stop) for start, stop in zip(starts, stops))
 
     def retrieve_data(self, posidx, refidx):
+        msg = ("Call to deprecated method MultiTag.retrieve_data. "
+               "Use MultiTag.tagged_data instead.")
+        warnings.warn(msg, category=DeprecationWarning)
         return self.tagged_data(posidx, refidx)
 
     def tagged_data(self, posidx, refidx):
@@ -204,6 +208,9 @@ class MultiTag(BaseTag):
         return DataView(ref, slices)
 
     def retrieve_feature_data(self, posidx, featidx):
+        msg = ("Call to deprecated method MultiTag.retrieve_feature_data. "
+               "Use MultiTag.feature_data instead.")
+        warnings.warn(msg, category=DeprecationWarning)
         return self.feature_data(posidx, featidx)
 
     def feature_data(self, posidx, featidx):

--- a/nixio/tag.py
+++ b/nixio/tag.py
@@ -6,6 +6,7 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
+import warnings
 
 import numpy as np
 
@@ -228,6 +229,9 @@ class Tag(BaseTag):
         return tuple(refslice)
 
     def retrieve_data(self, refidx):
+        msg = ("Call to deprecated method Tag.retrieve_data. "
+               "Use Tag.tagged_data instead.")
+        warnings.warn(msg, category=DeprecationWarning)
         return self.tagged_data(refidx)
 
     def tagged_data(self, refidx):
@@ -256,6 +260,9 @@ class Tag(BaseTag):
         return DataView(ref, slices)
 
     def retrieve_feature_data(self, featidx):
+        msg = ("Call to deprecated method Tag.retrieve_feature_data. "
+               "Use Tag.feature_data instead.")
+        warnings.warn(msg, category=DeprecationWarning)
         return self.feature_data(featidx)
 
     def feature_data(self, featidx):

--- a/nixio/tag.py
+++ b/nixio/tag.py
@@ -228,6 +228,9 @@ class Tag(BaseTag):
         return tuple(refslice)
 
     def retrieve_data(self, refidx):
+        return self.tagged_data(refidx)
+
+    def tagged_data(self, refidx):
         references = self.references
         position = self.position
         extent = self.extent
@@ -244,7 +247,7 @@ class Tag(BaseTag):
             raise IncompatibleDimensions(
                 "Number of dimensions in position or extent do not match "
                 "dimensionality of data",
-                "Tag.retrieve_data")
+                "Tag.tagged_data")
 
         slices = self._calc_data_slices(ref)
         if not self._slices_in_data(ref, slices):
@@ -253,6 +256,9 @@ class Tag(BaseTag):
         return DataView(ref, slices)
 
     def retrieve_feature_data(self, featidx):
+        return self.feature_data(featidx)
+
+    def feature_data(self, featidx):
         if len(self.features) == 0:
             raise OutOfBounds(
                 "There are no features associated with this tag!"

--- a/nixio/test/test_multi_tag.py
+++ b/nixio/test/test_multi_tag.py
@@ -245,7 +245,7 @@ class TestMultiTags(unittest.TestCase):
 
         assert(len(self.my_tag.features) == 0)
 
-    def test_multi_tag_retrieve_data(self):
+    def test_multi_tag_tagged_data(self):
         sample_iv = 0.001
         x = np.arange(0, 10, sample_iv)
         y = np.sin(2*np.pi*x)
@@ -272,16 +272,16 @@ class TestMultiTags(unittest.TestCase):
         mtag.units = ['ms']
         mtag.references.append(da)
 
-        assert(mtag.retrieve_data(0, 0).shape == (2001,))
-        assert(np.array_equal(y[:2001], mtag.retrieve_data(0, 0)[:]))
+        assert(mtag.tagged_data(0, 0).shape == (2001,))
+        assert(np.array_equal(y[:2001], mtag.tagged_data(0, 0)[:]))
 
         # get by name
-        data = mtag.retrieve_data(0, da.name)
+        data = mtag.tagged_data(0, da.name)
         assert(data.shape == (2001,))
         assert(np.array_equal(y[:2001], data[:]))
 
         # get by id
-        data = mtag.retrieve_data(0, da.id)
+        data = mtag.tagged_data(0, da.id)
         assert(data.shape == (2001,))
         assert(np.array_equal(y[:2001], data[:]))
 
@@ -319,30 +319,30 @@ class TestMultiTags(unittest.TestCase):
         segtag.extents = ext
         segtag.units = units
 
-        posdata = postag.retrieve_data(0, 0)
+        posdata = postag.tagged_data(0, 0)
         assert(len(posdata.shape) == 3)
         assert(posdata.shape == (1, 1, 1))
         assert(np.isclose(posdata[0, 0, 0], data[1, 1, 0]))
 
-        posdata = postag.retrieve_data(1, 0)
+        posdata = postag.tagged_data(1, 0)
         assert(len(posdata.shape) == 3)
         assert(posdata.shape == (1, 1, 1))
         assert(np.isclose(posdata[0, 0, 0], data[1, 1, 0]))
 
-        segdata = segtag.retrieve_data(0, 0)
+        segdata = segtag.tagged_data(0, 0)
         assert(len(segdata.shape) == 3)
         assert(segdata.shape == (2, 6, 2))
 
-        segdata = segtag.retrieve_data(1, 0)
+        segdata = segtag.tagged_data(1, 0)
         assert(len(segdata.shape) == 3)
         assert(segdata.shape == (1, 5, 1))
 
         # retrieve all positions for all references
         for ridx, ref in enumerate(mtag.references):
             for pidx, p in enumerate(mtag.positions):
-                mtag.retrieve_data(pidx, ridx)
+                mtag.tagged_data(pidx, ridx)
 
-    def test_multi_tag_retrieve_data_1d(self):
+    def test_multi_tag_tagged_data_1d(self):
         # MultiTags to vectors behave a bit differently
         # Testing separately
         oneddata = self.block.create_data_array("1dda", "data",
@@ -354,7 +354,7 @@ class TestMultiTags(unittest.TestCase):
                                                positions=onedpos)
         onedmtag.references.append(oneddata)
         for pidx, p in enumerate(onedmtag.positions):
-            onedmtag.retrieve_data(pidx, 0)
+            onedmtag.tagged_data(pidx, 0)
 
     def test_multi_tag_feature_data(self):
         index_data = self.block.create_data_array("indexed feature data",
@@ -407,50 +407,50 @@ class TestMultiTags(unittest.TestCase):
         assert(len(self.feature_tag.features) == 3)
 
         # indexed feature
-        feat_data = self.feature_tag.retrieve_feature_data(0, 0)
+        feat_data = self.feature_tag.feature_data(0, 0)
         assert(len(feat_data.shape) == 2)
         assert(feat_data.size == 10)
         assert(np.sum(feat_data) == 55)
 
         # disabled, don't understand how it could ever have worked,
         # there are only 3 positions
-        data_view = self.feature_tag.retrieve_feature_data(9, 0)
+        data_view = self.feature_tag.feature_data(9, 0)
         assert(np.sum(data_view[:, :]) == 9055)
 
         # untagged feature
-        data_view = self.feature_tag.retrieve_feature_data(0, 2)
+        data_view = self.feature_tag.feature_data(0, 2)
         assert(data_view.size == 100)
 
-        data_view = self.feature_tag.retrieve_feature_data(0, 2)
+        data_view = self.feature_tag.feature_data(0, 2)
         assert(data_view.size == 100)
         assert(np.sum(data_view) == total)
 
         # tagged feature
-        data_view = self.feature_tag.retrieve_feature_data(0, 1)
+        data_view = self.feature_tag.feature_data(0, 1)
         assert(len(data_view.shape) == 3)
 
-        data_view = self.feature_tag.retrieve_feature_data(1, 1)
+        data_view = self.feature_tag.feature_data(1, 1)
         assert(len(data_view.shape) == 3)
 
         # === retrieve by name ===
         # indexed feature
-        feat_data = self.feature_tag.retrieve_feature_data(0, index_data.name)
+        feat_data = self.feature_tag.feature_data(0, index_data.name)
         assert(len(feat_data.shape) == 2)
         assert(feat_data.size == 10)
         assert(np.sum(feat_data) == 55)
 
         # disabled, there are only 3 positions
-        data_view = self.feature_tag.retrieve_feature_data(9, index_data.name)
+        data_view = self.feature_tag.feature_data(9, index_data.name)
         assert(np.sum(data_view[:, :]) == 9055)
 
         # tagged feature
-        data_view = self.feature_tag.retrieve_feature_data(0, tagged_data.name)
+        data_view = self.feature_tag.feature_data(0, tagged_data.name)
         assert(len(data_view.shape) == 3)
 
-        data_view = self.feature_tag.retrieve_feature_data(1, tagged_data.name)
+        data_view = self.feature_tag.feature_data(1, tagged_data.name)
         assert(len(data_view.shape) == 3)
 
         def out_of_bounds():
-            self.feature_tag.retrieve_feature_data(2, 1)
+            self.feature_tag.feature_data(2, 1)
 
         self.assertRaises(IndexError,  out_of_bounds)

--- a/nixio/test/test_tag.py
+++ b/nixio/test/test_tag.py
@@ -173,7 +173,7 @@ class TestTags(unittest.TestCase):
 
         assert(len(self.my_tag.features) == 0)
 
-    def test_tag_retrieve_data(self):
+    def test_tag_tagged_data(self):
         sample_iv = 1.0
         ticks = [1.2, 2.3, 3.4, 4.5, 6.7]
         unit = "ms"
@@ -199,30 +199,30 @@ class TestTags(unittest.TestCase):
         segtag.extent = ext
         segtag.units = units
 
-        posdata = postag.retrieve_data(0)
+        posdata = postag.tagged_data(0)
         assert(len(posdata.shape) == 3)
         assert(posdata.shape == (1, 1, 1))
 
-        segdata = segtag.retrieve_data(0)
+        segdata = segtag.tagged_data(0)
         assert(len(segdata.shape) == 3)
         assert(segdata.shape == (1, 7, 2))
 
         # retrieve data by id and name
-        posdata = postag.retrieve_data(da.name)
+        posdata = postag.tagged_data(da.name)
         assert(len(posdata.shape) == 3)
         assert(posdata.shape == (1, 1, 1))
-        segdata = segtag.retrieve_data(da.name)
+        segdata = segtag.tagged_data(da.name)
         assert(len(segdata.shape) == 3)
         assert(segdata.shape == (1, 7, 2))
 
-        posdata = postag.retrieve_data(da.id)
+        posdata = postag.tagged_data(da.id)
         assert(len(posdata.shape) == 3)
         assert(posdata.shape == (1, 1, 1))
-        segdata = segtag.retrieve_data(da.id)
+        segdata = segtag.tagged_data(da.id)
         assert(len(segdata.shape) == 3)
         assert(segdata.shape == (1, 7, 2))
 
-    def test_tag_retrieve_feature_data(self):
+    def test_tag_feature_data(self):
         number_feat = self.block.create_data_array("number feature", "test",
                                                    data=10.)
         ramp_data = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
@@ -241,9 +241,9 @@ class TestTags(unittest.TestCase):
         pos_tag.create_feature(ramp_feat, nix.LinkType.Untagged)
         assert(len(pos_tag.features) == 3)
 
-        data1 = pos_tag.retrieve_feature_data(0)
-        data2 = pos_tag.retrieve_feature_data(1)
-        data3 = pos_tag.retrieve_feature_data(2)
+        data1 = pos_tag.feature_data(0)
+        data2 = pos_tag.feature_data(1)
+        data3 = pos_tag.feature_data(2)
 
         assert(data1.size == 1)
         assert(data2.size == 1)
@@ -251,17 +251,17 @@ class TestTags(unittest.TestCase):
 
         # make the tag pointing to a slice
         pos_tag.extent = [2.0]
-        data1 = pos_tag.retrieve_feature_data(0)
-        data2 = pos_tag.retrieve_feature_data(1)
-        data3 = pos_tag.retrieve_feature_data(2)
+        data1 = pos_tag.feature_data(0)
+        data2 = pos_tag.feature_data(1)
+        data3 = pos_tag.feature_data(2)
 
         assert(data1.size == 1)
         assert(data2.size == 3)
         assert(data3.size == len(ramp_data))
 
         # get by name
-        data1 = pos_tag.retrieve_feature_data(number_feat.name)
-        data2 = pos_tag.retrieve_feature_data(ramp_feat.name)
+        data1 = pos_tag.feature_data(number_feat.name)
+        data2 = pos_tag.feature_data(ramp_feat.name)
 
         assert(data1.size == 1)
         assert(data2.size == 3)


### PR DESCRIPTION
Dropping `retrieve_` prefix from data access methods in Tag and MultiTag:
- `retrieve_data` → `tagged_data`
- `retrieve_feature_data` → `feature_data`

Closes #372 