### PR TITLE
[prop] Add function to read old Values (incl. uncertainty, reference)

### DIFF
--- a/nixio/property.py
+++ b/nixio/property.py
@@ -147,7 +147,7 @@ class Property(Entity):
     def uncertainty(self):
         dataset = self._h5dataset
         x, y, z = dataset._parent.file.attrs["version"]
-        if y < 1 or z < 1:
+        if x < 1 or (x == 1 and y < 1) or (x == 1 and y == 1 and z < 1):
             val = self._h5dataset.dataset[:]
             v = val[0]["uncertainty"]
             return v
@@ -163,7 +163,7 @@ class Property(Entity):
     def reference(self):
         dataset = self._h5dataset
         x, y, z = dataset._parent.file.attrs["version"]
-        if y < 1 or z < 1:
+        if x < 1 or (x == 1 and y < 1) or (x == 1 and y == 1 and z < 1):
             val = self._h5dataset.dataset[:]
             v = val[0]["reference"]
             return v
@@ -239,7 +239,7 @@ class Property(Entity):
     def values(self):
         dataset = self._h5dataset
         x, y, z = dataset._parent.file.attrs["version"]
-        if y < 1 or z < 1:
+        if x < 1 or (x == 1 and y < 1) or (x == 1 and y == 1 and z < 1):
             v = self._read_old_values()
             return v
         if not sum(dataset.shape):

--- a/nixio/property.py
+++ b/nixio/property.py
@@ -145,6 +145,12 @@ class Property(Entity):
 
     @property
     def uncertainty(self):
+        dataset = self._h5dataset
+        x, y, z = dataset._parent.file.attrs["version"]
+        if y < 1 or z < 1:
+            val = self._h5dataset.dataset[:]
+            v = val[0]["uncertainty"]
+            return v
         return self._h5dataset.get_attr("uncertainty")
 
     @uncertainty.setter
@@ -155,6 +161,12 @@ class Property(Entity):
 
     @property
     def reference(self):
+        dataset = self._h5dataset
+        x, y, z = dataset._parent.file.attrs["version"]
+        if y < 1 or z < 1:
+            val = self._h5dataset.dataset[:]
+            v = val[0]["reference"]
+            return v
         return self._h5dataset.get_attr("reference")
 
     @reference.setter
@@ -215,9 +227,21 @@ class Property(Entity):
 
         self._h5dataset.set_attr("odml_type", str(new_type))
 
+    def _read_old_values(self):
+        val = self._h5dataset.dataset[:]
+        val_tu = tuple()
+        for v in val:
+            v = v["value"]
+            val_tu += (v,)
+        return val_tu
+
     @property
     def values(self):
         dataset = self._h5dataset
+        x, y, z = dataset._parent.file.attrs["version"]
+        if y < 1 or z < 1:
+            v = self._read_old_values()
+            return v
         if not sum(dataset.shape):
             return tuple()
 


### PR DESCRIPTION
Refer to Issue #364 
Originally, when reading values (getting props.values) from file with version < 1.1.1, it will return an old style compound type with (v.value, v.uncertainty, v.reference, v.filename, v.encoder, v.checksum). 

I break it down for value, uncertainty and reference. All now returns a tuple for values, single value for reference and uncertainty.

The problem is we cannot distinguish between an empty str or 0.0 and an unsetted uncertainty or reference. 