### PR TITLE
Change all Appveyor URLs to point to G-Node builds

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 .. image:: https://travis-ci.org/G-Node/nixpy.svg?branch=master
     :target: https://travis-ci.org/G-Node/nixpy
-.. image:: https://ci.appveyor.com/api/projects/status/nrsgupr9ura3vli3?svg=true
-    :target: https://ci.appveyor.com/project/achilleas-k/nixpy-um2sy
+.. image:: https://ci.appveyor.com/api/projects/status/72l10ooxbvf0vfgd/branch/master?svg=true
+    :target: https://ci.appveyor.com/project/G-Node/nixpy
 .. image:: https://coveralls.io/repos/github/G-Node/nixpy/badge.svg?branch=master
     :target: https://coveralls.io/github/G-Node/nixpy?branch=master
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
   BOOST_INCDIR: C:\Libraries\boost_1_67_0\lib64-msvc-14.1
   BOOST_LIBDIR: C:\Libraries\boost_1_67_0\lib64-msvc-14.1
 
-  NIX_APPVEYOR_ROOT: https://ci.appveyor.com/api/projects/stoewer/nix/artifacts/build
+  NIX_APPVEYOR_ROOT: https://ci.appveyor.com/api/projects/G-Node/nix/artifacts/build
 
 
   matrix:


### PR DESCRIPTION
Since we created the G-Node user on Appveyor and moved all official builds to that user, badges and links should be taken from that build. The NIX artifact URL isn't currently used in the appveyor.yml, but it will once we get compatibility tests working on Windows.