### PR TITLE
Copy function for all entities

### DIFF
--- a/nixio/block.py
+++ b/nixio/block.py
@@ -74,7 +74,8 @@ class Block(Entity):
         if copy_from:
             if not isinstance(copy_from, MultiTag):
                 raise TypeError("Object to be copied is not a MultiTag")
-            id = self._copy_objects(copy_from, "multi_tags", keep_copy_id)
+            id = self._copy_objects(copy_from, "multi_tags",
+                                    keep_copy_id, name)
             return self.multi_tags[id]
 
         util.check_entity_name_and_type(name, type_)
@@ -106,7 +107,7 @@ class Block(Entity):
         if copy_from:
             if not isinstance(copy_from, Tag):
                 raise TypeError("Object to be copied is not a Tag")
-            id = self._copy_objects(copy_from, "tags", keep_copy_id)
+            id = self._copy_objects(copy_from, "tags", keep_copy_id, name)
             return self.tags[id]
 
         util.check_entity_name_and_type(name, type_)
@@ -185,7 +186,8 @@ class Block(Entity):
         if copy_from:
             if not isinstance(copy_from, DataArray):
                 raise TypeError("Object to be copied is not a DataArray")
-            id = self._copy_objects(copy_from, "data_arrays", keep_copy_id)
+            id = self._copy_objects(copy_from, "data_arrays",
+                                    keep_copy_id, name)
             return self.data_arrays[id]
 
         if data is None:
@@ -246,7 +248,8 @@ class Block(Entity):
         if copy_from:
             if not isinstance(copy_from, DataFrame):
                 raise TypeError("Object to be copied is not a DataFrame")
-            id = self._copy_objects(copy_from, "data_frames", keep_copy_id)
+            id = self._copy_objects(copy_from, "data_frames",
+                                    keep_copy_id, name)
             return self.data_frames[id]
 
         util.check_entity_name_and_type(name, type_)
@@ -417,10 +420,17 @@ class Block(Entity):
             else:
                 print(n)
 
-    def _copy_objects(self, obj, clsname, keep_id=True):
+    def _copy_objects(self, obj, clsname, keep_id=True, name=""):
         src = "{}/{}".format(clsname, obj.name)
+        if not name:
+            name = str(obj.name)
+        ogrp = self._h5group.open_group(clsname, True)
+        if name in ogrp:
+            raise NameError("Name already exist. Possible solution is to "
+                            "provide a new name when copying destination "
+                            "is the same as the source parent")
         o = obj._parent._h5group.copy(source=src, dest=self._h5group,
-                                    name=str(obj.name), cls=clsname,
+                                    name=name, cls=clsname,
                                     keep_id=keep_id)
 
         return o.attrs["entity_id"]

--- a/nixio/block.py
+++ b/nixio/block.py
@@ -388,7 +388,7 @@ class Block(Entity):
             else:
                 print(n)
 
-    def copy_data_array(self, obj, change_id=False):
+    def copy_data_array(self, obj, keep_id=True):
         if not isinstance(obj, DataArray):
             raise TypeError("Object to be copied is not a DataArray")
 
@@ -398,14 +398,14 @@ class Block(Entity):
         da = h5_parent._h5group.copy(source=src, dest=self._h5group,
                                      name=str(obj.name), cls=clsname)
 
-        if change_id:
+        if not keep_id:
             id_ = util.create_id()
             da.attrs.modify("entity_id", np.string_(id_))
             da.visititems(self._change_id)
 
         return self.data_arrays[obj.name]
 
-    def copy_data_frame(self, obj, change_id=False):
+    def copy_data_frame(self, obj, keep_id=True):
         if not isinstance(obj, DataFrame):
             raise TypeError("Object to be copied is not a DataFrame")
 
@@ -414,14 +414,14 @@ class Block(Entity):
         src = "{}/{}".format(clsname, obj.name)
         df = h5_parent._h5group.copy(source=src, dest=self._h5group,
                                      name=str(obj.name), cls=clsname)
-        if change_id:
+        if not keep_id:
             id_ = util.create_id()
             df.attrs.modify("entity_id", np.string_(id_))
             df.visititems(self._change_id)
 
         return self.data_frames[obj.name]
 
-    def copy_multi_tag(self, obj, change_id=False):
+    def copy_multi_tag(self, obj, keep_id=True):
         if not isinstance(obj, MultiTag):
             raise TypeError("Object to be copied is not a MultiTag")
 
@@ -431,14 +431,14 @@ class Block(Entity):
         mt = h5_parent._h5group.copy(source=src, dest=self._h5group,
                                      name=str(obj.name), cls=clsname)
 
-        if change_id:
+        if not keep_id:
             id_ = util.create_id()
             mt.attrs.modify("entity_id", np.string_(id_))
             mt.visititems(self._change_id)
 
         return self.multi_tags[obj.name]
 
-    def copy_tag(self, obj, change_id=False):
+    def copy_tag(self, obj, keep_id=True):
         if not isinstance(obj, Tag):
             raise TypeError("Object to be copied is not a Tag")
 
@@ -448,7 +448,7 @@ class Block(Entity):
         tag = h5_parent._h5group.copy(source=src, dest=self._h5group,
                                       name=str(obj.name), cls=clsname)
 
-        if change_id:
+        if not keep_id:
             id_ = util.create_id()
             tag.attrs.modify("entity_id", np.string_(id_))
             tag.visititems(self._change_id)

--- a/nixio/block.py
+++ b/nixio/block.py
@@ -388,6 +388,46 @@ class Block(Entity):
             else:
                 print(n)
 
+    def copy_data_array(self, obj):
+        if not isinstance(obj, DataArray):
+            raise TypeError("Object to be copied is not a DataArray")
+
+        h5_parent = obj._parent
+        clsname = "data_arrays"
+        src = "{}/{}".format(clsname, obj.name)
+        h5_parent._h5group.copy(source=src, dest=self._h5group,
+                                name=str(obj.name), cls=clsname)
+
+    def copy_data_frame(self, obj):
+        if not isinstance(obj, DataFrame):
+            raise TypeError("Object to be copied is not a DataFrame")
+
+        h5_parent = obj._parent
+        clsname = "data_frames"
+        src = "{}/{}".format(clsname, obj.name)
+        h5_parent._h5group.copy(source=src, dest=self._h5group,
+                                name=str(obj.name), cls=clsname)
+
+    def copy_multi_tag(self, obj):
+        if not isinstance(obj, MultiTag):
+            raise TypeError("Object to be copied is not a MultiTag")
+
+        h5_parent = obj._parent
+        clsname = "multi_tags"
+        src = "{}/{}".format(clsname, obj.name)
+        h5_parent._h5group.copy(source=src, dest=self._h5group,
+                                name=str(obj.name), cls=clsname)
+
+    def copy_tag(self, obj):
+        if not isinstance(obj, Tag):
+            raise TypeError("Object to be copied is not a Tag")
+
+        h5_parent = obj._parent
+        clsname = "tags"
+        src = "{}/{}".format(clsname, obj.name)
+        h5_parent._h5group.copy(source=src, dest=self._h5group,
+                                name=str(obj.name), cls=clsname)
+
     @property
     def sources(self):
         """

--- a/nixio/block.py
+++ b/nixio/block.py
@@ -59,14 +59,18 @@ class Block(Entity):
     def create_multi_tag(self, name="", type_="", positions=0,
                          copy_from=None, keep_copy_id=True):
         """
-        Create a new multi tag for this block.
+        Create/copy a new multi tag for this block.
 
-        :param name: The name of the tag to create.
+        :param name: The name of the tag to create/copy.
         :type name: str
         :param type_: The type of tag.
         :type type_: str
         :param positions: A data array defining all positions of the tag.
         :type positions: DataArray
+        :param copy_from: The MultiTag to be copied, None in normal mode
+        :type copy_from: MultiTag
+        :param keep_copy_id: Specify if the id should be copied in copy mode
+        :type keep_copy_id: bool
 
         :returns: The newly created tag.
         :rtype: MultiTag
@@ -92,14 +96,18 @@ class Block(Entity):
     def create_tag(self, name="", type_="", position=0,
                    copy_from=None, keep_copy_id=True):
         """
-        Create a new tag for this block.
+        Create/copy a new tag for this block.
 
-        :param name: The name of the tag to create.
+        :param name: The name of the tag to create/copy.
         :type name: str
         :param type_: The type of tag.
         :type type_: str
         :param position: Coordinates of the start position
                          in units of the respective data dimension.
+        :param copy_from: The Tag to be copied, None in normal mode
+        :type copy_from: Tag
+        :param keep_copy_id: Specify if the id should be copied in copy mode
+        :type keep_copy_id: bool
 
         :returns: The newly created tag.
         :rtype: Tag
@@ -161,12 +169,12 @@ class Block(Entity):
                           data=None, compression=Compression.Auto,
                           copy_from=None, keep_copy_id=True):
         """
-        Create a new data array for this block. Either ``shape``
+        Create/copy a new data array for this block. Either ``shape``
         or ``data`` must be given. If both are given their shape must agree.
         If ``dtype`` is not specified it will default to 64-bit floating
         points.
 
-        :param name: The name of the data array to create.
+        :param name: The name of the data array to create/copy.
         :type name: str
         :param array_type: The type of the data array.
         :type array_type: str
@@ -178,6 +186,10 @@ class Block(Entity):
         :type data: array-like data
         :param compression: En-/disable dataset compression.
         :type compression: :class:`~nixio.Compression`
+        :param copy_from: The DataArray to be copied, None in normal mode
+        :type copy_from: DataArray
+        :param keep_copy_id: Specify if the id should be copied in copy mode
+        :type keep_copy_id: bool
 
         :returns: The newly created data array.
         :rtype: :class:`~nixio.DataArray`
@@ -216,16 +228,16 @@ class Block(Entity):
             da.write_direct(data)
         return da
 
-    def create_data_frame(self, name="", type_="", col_dict=None, col_names=None,
-                          col_dtypes=None, data=None,
+    def create_data_frame(self, name="", type_="", col_dict=None,
+                          col_names=None, col_dtypes=None, data=None,
                           compression=Compression.No,
                           copy_from=None, keep_copy_id=True):
         """
-         Create a new data frame for this block. Either ``col_dict``
+         Create/copy a new data frame for this block. Either ``col_dict``
          or ``col_name`` and ``col_dtypes`` must be given.
          If both are given, ``col_dict`` will be used.
 
-         :param name: The name of the data frame to create.
+         :param name: The name of the data frame to create/copy.
          :type name: str
          :param type_: The type of the data frame.
          :type type_: str
@@ -241,6 +253,10 @@ class Block(Entity):
                      as specified in the columns
          :param compression: En-/disable dataset compression.
          :type compression: :class:`~nixio.Compression`
+         :param copy_from: The DataFrame to be copied, None in normal mode
+         :type copy_from: DataFrame
+         :param keep_copy_id: Specify if the id should be copied in copy mode
+         :type keep_copy_id: bool
 
          :returns: The newly created data frame.
          :rtype: :class:`~nixio.DataFrame`
@@ -430,11 +446,10 @@ class Block(Entity):
                             "provide a new name when copying destination "
                             "is the same as the source parent")
         o = obj._parent._h5group.copy(source=src, dest=self._h5group,
-                                    name=name, cls=clsname,
-                                    keep_id=keep_id)
+                                      name=name, cls=clsname,
+                                      keep_id=keep_id)
 
         return o.attrs["entity_id"]
-
 
     @property
     def sources(self):

--- a/nixio/block.py
+++ b/nixio/block.py
@@ -350,7 +350,7 @@ class Block(Entity):
     @staticmethod
     def _pp(obj, ml, indent, ex, grp=False):
         spaces = " " * (indent)
-        if grp == True:
+        if grp:
             prefix = "*"
         else:
             prefix = ""
@@ -396,7 +396,7 @@ class Block(Entity):
         clsname = "data_arrays"
         src = "{}/{}".format(clsname, obj.name)
         da = h5_parent._h5group.copy(source=src, dest=self._h5group,
-                                name=str(obj.name), cls=clsname)
+                                     name=str(obj.name), cls=clsname)
 
         if change_id:
             id_ = util.create_id()
@@ -413,7 +413,7 @@ class Block(Entity):
         clsname = "data_frames"
         src = "{}/{}".format(clsname, obj.name)
         df = h5_parent._h5group.copy(source=src, dest=self._h5group,
-                                name=str(obj.name), cls=clsname)
+                                     name=str(obj.name), cls=clsname)
         if change_id:
             id_ = util.create_id()
             df.attrs.modify("entity_id", np.string_(id_))
@@ -429,7 +429,7 @@ class Block(Entity):
         clsname = "multi_tags"
         src = "{}/{}".format(clsname, obj.name)
         mt = h5_parent._h5group.copy(source=src, dest=self._h5group,
-                                name=str(obj.name), cls=clsname)
+                                     name=str(obj.name), cls=clsname)
 
         if change_id:
             id_ = util.create_id()
@@ -446,7 +446,7 @@ class Block(Entity):
         clsname = "tags"
         src = "{}/{}".format(clsname, obj.name)
         tag = h5_parent._h5group.copy(source=src, dest=self._h5group,
-                                name=str(obj.name), cls=clsname)
+                                      name=str(obj.name), cls=clsname)
 
         if change_id:
             id_ = util.create_id()

--- a/nixio/block.py
+++ b/nixio/block.py
@@ -388,45 +388,78 @@ class Block(Entity):
             else:
                 print(n)
 
-    def copy_data_array(self, obj):
+    def copy_data_array(self, obj, change_id=False):
         if not isinstance(obj, DataArray):
             raise TypeError("Object to be copied is not a DataArray")
 
         h5_parent = obj._parent
         clsname = "data_arrays"
         src = "{}/{}".format(clsname, obj.name)
-        h5_parent._h5group.copy(source=src, dest=self._h5group,
+        da = h5_parent._h5group.copy(source=src, dest=self._h5group,
                                 name=str(obj.name), cls=clsname)
 
-    def copy_data_frame(self, obj):
+        if change_id:
+            id_ = util.create_id()
+            da.attrs.modify("entity_id", np.string_(id_))
+            da.visititems(self._change_id)
+
+        return self.data_arrays[obj.name]
+
+    def copy_data_frame(self, obj, change_id=False):
         if not isinstance(obj, DataFrame):
             raise TypeError("Object to be copied is not a DataFrame")
 
         h5_parent = obj._parent
         clsname = "data_frames"
         src = "{}/{}".format(clsname, obj.name)
-        h5_parent._h5group.copy(source=src, dest=self._h5group,
+        df = h5_parent._h5group.copy(source=src, dest=self._h5group,
                                 name=str(obj.name), cls=clsname)
+        if change_id:
+            id_ = util.create_id()
+            df.attrs.modify("entity_id", np.string_(id_))
+            df.visititems(self._change_id)
 
-    def copy_multi_tag(self, obj):
+        return self.data_frames[obj.name]
+
+    def copy_multi_tag(self, obj, change_id=False):
         if not isinstance(obj, MultiTag):
             raise TypeError("Object to be copied is not a MultiTag")
 
         h5_parent = obj._parent
         clsname = "multi_tags"
         src = "{}/{}".format(clsname, obj.name)
-        h5_parent._h5group.copy(source=src, dest=self._h5group,
+        mt = h5_parent._h5group.copy(source=src, dest=self._h5group,
                                 name=str(obj.name), cls=clsname)
 
-    def copy_tag(self, obj):
+        if change_id:
+            id_ = util.create_id()
+            mt.attrs.modify("entity_id", np.string_(id_))
+            mt.visititems(self._change_id)
+
+        return self.multi_tags[obj.name]
+
+    def copy_tag(self, obj, change_id=False):
         if not isinstance(obj, Tag):
             raise TypeError("Object to be copied is not a Tag")
 
         h5_parent = obj._parent
         clsname = "tags"
         src = "{}/{}".format(clsname, obj.name)
-        h5_parent._h5group.copy(source=src, dest=self._h5group,
+        tag = h5_parent._h5group.copy(source=src, dest=self._h5group,
                                 name=str(obj.name), cls=clsname)
+
+        if change_id:
+            id_ = util.create_id()
+            tag.attrs.modify("entity_id", np.string_(id_))
+            tag.visititems(self._change_id)
+
+        return self.tags[obj.name]
+
+    @staticmethod
+    def _change_id(_, grp):
+        if "entity_id" in grp.attrs:
+            id_ = util.create_id()
+            grp.attrs.modify("entity_id", np.string_(id_))
 
     @property
     def sources(self):

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -313,6 +313,21 @@ class File(object):
         # TODO: if same file, set_attr("entity_id", id_)
 
     def copy_section(self, obj, children=True, keep_id=True, name=""):
+        """
+        Copy a section to the file.
+
+        :param obj: The Section to be copied
+        :type obj: Section
+        :param children: Specify if the copy should be recursive
+        :type children: bool
+        :param keep_id: Specify if the id should be kept
+        :type keep_id: bool
+        :param name: Name of copied section, Default is name of source section
+        :type name: str
+
+        :returns: The copied section
+        :rtype: Section
+        """
         if not isinstance(obj, Section):
             raise TypeError("Object to be copied is not a Section")
 
@@ -362,6 +377,10 @@ class File(object):
         :param type_: The type of the block.
         :type type_: str
         :param compression: No, DeflateNormal, Auto (default: Auto)
+        :param copy_from: The Block to be copied, None in normal mode
+        :type copy_from: Block
+        :param keep_copy_id: Specify if the id should be copied in copy mode
+        :type keep_copy_id: bool
 
         :returns: The newly created block.
         :rtype: Block
@@ -381,9 +400,9 @@ class File(object):
                                                 name=name,
                                                 cls=clsname,
                                                 keep_id=keep_copy_id)
+            id_ = b.attrs["entity_id"]
+            return self.blocks[id_]
 
-            id =  b.attrs["entity_id"]
-            return self.blocks[id]
         if name in self._data:
             raise ValueError("Block with the given name already exists!")
         if compression == Compression.Auto:

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -312,7 +312,7 @@ class File(object):
 
         # TODO: if same file, set_attr("entity_id", id_)
 
-    def copy_section(self, obj, children=True, keep_id=True):
+    def copy_section(self, obj, children=True, keep_id=True, name=""):
         if not isinstance(obj, Section):
             raise TypeError("Object to be copied is not a Section")
 
@@ -321,9 +321,16 @@ class File(object):
         else:
             src = "{}/{}".format("metadata", obj.name)
         clsname = "metadata"
-        sec = obj._parent._h5group.copy(source=src, dest=self._h5group,
-                                      name=str(obj.name), cls=clsname,
-                                      shallow=not children, keep_id=keep_id)
+        if not name:
+            name = str(obj.name)
+        sec = self._h5group.open_group("sections", True)
+        if name in sec:
+            raise NameError("Name already exist. Possible solution is to "
+                            "provide a new name when copying destination "
+                            "is the same as the source parent")
+        obj._parent._h5group.copy(source=src, dest=self._h5group,
+                                  name=name, cls=clsname,
+                                  shallow=not children, keep_id=keep_id)
 
         if not children:
             for p in obj.props:
@@ -364,8 +371,14 @@ class File(object):
                 raise TypeError("Object to be copied is not a Block")
             clsname = "data"
             src = "{}/{}".format(clsname, copy_from.name)
+            if not name:
+                name = str(copy_from.name)
+            if name in self._data:
+                raise NameError("Name already exist. Possible solution is to "
+                                "provide a new name when copying destination "
+                                "is the same as the source parent")
             b = copy_from._parent._h5group.copy(source=src, dest=self._h5group,
-                                                name=str(copy_from.name),
+                                                name=name,
                                                 cls=clsname,
                                                 keep_id=keep_copy_id)
 

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -310,6 +310,28 @@ class File(object):
             print("No errors found: The file is a valid NIX file")
             return errors
 
+        # TODO: if same file, set_attr("entity_id", id_)
+
+    def copy_block(self, obj):
+        if not isinstance(obj, Block):
+            raise TypeError("Object to be copied is not a Block")
+
+        h5_parent = obj._parent
+        clsname = "data"
+        src = "{}/{}".format(clsname, obj.name)
+        h5_parent._h5group.copy(source=src, dest=self._h5group,
+                                name=str(obj.name), cls=clsname)
+
+    def copy_section(self, obj):
+        if not isinstance(obj, Section):
+            raise TypeError("Object to be copied is not a Section")
+
+        h5_parent = obj._parent
+        clsname = "metadata"
+        src = "{}/{}".format(clsname, obj.name)
+        h5_parent._h5group.copy(source=src, dest=self._h5group,
+                                name=str(obj.name), cls=clsname)
+
     def flush(self):
         self._h5file.flush()
 

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -312,7 +312,7 @@ class File(object):
 
         # TODO: if same file, set_attr("entity_id", id_)
 
-    def copy_block(self, obj, change_id=False):
+    def copy_block(self, obj, keep_id=True):
         if not isinstance(obj, Block):
             raise TypeError("Object to be copied is not a Block")
 
@@ -321,7 +321,7 @@ class File(object):
         src = "{}/{}".format(clsname, obj.name)
         b = h5_parent._h5group.copy(source=src, dest=self._h5group,
                                     name=str(obj.name), cls=clsname)
-        if change_id:
+        if not keep_id:
             def change_id(_, grp):
                 if "entity_id" in grp.attrs:
                     id_ = util.create_id()
@@ -333,7 +333,7 @@ class File(object):
 
         return self.blocks[obj.name]
 
-    def copy_section(self, obj, change_id=False):
+    def copy_section(self, obj, children=True, keep_id=True):
         if not isinstance(obj, Section):
             raise TypeError("Object to be copied is not a Section")
 
@@ -344,9 +344,14 @@ class File(object):
             src = "{}/{}".format("metadata", obj.name)
         clsname = "metadata"
         sec = h5_parent._h5group.copy(source=src, dest=self._h5group,
-                                      name=str(obj.name), cls=clsname)
+                                      name=str(obj.name),
+                                      cls=clsname, shallow=not children)
 
-        if change_id:
+        if not children:
+            for p in obj.props:
+                self.sections[obj.name].copy_property(p, keep_id)
+
+        if not keep_id:
             def change_id(_, grp):
                 if "entity_id" in grp.attrs:
                     id_ = util.create_id()

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -327,8 +327,11 @@ class File(object):
             raise TypeError("Object to be copied is not a Section")
 
         h5_parent = obj._parent
+        if obj._sec_parent:
+            src = "{}/{}".format("sections", obj.name)
+        else:
+            src = "{}/{}".format("metadata", obj.name)
         clsname = "metadata"
-        src = "{}/{}".format(clsname, obj.name)
         h5_parent._h5group.copy(source=src, dest=self._h5group,
                                 name=str(obj.name), cls=clsname)
 

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -320,7 +320,7 @@ class File(object):
         clsname = "data"
         src = "{}/{}".format(clsname, obj.name)
         b = h5_parent._h5group.copy(source=src, dest=self._h5group,
-                                name=str(obj.name), cls=clsname)
+                                    name=str(obj.name), cls=clsname)
         if change_id:
             def change_id(_, grp):
                 if "entity_id" in grp.attrs:
@@ -344,7 +344,7 @@ class File(object):
             src = "{}/{}".format("metadata", obj.name)
         clsname = "metadata"
         sec = h5_parent._h5group.copy(source=src, dest=self._h5group,
-                                name=str(obj.name), cls=clsname)
+                                      name=str(obj.name), cls=clsname)
 
         if change_id:
             def change_id(_, grp):

--- a/nixio/hdf5/h5group.py
+++ b/nixio/hdf5/h5group.py
@@ -290,10 +290,10 @@ class H5Group(object):
         g = dest_grp[name]
         g.attrs["name"] = name
         if not keep_id:
-            def change_id(_, grp):
-                if "entity_id" in grp.attrs:
+            def change_id(_, igrp):
+                if "entity_id" in igrp.attrs:
                     id_ = util.create_id()
-                    grp.attrs.modify("entity_id", np.string_(id_))
+                    igrp.attrs.modify("entity_id", np.string_(id_))
             id_ = util.create_id()
             g.attrs.modify("entity_id", np.string_(id_))
             g.visititems(change_id)

--- a/nixio/hdf5/h5group.py
+++ b/nixio/hdf5/h5group.py
@@ -288,6 +288,7 @@ class H5Group(object):
         grp.copy(source=source, dest=dest_grp, name=name, shallow=shallow)
 
         g = dest_grp[name]
+        g.attrs["name"] = name
         if not keep_id:
             def change_id(_, grp):
                 if "entity_id" in grp.attrs:

--- a/nixio/hdf5/h5group.py
+++ b/nixio/hdf5/h5group.py
@@ -280,8 +280,7 @@ class H5Group(object):
         return result
 
     def copy(self, source, dest, name=None, cls=None):
-
-        grp =self.group
+        grp = self.group
         dest.open_group(cls, create=True)
         dest_grp = dest.group[cls]
         grp.copy(source=source, dest=dest_grp, name=name)

--- a/nixio/hdf5/h5group.py
+++ b/nixio/hdf5/h5group.py
@@ -284,6 +284,7 @@ class H5Group(object):
         dest.open_group(cls, create=True)
         dest_grp = dest.group[cls]
         grp.copy(source=source, dest=dest_grp, name=name)
+        return dest_grp[name]
 
     @property
     def file(self):

--- a/nixio/hdf5/h5group.py
+++ b/nixio/hdf5/h5group.py
@@ -279,11 +279,11 @@ class H5Group(object):
         self.group.visititems(match)
         return result
 
-    def copy(self, source, dest, name=None, cls=None):
+    def copy(self, source, dest, name=None, cls=None, shallow=False):
         grp = self.group
         dest.open_group(cls, create=True)
         dest_grp = dest.group[cls]
-        grp.copy(source=source, dest=dest_grp, name=name)
+        grp.copy(source=source, dest=dest_grp, name=name, shallow=shallow)
         return dest_grp[name]
 
     @property

--- a/nixio/hdf5/h5group.py
+++ b/nixio/hdf5/h5group.py
@@ -279,6 +279,13 @@ class H5Group(object):
         self.group.visititems(match)
         return result
 
+    def copy(self, source, dest, name=None, cls=None):
+
+        grp =self.group
+        dest.open_group(cls, create=True)
+        dest_grp = dest.group[cls]
+        grp.copy(source=source, dest=dest_grp, name=name)
+
     @property
     def file(self):
         """

--- a/nixio/section.py
+++ b/nixio/section.py
@@ -93,13 +93,17 @@ class Section(Entity):
         """
         Add a new property to the section.
 
-        :param name: The name of the property to create.
+        :param name: The name of the property to create/copy.
         :type name: str
         :param values_or_dtype: The values of the property or a valid DataType.
         :type values_or_dtype: list of values or a DataType
         :param oid: object id, UUID string as specified in RFC 4122. If no id
                     is provided, an id will be generated and assigned.
         :type oid: str
+        :param copy_from: The Property to be copied, None in normal mode
+        :type copy_from: Property
+        :param keep_copy_id: Specify if the id should be copied in copy mode
+        :type keep_copy_id: bool
 
         :returns: The newly created property.
         :rtype: Property
@@ -121,8 +125,8 @@ class Section(Entity):
                                                 cls=clsname,
                                                 keep_id=keep_copy_id)
 
-            id = p.attrs["entity_id"]
-            return self.props[id]
+            id_ = p.attrs["entity_id"]
+            return self.props[id_]
 
         vals = values_or_dtype
 
@@ -170,6 +174,21 @@ class Section(Entity):
         return prop
 
     def copy_section(self, obj, children=True, keep_id=True, name=""):
+        """
+        Copy a section to the section.
+
+        :param obj: The Section to be copied
+        :type obj: Section
+        :param children: Specify if the copy should be recursive
+        :type children: bool
+        :param keep_id: Specify if the id should be kept
+        :type keep_id: bool
+        :param name: Name of copied section, Default is name of source section
+        :type name: str
+
+        :returns: The copied section
+        :rtype: Section
+        """
         if not isinstance(obj, Section):
             raise TypeError("Object to be copied is not a Section")
 
@@ -187,8 +206,8 @@ class Section(Entity):
                             "provide a new name when copying destination "
                             "is the same as the source parent")
         sec = obj._parent._h5group.copy(source=src, dest=self._h5group,
-                                    name=name, cls=clsname,
-                                    keep_id=keep_id)
+                                        name=name, cls=clsname,
+                                        keep_id=keep_id)
 
         if not children:
             for p in obj.props:

--- a/nixio/section.py
+++ b/nixio/section.py
@@ -450,3 +450,27 @@ class Section(Entity):
                 print("{} {} [{}]\n{}[...]".format(child_sec_indent,
                                                    s.name, s.type,
                                                    more_indent))
+
+    def copy_section(self, obj):
+        if not isinstance(obj, Section):
+            raise TypeError("Object to be copied is not a Section")
+
+        h5_parent = obj._parent
+        if obj._sec_parent:
+            src = "{}/{}".format("sections", obj.name)
+        else:
+            src = "{}/{}".format("metadata", obj.name)
+
+        clsname = "sections"
+        h5_parent._h5group.copy(source=src, dest=self._h5group,
+                                name=str(obj.name), cls=clsname)
+
+    def copy_property(self, obj):
+        if not isinstance(obj, Property):
+            raise TypeError("Object to be copied is not a Property")
+
+        h5_parent = obj._parent
+        clsname = "properties"
+        src = "{}/{}".format(clsname, obj.name)
+        h5_parent._h5group.copy(source=src, dest=self._h5group,
+                                name=str(obj.name), cls=clsname)

--- a/nixio/section.py
+++ b/nixio/section.py
@@ -463,7 +463,7 @@ class Section(Entity):
 
         clsname = "sections"
         sec = h5_parent._h5group.copy(source=src, dest=self._h5group,
-                                name=str(obj.name), cls=clsname)
+                                      name=str(obj.name), cls=clsname)
         if change_id:
             id_ = util.create_id()
             sec.attrs.modify("entity_id", np.string_(id_))
@@ -479,7 +479,7 @@ class Section(Entity):
         clsname = "properties"
         src = "{}/{}".format(clsname, obj.name)
         p = h5_parent._h5group.copy(source=src, dest=self._h5group,
-                                name=str(obj.name), cls=clsname)
+                                    name=str(obj.name), cls=clsname)
         if change_id:
             id_ = util.create_id()
             p.attrs.modify("entity_id", np.string_(id_))

--- a/nixio/section.py
+++ b/nixio/section.py
@@ -451,7 +451,7 @@ class Section(Entity):
                                                    s.name, s.type,
                                                    more_indent))
 
-    def copy_section(self, obj, change_id=False):
+    def copy_section(self, obj, children=True, keep_id=True):
         if not isinstance(obj, Section):
             raise TypeError("Object to be copied is not a Section")
 
@@ -463,15 +463,17 @@ class Section(Entity):
 
         clsname = "sections"
         sec = h5_parent._h5group.copy(source=src, dest=self._h5group,
-                                      name=str(obj.name), cls=clsname)
-        if change_id:
+                                      name=str(obj.name),
+                                      cls=clsname, shallow=not children)
+
+        if not keep_id:
             id_ = util.create_id()
             sec.attrs.modify("entity_id", np.string_(id_))
             sec.visititems(self._change_id)
 
         return self.sections[obj.name]
 
-    def copy_property(self, obj, change_id=False):
+    def copy_property(self, obj, keep_id=True):
         if not isinstance(obj, Property):
             raise TypeError("Object to be copied is not a Property")
 
@@ -480,7 +482,7 @@ class Section(Entity):
         src = "{}/{}".format(clsname, obj.name)
         p = h5_parent._h5group.copy(source=src, dest=self._h5group,
                                     name=str(obj.name), cls=clsname)
-        if change_id:
+        if not keep_id:
             id_ = util.create_id()
             p.attrs.modify("entity_id", np.string_(id_))
             p.visititems(self._change_id)

--- a/nixio/section.py
+++ b/nixio/section.py
@@ -109,8 +109,15 @@ class Section(Entity):
                 raise TypeError("Object to be copied is not a Property")
             clsname = "properties"
             src = "{}/{}".format(clsname, copy_from.name)
+            if not name:
+                name = str(copy_from.name)
+            properties = self._h5group.open_group("properties", True)
+            if name in properties:
+                raise NameError("Name already exist. Possible solution is to "
+                                "provide a new name when copying destination "
+                                "is the same as the source parent")
             p = copy_from._parent._h5group.copy(source=src, dest=self._h5group,
-                                                name=str(copy_from.name),
+                                                name=name,
                                                 cls=clsname,
                                                 keep_id=keep_copy_id)
 
@@ -162,7 +169,7 @@ class Section(Entity):
 
         return prop
 
-    def copy_section(self, obj, children=True, keep_id=True):
+    def copy_section(self, obj, children=True, keep_id=True, name=""):
         if not isinstance(obj, Section):
             raise TypeError("Object to be copied is not a Section")
 
@@ -172,8 +179,15 @@ class Section(Entity):
             src = "{}/{}".format("metadata", obj.name)
 
         clsname = "sections"
+        if not name:
+            name = str(obj.name)
+        sec = self._h5group.open_group("sections", True)
+        if name in sec:
+            raise NameError("Name already exist. Possible solution is to "
+                            "provide a new name when copying destination "
+                            "is the same as the source parent")
         sec = obj._parent._h5group.copy(source=src, dest=self._h5group,
-                                    name=str(obj.name), cls=clsname,
+                                    name=name, cls=clsname,
                                     keep_id=keep_id)
 
         if not children:

--- a/nixio/test/test_block.py
+++ b/nixio/test/test_block.py
@@ -185,3 +185,36 @@ class TestBlock(unittest.TestCase):
         del self.block.groups[0]
 
         assert(len(self.block.groups) == 0)
+
+    def test_copy_on_block(self):
+        tar_filename = os.path.join(self.tmpdir.path, "copytarget.nix")
+        tar_file = nix.File.open(tar_filename, nix.FileMode.Overwrite)
+        blk2 = tar_file.create_block("blk2", "blk")
+        data = [(1, 2, 3), (4, 5, 6)]
+        da = self.block.create_data_array("da1", 'grp da1', data=data)
+        mt = self.block.create_multi_tag("mt1", "some mt", da)
+        namelist = ['name', 'id', 'time']
+        dtlist = [nix.DataType.Int64, str,
+                           nix.DataType.Float]
+        arr = [(1, "cat", 20.18), (2, 'dog', 20.15), (2, 'dog', 20.15)]
+        df = self.block.create_data_frame('test1', 'for_test', col_names=namelist,
+                                   col_dtypes=dtlist, data=arr)
+        tag = self.block.create_tag("a tag", "some tag", position=(4, 5, 6))
+        blk2.create_multi_tag(copy_from=mt)
+        blk2.create_data_array(copy_from=da)
+        blk2.create_data_frame(copy_from=df)
+        blk2.create_tag(copy_from=tag)
+        assert mt == blk2.multi_tags[0]
+        assert da == blk2.data_arrays[0]
+        assert df == blk2.data_frames[0]
+        assert tag == blk2.tags[0]
+        tar_file.close()
+        self.block.create_data_array("da2", 'grp da2', data=[(1, 2, 3)])
+        da2 = self.block.data_arrays[1]
+        mt2 = self.block.multi_tags[0]
+        self.assertRaises(NameError, lambda: self.block.create_data_array(
+            copy_from=da2))
+        self.block.create_data_array(name="new da name", copy_from=da2)
+        self.block.create_multi_tag(name="new mt name", copy_from=mt2)
+        assert self.block.multi_tags[0] == mt2
+        assert self.block.data_arrays[1] == da2

--- a/nixio/test/test_block.py
+++ b/nixio/test/test_block.py
@@ -195,10 +195,11 @@ class TestBlock(unittest.TestCase):
         mt = self.block.create_multi_tag("mt1", "some mt", da)
         namelist = ['name', 'id', 'time']
         dtlist = [nix.DataType.Int64, str,
-                           nix.DataType.Float]
+                  nix.DataType.Float]
         arr = [(1, "cat", 20.18), (2, 'dog', 20.15), (2, 'dog', 20.15)]
-        df = self.block.create_data_frame('test1', 'for_test', col_names=namelist,
-                                   col_dtypes=dtlist, data=arr)
+        df = self.block.create_data_frame('test1', 'for_test',
+                                          col_names=namelist,
+                                          col_dtypes=dtlist, data=arr)
         tag = self.block.create_tag("a tag", "some tag", position=(4, 5, 6))
         blk2.create_multi_tag(copy_from=mt)
         blk2.create_data_array(copy_from=da)

--- a/nixio/test/test_file.py
+++ b/nixio/test/test_file.py
@@ -135,6 +135,36 @@ class TestFile(unittest.TestCase):
         with nix.File.open(fname, nix.FileMode.ReadOnly) as nf:
             self.assertEqual(nf.blocks[0].name, "blocky")
 
+    def test_copy_on_file(self):
+        tar_filename = os.path.join(self.tmpdir.path, "copytarget.nix")
+        tar_file = nix.File.open(tar_filename, nix.FileMode.Overwrite)
+        blk1 = self.file.create_block("t111t bk", "testcopy")
+        blk2 = tar_file.create_block("blk2", "blk")
+        blk1.create_data_array("da1", 'grp da1', data=[(1,2,3)])
+        da2 = blk2.create_data_array("da2", 'grp da2', data=[(4,5,6)])
+        blk2.create_multi_tag("mt2", "useless", da2)
+        sec1 = self.file.create_section("test sec", 'test')
+        sec1.create_section("child sec", "child")
+        ori_prop = sec1.create_property("prop origin", values_or_dtype=[1,2,3])
+        tar_file.create_block(copy_from=blk1, keep_copy_id=False)
+        copied_sec = tar_file.copy_section(sec1, children=False, keep_id=True)
+        assert tar_file.sections[0].name == sec1.name
+        assert tar_file.blocks[1].name == blk1.name
+        assert tar_file.blocks[1].data_arrays[0].name == blk1.data_arrays[0].name
+        assert tar_file.blocks[1].data_arrays[0].id != blk1.data_arrays[0].id
+        assert tar_file.sections[0] == sec1
+        assert len(self.file.find_sections()) == 2
+        assert len(tar_file.find_sections()) == 1
+        assert copied_sec.props[0] == ori_prop # Properties are still there
+        assert not copied_sec.sections # children is False
+        tar_file.close()
+        # test copying on the same file
+        self.assertRaises(NameError, lambda: self.file.create_block(
+            copy_from=blk1))
+        self.file.create_block(name="111", copy_from=blk1)
+        assert self.file.blocks[0] == self.file.blocks[1]  # ID stays the same
+        assert self.file.blocks[0].name != self.file.blocks[1].name
+
 
 class TestFileVer(unittest.TestCase):
 
@@ -214,3 +244,4 @@ class TestFileVer(unittest.TestCase):
         self.set_header(fformat="NOT_A_NIX_FILE")
         with self.assertRaises(InvalidFile):
             self.try_open(nix.FileMode.ReadOnly)
+

--- a/nixio/test/test_file.py
+++ b/nixio/test/test_file.py
@@ -140,23 +140,25 @@ class TestFile(unittest.TestCase):
         tar_file = nix.File.open(tar_filename, nix.FileMode.Overwrite)
         blk1 = self.file.create_block("t111t bk", "testcopy")
         blk2 = tar_file.create_block("blk2", "blk")
-        blk1.create_data_array("da1", 'grp da1', data=[(1,2,3)])
-        da2 = blk2.create_data_array("da2", 'grp da2', data=[(4,5,6)])
+        blk1.create_data_array("da1", 'grp da1', data=[(1, 2, 3)])
+        da2 = blk2.create_data_array("da2", 'grp da2', data=[(4, 5, 6)])
         blk2.create_multi_tag("mt2", "useless", da2)
         sec1 = self.file.create_section("test sec", 'test')
         sec1.create_section("child sec", "child")
-        ori_prop = sec1.create_property("prop origin", values_or_dtype=[1,2,3])
+        ori_prop = sec1.create_property("prop origin",
+                                        values_or_dtype=[1, 2, 3])
         tar_file.create_block(copy_from=blk1, keep_copy_id=False)
         copied_sec = tar_file.copy_section(sec1, children=False, keep_id=True)
         assert tar_file.sections[0].name == sec1.name
         assert tar_file.blocks[1].name == blk1.name
-        assert tar_file.blocks[1].data_arrays[0].name == blk1.data_arrays[0].name
+        assert tar_file.blocks[1].data_arrays[0].name \
+            == blk1.data_arrays[0].name
         assert tar_file.blocks[1].data_arrays[0].id != blk1.data_arrays[0].id
         assert tar_file.sections[0] == sec1
         assert len(self.file.find_sections()) == 2
         assert len(tar_file.find_sections()) == 1
-        assert copied_sec.props[0] == ori_prop # Properties are still there
-        assert not copied_sec.sections # children is False
+        assert copied_sec.props[0] == ori_prop  # Properties are still there
+        assert not copied_sec.sections  # children is False
         tar_file.close()
         # test copying on the same file
         self.assertRaises(NameError, lambda: self.file.create_block(

--- a/nixio/test/test_section.py
+++ b/nixio/test/test_section.py
@@ -296,3 +296,21 @@ class TestSections(unittest.TestCase):
 
         inhpropnames = [p.name for p in self.other.inherited_properties()]
         self.assertIn("PropOnSection", inhpropnames)
+
+    # Test for copying props and sections on sections
+    def test_copy_on_sections(self):
+        tarfilename = os.path.join(self.tmpdir.path, "destination.nix")
+        tarfile = nix.File.open(tarfilename, nix.FileMode.Overwrite)
+        sec1 = self.section
+        prop1 = sec1.create_property("prop from origin",
+                                     values_or_dtype=[1, 2, 3])
+        sec2 = sec1.create_section("nested sec", 'test nested')
+        tarsec = tarfile.create_section("tar sec", "tar")
+        tarsec.create_property(copy_from=prop1)
+        assert prop1 == tarsec.props[0]
+        tarsec.copy_section(sec1)
+        tarsec.copy_section(sec2)
+        assert sec1 == tarsec.sections[0]
+        assert sec2 == tarsec.sections[1]
+        assert sec1.sections[0] == tarsec.sections[1]
+        tarfile.close()

--- a/nixio/util/util.py
+++ b/nixio/util/util.py
@@ -168,3 +168,4 @@ def link_type_from_string(ltstr):
         return LinkType.Untagged
     else:
         raise RuntimeError("Invalid string for LinkType")
+

--- a/nixio/util/util.py
+++ b/nixio/util/util.py
@@ -168,4 +168,3 @@ def link_type_from_string(ltstr):
         return LinkType.Untagged
     else:
         raise RuntimeError("Invalid string for LinkType")
-


### PR DESCRIPTION
Refer to the Issue #367 

This PR adds a function on the entity level to allow copying NIX objects between files. This copy is recursive and the data in the objects is also carried over.

The UUID will always be carried over.

Definitely need some tests.

How should one deal with the links to the group in the block is opened to discussion. (I have never tried just copying a non-empty group without copying the contents in the block)