### PR TITLE
Docstrings for DataFrame and Validator

### DIFF
--- a/nixio/block.py
+++ b/nixio/block.py
@@ -455,22 +455,6 @@ class Block(Entity):
             self._groups = Container("groups", self, Group)
         return self._groups
 
-    def __eq__(self, other):
-        """
-        Two Blocks are considered equal when they have the same id.
-        """
-        if hasattr(other, "id"):
-            return self.id == other.id
-        return False
-
-    def __hash__(self):
-        """
-        overwriting method __eq__ blocks inheritance of __hash__ in Python 3
-        hash has to be either explicitly inherited from parent class,
-        implemented or escaped
-        """
-        return hash(self.id)
-
     # metadata
     @property
     def metadata(self):

--- a/nixio/block.py
+++ b/nixio/block.py
@@ -196,7 +196,31 @@ class Block(Entity):
     def create_data_frame(self, name, type_, col_dict=None, col_names=None,
                           col_dtypes=None, data=None,
                           compression=Compression.No):
+        """
+         Create a new data frame for this block. Either ``col_dict``
+         or ``col_name`` and ``col_dtypes`` must be given.
+         If both are given, ``col_dict`` will be used.
 
+         :param name: The name of the data frame to create.
+         :type name: str
+         :param type_: The type of the data frame.
+         :type type_: str
+         :param col_dict: The dictionary that specify column
+                          names and data type in each column
+         :type col_dict:dict or OrderedDict of {str: type}
+         :param col_names: The collection of name of all columns in order
+         :type col_names: tuples or list or np.array of string
+         :param col_dtypes: The collection of data type of all columns in order
+         :type col_dtypes: tuples or list or np.array of type
+         :param data: Data to write after storage has been created
+         :type data: array-like data with compound data type
+                     as specified in the columns
+         :param compression: En-/disable dataset compression.
+         :type compression: :class:`~nixio.Compression`
+
+         :returns: The newly created data frame.
+         :rtype: :class:`~nixio.DataFrame`
+         """
         if (isinstance(col_dict, dict)
                 and not isinstance(col_dict, OrderedDict)
                 and sys.version_info[0] < 3):

--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -340,20 +340,6 @@ class DataArray(Entity, DataSet):
                                                   Dimension)
         return self._dimensions
 
-    def __eq__(self, other):
-        if hasattr(other, "id"):
-            return self.id == other.id
-        else:
-            return False
-
-    def __hash__(self):
-        """
-        Overwriting method __eq__ blocks inheritance of __hash__ in Python 3
-        hash has to be either explicitly inherited from parent class,
-        implemented or escaped
-        """
-        return hash(self.id)
-
     # metadata
     @property
     def metadata(self):

--- a/nixio/data_frame.py
+++ b/nixio/data_frame.py
@@ -1,5 +1,11 @@
 # -*- coding: utf-8 -*-
-
+# Copyright © 2019, German Neuroinformatics Node (G-Node)
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted under the terms of the BSD License. See
+# LICENSE file in the root of the Project.
 from __future__ import (absolute_import, division, print_function)
 try:
     from collections.abc import Iterable

--- a/nixio/data_frame.py
+++ b/nixio/data_frame.py
@@ -79,8 +79,7 @@ class DataFrame(Entity, DataSet):
 
     def append_rows(self, data):
         """
-        Append a new row to the DataFrame
-        In Python2, the data supplied must be iterable (not np arrays)
+        Append a new row to the DataFrame. The data supplied must be iterable.
 
         :param data: The new row
         :type data: array-like data
@@ -376,7 +375,6 @@ class DataFrame(Entity, DataSet):
     @property
     def metadata(self):
         """
-
         Associated metadata of the entity. Sections attached to the entity via
         this attribute can provide additional annotations. This is an optional
         read-write property, and can be None if no metadata is available.

--- a/nixio/data_frame.py
+++ b/nixio/data_frame.py
@@ -19,6 +19,7 @@ from .entity import Entity
 from . import util
 from .data_set import DataSet
 from .datatype import DataType
+from .section import Section
 from six import string_types
 import csv
 
@@ -248,3 +249,31 @@ class DataFrame(Entity, DataSet):
         df_shape = tuple(df_shape)
         self._h5group.set_attr("df_shape", df_shape)
         return self._h5group.get_attr("df_shape")
+
+    # metadata
+    @property
+    def metadata(self):
+        """
+
+        Associated metadata of the entity. Sections attached to the entity via
+        this attribute can provide additional annotations. This is an optional
+        read-write property, and can be None if no metadata is available.
+
+        :type: Section
+        """
+        if "metadata" in self._h5group:
+            return Section(None, self._h5group.open_group("metadata"))
+        else:
+            return None
+
+    @metadata.setter
+    def metadata(self, sect):
+        if not isinstance(sect, Section):
+            raise TypeError("{} is not of type Section".format(sect))
+        self._h5group.create_link(sect, "metadata")
+
+    @metadata.deleter
+    def metadata(self):
+        if "metadata" in self._h5group:
+            self._h5group.delete("metadata")
+

--- a/nixio/data_frame.py
+++ b/nixio/data_frame.py
@@ -41,7 +41,17 @@ class DataFrame(Entity, DataSet):
         return newentity
 
     def append_column(self, column, name, datatype=None):
-        # datatype is better included for strings
+        """
+        Append a new column to the DataFrame
+        In case of string, it will be better to set explicitly the datatype.
+
+        :param column: The new column
+        :type column: array-like data
+        :param name: The name of new column
+        :type name: str
+        :param datatype: The DataType of new column
+        :type datatype: DataType
+        """
         if len(column) < len(self):
             raise ValueError("Not enough entries for column in this dataframe")
         elif len(column) > len(self):
@@ -68,7 +78,13 @@ class DataFrame(Entity, DataSet):
         self.write_direct(farr)
 
     def append_rows(self, data):
-        # In Python2, the data supplied must be iterable (not np arrays)
+        """
+        Append a new row to the DataFrame
+        In Python2, the data supplied must be iterable (not np arrays)
+
+        :param data: The new row
+        :type data: array-like data
+        """
         li_data = []
         for d in data:
             d = tuple(d)
@@ -77,6 +93,17 @@ class DataFrame(Entity, DataSet):
         self.append(pro_data, axis=0)
 
     def write_column(self, column, index=None, name=None):
+        """
+        Overwrite an existing column.
+        Either index or name of the column should be provided.
+
+        :param column: The new column
+        :type column: array-like data
+        :param index: The index of the column that is written to
+        :type index: string
+        :param name: The name of the column that is written to
+        :type name: str
+        """
         if len(column) != self.shape[0]:
             raise ValueError('If there are missing data, please fill in None')
         if not index and not name:
@@ -91,6 +118,16 @@ class DataFrame(Entity, DataSet):
 
     # TODO: for read column add a Mode that break down the tuples
     def read_columns(self, index=None, name=None, sl=None):
+        """
+        Read one or multiple (part of) column(s) in the DataFrame
+
+        :param index: Index of column(s) to be returned
+        :type index: list of int
+        :param name: Name of column(s) to be returned
+        :type name: list of str
+        :param sl: The part of each column to be returned
+        :type sl: slice
+        """
         if index is None and name is None:
             raise ValueError("Either index or name must not be None")
         if name is None:
@@ -107,6 +144,14 @@ class DataFrame(Entity, DataSet):
         return get_col
 
     def write_rows(self, rows, index):
+        """
+        Overwrite one or multiple existing row(s)
+
+        :param rows: The new rows(s) and their data
+        :type rows: array-like data
+        :param index: Index of rows(s) to be overwritten
+        :type index: list of int
+        """
         if len(rows) != len(index):
             raise IndexError(
                 "Number of rows ({}) does not match "
@@ -127,12 +172,32 @@ class DataFrame(Entity, DataSet):
             self._write_data(cr_list, sl=index)
 
     def read_rows(self, index):
+        """
+        Read one or multiple row(s) in the DataFrame
+
+        :param index: Index of row(s) to be returned
+        :type index: list of int
+        """
         if isinstance(index, Iterable):
             index = list(index)
         get_row = self._read_data(sl=(index,))
         return get_row
 
+    # TODO: allow writing multiple cells at the same time
     def write_cell(self, cell, position=None, col_name=None, row_idx=None):
+        """
+        Overwrite a cell in the DataFrame
+
+        :param cell: The new cell
+        :type cell: same type as the specified column
+        :param position: Position of the targeted cell
+        :type position: tuple or list or array with length 2
+        :param col_name: The column name in which the targeted cell belongs to
+        :type col_name: str
+        :param row_idx: A length 1 list that specify on
+                        which row the targeted cell is located
+        :type row_idx: list of int
+         """
         if position is not None:
             if len(position) != 2:
                 raise ValueError("position is invalid: "
@@ -149,6 +214,17 @@ class DataFrame(Entity, DataSet):
             self._write_data(targeted_row, sl=row_idx)
 
     def read_cell(self, position=None, col_name=None, row_idx=None):
+        """
+        Read a cell in the DataFrame
+
+        :param position: Position of the targeted cell
+        :type position: tuple or list or array with length 2
+        :param col_name: The column name in which the targeted cell belongs to
+        :type col_name: str
+        :param row_idx: A length 1 list that specify on
+                         which row the targeted cell is located
+        :type row_idx: list of int
+        """
         if position is not None:
             if len(position) != 2:
                 raise ValueError('Not a position')
@@ -161,7 +237,11 @@ class DataFrame(Entity, DataSet):
             cell = cell[0]
             return cell
 
+    # TODO: allow printing part of the DataFrame
     def print_table(self):
+        """
+        Print the whole DataFrame as a table
+        """
         row_form = "{:^10}" * (len(self.column_names) + 1)
         print(row_form.format(" ", *self.column_names))
         if self.units:
@@ -181,10 +261,21 @@ class DataFrame(Entity, DataSet):
         return None
 
     def row_count(self):
+        """
+        Return the total number of rows
+        """
         count = len(self)
         return count
 
     def write_to_csv(self, filename, mode='w'):
+        """
+        Export the whole DataFrame to a CSV file
+
+        :param filename: The resulted/ targeted CSV file to write to/ create
+        :type filename: str
+        :param mode: The column name in which the targeted cell belongs to
+        :type mode: str
+        """
         with open(filename, mode, newline='') as csvfile:
             dw = csv.DictWriter(csvfile, fieldnames=self.column_names)
             dw.writeheader()
@@ -204,6 +295,12 @@ class DataFrame(Entity, DataSet):
 
     @property
     def units(self):
+        """
+        The unit of the values stored in the DataFrame.
+        This is a read-write property and can be set to None.
+
+        :type: array of str
+        """
         return self._h5group.get_attr("units")
 
     @units.setter
@@ -216,6 +313,13 @@ class DataFrame(Entity, DataSet):
 
     @property
     def columns(self):
+        """
+        The dtype is the list of names and data types
+        of all columns in the DatFrame.
+        This is a read only property.
+
+        :type: list of tuples
+        """
         if self.units:
             cols = [(n, dt, u) for n, dt, u in
                     zip(self.column_names, self.dtype, self.units)]
@@ -226,11 +330,23 @@ class DataFrame(Entity, DataSet):
 
     @property
     def column_names(self):
+        """
+        The dtype is the list of names of all columns in the DatFrame.
+        This is a read only property.
+
+        :type: list of str
+        """
         dt = self._h5group.group["data"].dtype
         return dt.names
 
     @property
     def dtype(self):
+        """
+        The dtype is the list of DataTypes of all columns in the DatFrame.
+        This is a read only property.
+
+        :type: list of DataType
+        """
         dt = self._h5group.group["data"].dtype
         key = self.column_names
         di = OrderedDict()
@@ -243,6 +359,13 @@ class DataFrame(Entity, DataSet):
 
     @property
     def df_shape(self):
+        """
+        The df_shape is the shape of the DataFrame
+        in (number of rows, number of columns) format.
+        This is a read only property.
+
+        :type: tuple
+        """
         x = len(self._h5group.group["data"])
         y = len(self.column_names)
         df_shape = (x, y)
@@ -250,7 +373,6 @@ class DataFrame(Entity, DataSet):
         self._h5group.set_attr("df_shape", df_shape)
         return self._h5group.get_attr("df_shape")
 
-    # metadata
     @property
     def metadata(self):
         """

--- a/nixio/entity.py
+++ b/nixio/entity.py
@@ -139,12 +139,19 @@ class Entity(object):
         self._h5group.set_attr("type", t)
 
     def __eq__(self, other):
+        """
+        Two Entities are considered equal when they have the same id.
+        """
         if hasattr(other, "id"):
             return self.id == other.id
-        else:
-            return False
+        return False
 
     def __hash__(self):
+        """
+        overwriting method __eq__ blocks inheritance of __hash__ in Python 3
+        hash has to be either explicitly inherited from parent class,
+        implemented or escaped
+        """
         return hash(self.id)
 
     def __str__(self):

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -264,6 +264,12 @@ class File(object):
             return False
 
     def validate(self):
+        """
+        Checks if the file is a valid nix file.
+
+        :returns: A dict which contains all objects in file and related errors
+        :rtype: Dictionary
+        """
         validator = Validate(self)
         validator.check_file()
         validator.form_dict()

--- a/nixio/section.py
+++ b/nixio/section.py
@@ -366,20 +366,6 @@ class Section(Entity):
             self._sections = SectionContainer("sections", self, Section)
         return self._sections
 
-    def __eq__(self, other):
-        if hasattr(other, "id"):
-            return self.id == other.id
-
-        return False
-
-    def __hash__(self):
-        """
-        overwriting method __eq__ blocks inheritance of __hash__ in Python 3
-        hash has to be either explicitly inherited from parent class,
-        implemented or escaped
-        """
-        return hash(self.id)
-
     def __len__(self):
         return len(self.props)
 

--- a/nixio/source.py
+++ b/nixio/source.py
@@ -102,20 +102,6 @@ class Source(Entity):
             self._sources = SourceContainer("sources", self, Source)
         return self._sources
 
-    def __eq__(self, other):
-        if hasattr(other, "id"):
-            return self.id == other.id
-        else:
-            return False
-
-    def __hash__(self):
-        """
-        overwriting method __eq__ blocks inheritance of __hash__ in Python 3
-        hash has to be either explicitly inherited from parent class,
-        implemented or escaped
-        """
-        return hash(self.id)
-
     # metadata
     @property
     def metadata(self):

--- a/nixio/validate.py
+++ b/nixio/validate.py
@@ -79,7 +79,7 @@ class Validate:
 
     def check_file(self):
         """
-        Check if the file meet the nix requirements on file level.
+        Check if the file meets the NIX requirements at the file level.
 
         :returns: The error dictionary with errors appended on the file level
         :rtype: Dictionary
@@ -97,7 +97,7 @@ class Validate:
 
     def check_blocks(self, block, blk_idx):
         """
-        Check if the file meet the nix requirements on block level.
+        Check if the file meets the NIX requirements at the block level.
 
         :returns: The error dictionary with errors appended on the block level
         :rtype: Dictionary
@@ -110,7 +110,7 @@ class Validate:
 
     def check_groups(self, group, grp_idx, blk_idx):
         """
-        Check if the file meet the nix requirements on the group level.
+        Check if the file meets the NIX requirements at the group level.
 
         :returns: The error dict with errors appended on group level or None
         :rtype: Dictionary or None if no errors found
@@ -127,7 +127,7 @@ class Validate:
 
     def check_data_arrays(self, da, da_idx, blk_idx):
         """
-        Check if the file meet the nix requirements on DataArray level.
+        Check if the file meets the NIX requirements at the DataArray level.
 
         :returns: The error dictionary with errors appended on DataArray level
         :rtype: Dictionary
@@ -193,7 +193,7 @@ class Validate:
 
     def check_tag(self, tag, tag_idx, blk_idx):
         """
-        Check if the file meet the nix requirements on tag level.
+        Check if the file meets the NIX requirements at the tag level.
 
         :returns: The error dictionary with errors appended on Tag level
         :rtype: Dictionary
@@ -303,7 +303,7 @@ class Validate:
 
     def check_section(self, section, sec_idx):
         """
-        Check if the file meet the nix requirements on section level.
+        Check if the file meets the NIX requirements at the section level.
 
         :returns: The error dictionary with errors appended on section level
         :rtype: Dictionary
@@ -330,7 +330,7 @@ class Validate:
 
     def check_features(self, feat, parent, blk_idx, tag_idx, fea_idx):
         """
-        Check if the file meet the nix requirements on feature level.
+        Check if the file meets the NIX requirements at the feature level.
 
         :returns: The error dictionary with errors appended on feature level
         :rtype: Dictionary
@@ -349,7 +349,7 @@ class Validate:
 
     def check_sources(self, src, blk_idx):
         """
-        Check if the file meet the nix requirements on source level.
+        Check if the file meets the NIX requirements at the source level.
 
         :returns: The error dictionary with errors appended on source level
         :rtype: Dictionary or None if no errors
@@ -373,7 +373,7 @@ class Validate:
 
     def check_range_dim(self, r_dim, dim_idx, da_idx, blk_idx):
         """
-        Check if the file meet the nix requirements for range dimensions.
+        Check if the file meets the NIX requirements for range dimensions.
 
         :returns: The error dictionary with errors appended on range dimensions
         :rtype: Dictionary
@@ -403,7 +403,7 @@ class Validate:
 
     def check_set_dim(self, set_dim, dim_idx, da_idx, blk_idx):
         """
-        Check if the file meet the nix requirements for set dimensions.
+        Check if the file meets the NIX requirements for set dimensions.
 
         :returns: The error dictionary with errors appended on set dimensions
         :rtype: Dictionary
@@ -421,7 +421,7 @@ class Validate:
 
     def check_sampled_dim(self, sam_dim, dim_idx, da_idx, blk_idx):
         """
-        Check if the file meet the nix requirements for sampled dimensions.
+        Check if the file meets the NIX requirements for sampled dimensions.
 
         :returns: The error dict with errors appended on sampled dimensions
         :rtype: Dictionary

--- a/nixio/validate.py
+++ b/nixio/validate.py
@@ -1,3 +1,11 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2019, German Neuroinformatics Node (G-Node)
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted under the terms of the BSD License. See
+# LICENSE file in the root of the Project.
 from __future__ import (absolute_import, division, print_function)
 import numpy as np
 from .util import units

--- a/nixio/validate.py
+++ b/nixio/validate.py
@@ -28,6 +28,9 @@ class Validate:
         self.error_count = 0
 
     def form_dict(self):
+        """
+        Form a empty dict that has same structure as the data tree in the file.
+        """
         file = self.file
         self.error_count = 0
 
@@ -75,7 +78,12 @@ class Validate:
                     tag['features'].append(fea_dict)
 
     def check_file(self):
+        """
+        Check if the file meet the nix requirements on file level.
 
+        :returns: The error dictionary with errors appended on the file level
+        :rtype: Dictionary
+        """
         file_err_list = []
         if not self.file.created_at:
             file_err_list.append("date is not set!")
@@ -88,6 +96,12 @@ class Validate:
         return self.errors
 
     def check_blocks(self, block, blk_idx):
+        """
+        Check if the file meet the nix requirements on block level.
+
+        :returns: The error dictionary with errors appended on the block level
+        :rtype: Dictionary
+        """
         blk_err_list = self.check_for_basics(block)
 
         self.errors['blocks'][blk_idx]['errors'] = blk_err_list
@@ -95,6 +109,12 @@ class Validate:
         return self.errors
 
     def check_groups(self, group, grp_idx, blk_idx):
+        """
+        Check if the file meet the nix requirements on the group level.
+
+        :returns: The error dict with errors appended on group level or None
+        :rtype: Dictionary or None if no errors found
+        """
         grp_err_list = self.check_for_basics(group)
 
         if grp_err_list:
@@ -106,6 +126,12 @@ class Validate:
             return None
 
     def check_data_arrays(self, da, da_idx, blk_idx):
+        """
+        Check if the file meet the nix requirements on DataArray level.
+
+        :returns: The error dictionary with errors appended on DataArray level
+        :rtype: Dictionary
+        """
         da_error_list = []
         if self.check_for_basics(da):
             da_error_list.extend(self.check_for_basics(da))
@@ -166,6 +192,12 @@ class Validate:
         return self.errors
 
     def check_tag(self, tag, tag_idx, blk_idx):
+        """
+        Check if the file meet the nix requirements on tag level.
+
+        :returns: The error dictionary with errors appended on Tag level
+        :rtype: Dictionary
+        """
         tag_err_list = []
 
         if not tag.position:
@@ -270,6 +302,12 @@ class Validate:
         return self.errors
 
     def check_section(self, section, sec_idx):
+        """
+        Check if the file meet the nix requirements on section level.
+
+        :returns: The error dictionary with errors appended on section level
+        :rtype: Dictionary
+        """
         sec = self.errors['sections'][sec_idx]
         sec['errors'] = self.check_for_basics(section)
         self.error_count += len(self.check_for_basics(section))
@@ -291,6 +329,12 @@ class Validate:
         return self.errors
 
     def check_features(self, feat, parent, blk_idx, tag_idx, fea_idx):
+        """
+        Check if the file meet the nix requirements on feature level.
+
+        :returns: The error dictionary with errors appended on feature level
+        :rtype: Dictionary
+        """
         fea_err_list = []
         # will raise RuntimeError for both, actually no need to check
         if not feat.link_type:
@@ -304,6 +348,12 @@ class Validate:
         return self.errors
 
     def check_sources(self, src, blk_idx):
+        """
+        Check if the file meet the nix requirements on source level.
+
+        :returns: The error dictionary with errors appended on source level
+        :rtype: Dictionary or None if no errors
+        """
         if self.check_for_basics(src):
             blk = self.errors['blocks'][blk_idx]
             blk['sources'] = self.check_for_basics(src)
@@ -312,6 +362,9 @@ class Validate:
         return None
 
     def check_dim(self, dimen):
+        """
+        General checks for all dimensions
+        """
         # call it in file after the index problem is fixed
         # call it in other check dim function / don't call alone
         if dimen.index and dimen.index > 0:
@@ -319,6 +372,12 @@ class Validate:
         return 'index must > 0'
 
     def check_range_dim(self, r_dim, dim_idx, da_idx, blk_idx):
+        """
+        Check if the file meet the nix requirements for range dimensions.
+
+        :returns: The error dictionary with errors appended on range dimensions
+        :rtype: Dictionary
+        """
         rdim_err_list = []
 
         if self.check_dim(r_dim):
@@ -343,6 +402,12 @@ class Validate:
         return self.errors
 
     def check_set_dim(self, set_dim, dim_idx, da_idx, blk_idx):
+        """
+        Check if the file meet the nix requirements for set dimensions.
+
+        :returns: The error dictionary with errors appended on set dimensions
+        :rtype: Dictionary
+        """
         if self.check_dim(set_dim):
             da = self.errors['blocks'][blk_idx]['data_arrays'][da_idx]
             da['dimensions'][dim_idx]['errors'].append(self.check_dim(set_dim))
@@ -355,6 +420,12 @@ class Validate:
         return self.errors
 
     def check_sampled_dim(self, sam_dim, dim_idx, da_idx, blk_idx):
+        """
+        Check if the file meet the nix requirements for sampled dimensions.
+
+        :returns: The error dict with errors appended on sampled dimensions
+        :rtype: Dictionary
+        """
         sdim_err_list = []
 
         if self.check_dim(sam_dim):
@@ -381,6 +452,9 @@ class Validate:
         return self.errors
 
     def check_for_basics(self, entity):
+        """
+        General check for the nix requirements applicable for all nix Objects
+        """
         basic_check_list = []
         typename = type(entity).__name__
         if not entity.type:
@@ -393,6 +467,9 @@ class Validate:
         return basic_check_list
 
     def get_dim_units(self, data_arrays):
+        """
+        Help function to collect the units of the dimensions of a data array
+        """
         unit_list = []
         for dim in data_arrays.dimensions:
             if dim.dimension_type == 'range':


### PR DESCRIPTION
Add the descriptions  to the DataFrame and Validator methods and properties. 

Add the link to metadata for DataFrame 

Delete the __eq__ and __hash__  for some objects and their parent Class entity already have the exactly same method.
