### PR TITLE
Inverse search fix

### DIFF
--- a/nixio/section.py
+++ b/nixio/section.py
@@ -259,7 +259,8 @@ class Section(Entity):
     @property
     def referring_blocks(self):
         f = self.file
-        return list(blk for blk in f.blocks if blk.metadata.id == self.id)
+        return list(blk for blk in f.blocks
+                    if blk.metadata is not None and blk.metadata.id == self.id)
 
     @property
     def referring_groups(self):
@@ -267,7 +268,8 @@ class Section(Entity):
         groups = []
         for blk in f.blocks:
             groups.extend(grp for grp in blk.groups
-                          if grp.metadata.id == self.id)
+                          if (grp.metadata is not None and
+                              grp.metadata.id == self.id))
         return groups
 
     @property
@@ -276,7 +278,8 @@ class Section(Entity):
         data_arrays = []
         for blk in f.blocks:
             data_arrays.extend(da for da in blk.data_arrays
-                               if da.metadata.id == self.id)
+                               if (da.metadata is not None and
+                                   da.metadata.id == self.id))
         return data_arrays
 
     @property
@@ -285,7 +288,8 @@ class Section(Entity):
         tags = []
         for blk in f.blocks:
             tags.extend(tg for tg in blk.tags
-                        if tg.metadata.id == self.id)
+                        if (tg.metadata is not None and
+                            tg.metadata.id == self.id))
         return tags
 
     @property
@@ -294,7 +298,8 @@ class Section(Entity):
         multi_tags = []
         for blk in f.blocks:
             multi_tags.extend(mt for mt in blk.multi_tags
-                              if mt.metadata.id == self.id)
+                              if (mt.metadata is not None and
+                                  mt.metadata.id == self.id))
         return multi_tags
 
     @property
@@ -303,7 +308,8 @@ class Section(Entity):
         sources = []
         for blk in f.blocks:
             sources.extend(src for src in blk.sources
-                           if src.metadata.id == self.id)
+                           if (src.metadata is not None and
+                               src.metadata.id == self.id))
         return sources
 
     def find_sections(self, filtr=lambda _: True, limit=None):

--- a/nixio/test/test_section.py
+++ b/nixio/test/test_section.py
@@ -238,6 +238,8 @@ class TestSections(unittest.TestCase):
         otherblock = self.file.create_block("b block", "block with metadata")
         otherblock.metadata = self.other
 
+        self.file.create_block("c block", "block without metadata")
+
         self.assertEqual(len(self.section.referring_blocks), 1)
         self.assertEqual(len(self.other.referring_blocks), 1)
         self.assertEqual(self.section.referring_blocks[0], block)
@@ -248,24 +250,30 @@ class TestSections(unittest.TestCase):
         da_two = block.create_data_array("foobar", "data_array", data=[1])
         da_two.metadata = self.other
 
+        block.create_data_array("nomd", "data_array", data=[9])
+
         self.assertEqual(len(self.other.referring_data_arrays), 2)
         self.assertIn(da_one, self.other.referring_data_arrays)
         self.assertIn(da_two, self.other.referring_data_arrays)
 
         tag = block.create_tag("tago", "tagtype", [1, 1])
         tag.metadata = self.section
+
+        block.create_tag("tagi", "tagtype", [1, 10])
         self.assertEqual(len(self.section.referring_tags), 1)
         self.assertEqual(len(self.other.referring_tags), 0)
         self.assertEqual(self.section.referring_tags[0].id, tag.id)
 
         mtag = block.create_multi_tag("MultiTagName", "MultiTagType", da_one)
         mtag.metadata = self.section
+        block.create_multi_tag("MtagNOMD", "MultiTagType", da_one)
         self.assertEqual(len(self.section.referring_multi_tags), 1)
         self.assertEqual(len(self.other.referring_multi_tags), 0)
         self.assertEqual(self.section.referring_multi_tags[0].id, mtag.id)
 
         src = block.create_source("sauce", "stype")
         src.metadata = self.other
+        block.create_source("nosauce", "stype")
         self.assertEqual(len(self.other.referring_sources), 1)
         self.assertEqual(len(self.section.referring_sources), 0)
         self.assertEqual(self.other.referring_sources[0].id, src.id)


### PR DESCRIPTION
Found (and fixed) a bug in the inverse search when there were objects in the file that did not have a metadata link.