### PR TITLE
Add auto-time-update flag to NIXpy file

### DIFF
--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -89,6 +89,8 @@ class DataArray(Entity, DataSet):
         setdim = SetDimension._create_new(dimgroup, index)
         if labels:
             setdim.labels = labels
+        if self._parent._parent.time_auto_update:
+            self.force_updated_at()
         return setdim
 
     def append_sampled_dimension(self, sampling_interval, label=None,
@@ -114,6 +116,8 @@ class DataArray(Entity, DataSet):
             smpldim.unit = unit
         if offset:
             smpldim.offset = offset
+        if self._parent._parent.time_auto_update:
+            self.force_updated_at()
         return smpldim
 
     def append_range_dimension(self, ticks, label=None, unit=None):
@@ -133,6 +137,8 @@ class DataArray(Entity, DataSet):
         if label:
             rdim.label = label
             rdim.unit = unit
+        if self._parent._parent.time_auto_update:
+            self.force_updated_at()
         return rdim
 
     def append_alias_range_dimension(self):
@@ -218,6 +224,8 @@ class DataArray(Entity, DataSet):
         else:
             dtype = DataType.Double
             self._h5group.write_data("polynom_coefficients", coeff, dtype)
+        if self._parent._parent.time_auto_update:
+            self.force_updated_at()
 
     @property
     def expansion_origin(self):
@@ -234,6 +242,8 @@ class DataArray(Entity, DataSet):
     def expansion_origin(self, eo):
         util.check_attr_type(eo, Number)
         self._h5group.set_attr("expansion_origin", eo)
+        if self._parent._parent.time_auto_update:
+            self.force_updated_at()
 
     @property
     def label(self):
@@ -250,6 +260,8 @@ class DataArray(Entity, DataSet):
     def label(self, l):
         util.check_attr_type(l, str)
         self._h5group.set_attr("label", l)
+        if self._parent._parent.time_auto_update:
+            self.force_updated_at()
 
     @property
     def unit(self):
@@ -278,6 +290,8 @@ class DataArray(Entity, DataSet):
                     "DataArray.unit"
                 )
         self._h5group.set_attr("unit", u)
+        if self._parent._parent.time_auto_update:
+            self.force_updated_at()
 
     def get_slice(self, positions, extents=None, mode=DataSliceMode.Index):
         datadim = len(self.shape)

--- a/nixio/data_frame.py
+++ b/nixio/data_frame.py
@@ -309,6 +309,8 @@ class DataFrame(Entity, DataSet):
             util.check_attr_type(i, str)
         u = np.array(u, dtype=util.vlen_str_dtype)
         self._h5group.set_attr("units", u)
+        if self._parent._parent.time_auto_update:
+            self.force_updated_at()
 
     @property
     def columns(self):

--- a/nixio/entity.py
+++ b/nixio/entity.py
@@ -108,6 +108,8 @@ class Entity(object):
     def definition(self, d):
         util.check_attr_type(d, str)
         self._h5group.set_attr("definition", d)
+        if self._h5group.group.file.attrs["time_auto_update"]:
+            self.force_updated_at()
 
     @property
     def name(self):
@@ -137,6 +139,8 @@ class Entity(object):
             raise AttributeError("type can't be None")
         util.check_attr_type(t, str)
         self._h5group.set_attr("type", t)
+        if self._h5group.group.file.attrs["time_auto_update"]:
+            self.force_updated_at()
 
     def __eq__(self, other):
         """

--- a/nixio/entity.py
+++ b/nixio/entity.py
@@ -108,7 +108,10 @@ class Entity(object):
     def definition(self, d):
         util.check_attr_type(d, str)
         self._h5group.set_attr("definition", d)
-        if self._h5group.group.file.attrs["time_auto_update"]:
+        par = self._parent
+        while isinstance(par, Entity):
+            par = par._parent
+        if par.time_auto_update:
             self.force_updated_at()
 
     @property
@@ -139,7 +142,10 @@ class Entity(object):
             raise AttributeError("type can't be None")
         util.check_attr_type(t, str)
         self._h5group.set_attr("type", t)
-        if self._h5group.group.file.attrs["time_auto_update"]:
+        par = self._parent
+        while isinstance(par, Entity):
+            par = par._parent
+        if par.time_auto_update:
             self.force_updated_at()
 
     def __eq__(self, other):

--- a/nixio/feature.py
+++ b/nixio/feature.py
@@ -34,6 +34,8 @@ class Feature(Entity):
     @link_type.setter
     def link_type(self, lt):
         self._h5group.set_attr("link_type", util.link_type_to_string(lt))
+        if self._parent._parent.time_auto_update:
+            self.force_updated_at()
 
     @property
     def data(self):
@@ -52,4 +54,5 @@ class Feature(Entity):
         if "data" in self._h5group:
             del self._h5group["data"]
         self._h5group.create_link(da, "data")
-        self.force_updated_at()
+        if self._parent._parent.time_auto_update:
+            self.force_updated_at()

--- a/nixio/feature.py
+++ b/nixio/feature.py
@@ -34,7 +34,7 @@ class Feature(Entity):
     @link_type.setter
     def link_type(self, lt):
         self._h5group.set_attr("link_type", util.link_type_to_string(lt))
-        if self._parent._parent.time_auto_update:
+        if self._parent._parent._parent.time_auto_update:
             self.force_updated_at()
 
     @property
@@ -54,5 +54,5 @@ class Feature(Entity):
         if "data" in self._h5group:
             del self._h5group["data"]
         self._h5group.create_link(da, "data")
-        if self._parent._parent.time_auto_update:
+        if self._parent._parent._parent.time_auto_update:
             self.force_updated_at()

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -216,8 +216,8 @@ class File(object):
         return self._time_auto_update
 
     @time_auto_update.setter
-    def time_auto_update(self, bool):
-        self._time_auto_update = bool
+    def time_auto_update(self, auto_update_flag):
+        self._time_auto_update = auto_update_flag
 
     @property
     def created_at(self):

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -119,7 +119,7 @@ class File(object):
         self._h5file = h5py.File(fid)
         self._root = H5Group(self._h5file, "/", create=True)
         self._h5group = self._root  # to match behaviour of other objects
-        self.time_auto_update = True
+        self._time_auto_update = True
         if new:
             self._create_header()
         self._check_header(mode)
@@ -131,8 +131,6 @@ class File(object):
         if "updated_at" not in self._h5file.attrs:
             self.force_updated_at()
         self.time_auto_update = auto_update_time
-        if mode != FileMode.ReadOnly:
-            self._h5file.attrs["time_auto_update"] = auto_update_time
         if compression == Compression.Auto:
             compression = Compression.No
         self._compr = compression
@@ -146,14 +144,6 @@ class File(object):
         if backend is not None:
             warn("Backend selection is deprecated. Ignoring value.")
         return cls(path, mode, compression, auto_update_time)
-
-    def time_auto_update_off(self):
-        self.time_auto_update = False
-        self._h5file.attrs["time_auto_update"] = self.time_auto_update
-
-    def time_auto_update_on(self):
-        self.time_auto_update = True
-        self._h5file.attrs["time_auto_update"] = self.time_auto_update
 
     def _create_header(self):
         self.format = FILE_FORMAT
@@ -214,6 +204,20 @@ class File(object):
         self._root.set_attr("format", f.encode("ascii"))
         if self.time_auto_update:
             self.force_updated_at()
+
+    @property
+    def time_auto_update(self):
+        """
+        A user defined flag which decided if time should always be updated
+        when properties are changed.
+
+        :type: bool
+        """
+        return self._time_auto_update
+
+    @time_auto_update.setter
+    def time_auto_update(self, bool):
+        self._time_auto_update = bool
 
     @property
     def created_at(self):

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -130,8 +130,8 @@ class File(object):
             self.force_created_at()
         if "updated_at" not in self._h5file.attrs:
             self.force_updated_at()
-            self.time_auto_update = auto_update_time
-        if "time_auto_update" not in self._h5file.attrs:
+        self.time_auto_update = auto_update_time
+        if mode != FileMode.ReadOnly:
             self._h5file.attrs["time_auto_update"] = auto_update_time
         if compression == Compression.Auto:
             compression = Compression.No

--- a/nixio/multi_tag.py
+++ b/nixio/multi_tag.py
@@ -52,7 +52,8 @@ class MultiTag(BaseTag):
         if "positions" in self._h5group:
             del self._h5group["positions"]
         self._h5group.create_link(da, "positions")
-        self.force_updated_at()
+        if self._parent._parent.time_auto_update:
+            self.force_updated_at()
 
     @property
     def extents(self):
@@ -73,6 +74,8 @@ class MultiTag(BaseTag):
             del self._h5group["extents"]
         else:
             self._h5group.create_link(da, "extents")
+        if self._parent._parent.time_auto_update:
+            self.force_updated_at()
 
     @property
     def references(self):

--- a/nixio/section.py
+++ b/nixio/section.py
@@ -224,7 +224,7 @@ class Section(Entity):
     def reference(self, ref):
         util.check_attr_type(ref, str)
         self._h5group.set_attr("reference", ref)
-        if self._h5group.group.file.attrs["time_auto_update"]:
+        if self.file.time_auto_update:
             self.force_updated_at()
 
     @property
@@ -252,7 +252,7 @@ class Section(Entity):
             sec = rootsec.find_sections(filtr=lambda x: x.id == id_or_sec)
 
         self._h5group.create_link(sec, "link")
-        if self._h5group.group.file.attrs["time_auto_update"]:
+        if self.file.time_auto_update:
             self.force_updated_at()
 
     def inherited_properties(self):
@@ -276,7 +276,7 @@ class Section(Entity):
     def repository(self, r):
         util.check_attr_type(r, str)
         self._h5group.set_attr("repository", r)
-        if self._h5group.group.file.attrs["time_auto_update"]:
+        if self.file.time_auto_update:
             self.force_updated_at()
 
     @property

--- a/nixio/section.py
+++ b/nixio/section.py
@@ -224,6 +224,8 @@ class Section(Entity):
     def reference(self, ref):
         util.check_attr_type(ref, str)
         self._h5group.set_attr("reference", ref)
+        if self._h5group.group.file.attrs["time_auto_update"]:
+            self.force_updated_at()
 
     @property
     def link(self):
@@ -250,6 +252,8 @@ class Section(Entity):
             sec = rootsec.find_sections(filtr=lambda x: x.id == id_or_sec)
 
         self._h5group.create_link(sec, "link")
+        if self._h5group.group.file.attrs["auto_update"]:
+            self.force_updated_at()
 
     def inherited_properties(self):
         properties = self._h5group.open_group("properties")
@@ -272,6 +276,8 @@ class Section(Entity):
     def repository(self, r):
         util.check_attr_type(r, str)
         self._h5group.set_attr("repository", r)
+        if self._h5group.group.file.attrs["time_auto_update"]:
+            self.force_updated_at()
 
     @property
     def parent(self):

--- a/nixio/section.py
+++ b/nixio/section.py
@@ -252,7 +252,7 @@ class Section(Entity):
             sec = rootsec.find_sections(filtr=lambda x: x.id == id_or_sec)
 
         self._h5group.create_link(sec, "link")
-        if self._h5group.group.file.attrs["auto_update"]:
+        if self._h5group.group.file.attrs["time_auto_update"]:
             self.force_updated_at()
 
     def inherited_properties(self):

--- a/nixio/tag.py
+++ b/nixio/tag.py
@@ -83,6 +83,7 @@ class BaseTag(Entity):
 
             dtype = DataType.String
             self._h5group.write_data("units", sanitized, dtype)
+        if self._parent._parent.time_auto_update:
             self.force_updated_at()
 
     def create_feature(self, data, link_type):
@@ -189,6 +190,8 @@ class Tag(BaseTag):
         else:
             dtype = DataType.Double
             self._h5group.write_data("position", pos, dtype)
+        if self._parent._parent.time_auto_update:
+            self.force_updated_at()
 
     @property
     def extent(self):
@@ -208,6 +211,8 @@ class Tag(BaseTag):
         else:
             dtype = DataType.Double
             self._h5group.write_data("extent", ext, dtype)
+        if self._parent._parent.time_auto_update:
+            self.force_updated_at()
 
     def _calc_data_slices(self, data):
         refslice = list()


### PR DESCRIPTION
Refer to the issue #368 

I added a flag for timestamp updating when the file is opened. 2 functions (time_auto_update_on() and time_auto_update_off()) are added for altering the flag after the file is opened.

The current policy is to update the time whenever a property of an Entity or File is changed and when the time_auto_update flag is True. I do not put the flag in the force_update_at() function because it is more flexible this way. Note that the update of metatdata will not change the update_at() time anyway.

The force_update_at() in creation is not affected.

As of the performance issue, the time used for changing the expansion_origin for data_array 100,000 times is:

**EDITED:**

always update (without a flag): around 45s
flag = True: around 45s (possibly slower for sections or property)
flag = False: around 20s 
do not provide an auto_update possibility at all: around 20s (slightly less than flag = False)




