### PR TITLE
[feature] Change base class from Entity to object

### DIFF
--- a/nixio/feature.py
+++ b/nixio/feature.py
@@ -10,19 +10,30 @@ from .entity import Entity
 from .data_array import DataArray
 from .link_type import LinkType
 from six import string_types
+from .util import util
 
 
-class Feature(Entity):
+class Feature(object):
 
     def __init__(self, nixparent, h5group):
-        super(Feature, self).__init__(nixparent, h5group)
+        util.check_entity_id(h5group.get_attr("entity_id"))
+        self._h5group = h5group
+        self._parent = nixparent
 
     @classmethod
     def _create_new(cls, nixparent, h5parent, data, link_type):
-        newentity = super(Feature, cls)._create_new(nixparent, h5parent)
-        newentity.link_type = link_type
-        newentity.data = data
-        return newentity
+        id_ = util.create_id()
+        h5group = h5parent.open_group(id_)
+        h5group.set_attr("entity_id", id_)
+        newfeature = cls(nixparent, h5group)
+        newfeature.link_type = link_type
+        newfeature.data = data
+        newfeature._h5group.set_attr("created_at",
+                                     util.time_to_str(util.now_int()))
+        newfeature._h5group.set_attr("updated_at",
+                                     util.time_to_str(util.now_int()))
+
+        return newfeature
 
     @property
     def id(self):
@@ -39,7 +50,8 @@ class Feature(Entity):
         lt = LinkType(lt)
         self._h5group.set_attr("link_type", lt.value)
         if self._parent._parent._parent.time_auto_update:
-            self.force_updated_at()
+            t = util.now_int()
+            self._h5group.set_attr("updated_at", util.time_to_str(t))
 
     @property
     def data(self):
@@ -59,4 +71,49 @@ class Feature(Entity):
             del self._h5group["data"]
         self._h5group.create_link(da, "data")
         if self._parent._parent._parent.time_auto_update:
-            self.force_updated_at()
+            t = util.now_int()
+            self._h5group.set_attr("updated_at", util.time_to_str(t))
+
+    @property
+    def created_at(self):
+        """
+        The creation time of the entity. This is a read-only property.
+        Use `force_created_at` in order to change the creation time.
+
+        :rtype: int
+        """
+        return util.str_to_time(self._h5group.get_attr("created_at"))
+
+    @property
+    def updated_at(self):
+        """
+        The time of the last update of the entity. This is a read-only
+        property. Use `force_updated_at` in order to change the update
+        time.
+
+        :rtype: int
+        """
+        return util.str_to_time(self._h5group.get_attr("updated_at"))
+
+    def __eq__(self, other):
+        """
+        Two Entities are considered equal when they have the same id.
+        """
+        if hasattr(other, "id"):
+            return self.id == other.id
+        return False
+
+    def __hash__(self):
+        """
+        overwriting method __eq__ blocks inheritance of __hash__ in Python 3
+        hash has to be either explicitly inherited from parent class,
+        implemented or escaped
+        """
+        return hash(self.id)
+
+    def __str__(self):
+        return "Feature: {{data = {}, link_type = {} }}".\
+            format(self.data.name, self.link_type)
+
+    def __repr__(self):
+        return self.__str__()

--- a/nixio/tag.py
+++ b/nixio/tag.py
@@ -44,6 +44,8 @@ class FeatureContainer(Container):
             raise ke
 
     def __contains__(self, item):
+        if isinstance(item, Feature):
+            item =  item.id
         if not Container.__contains__(self, item):
             # check if it contains a Feature whose data matches 'item'
             for feat in self:


### PR DESCRIPTION
Refer to Issue #389.

As suggested in #389, the features should not have the attribute name. Also, feature should not have type_ and definition attributes. Its string representation should also be different. Therefore, this PR remove the base class entity.

As an result,

- Feature will not have name, type, definition attributes anymore
-  The __contains__ method of feature container will not use the feature.name
- create_at and update_at property is kept and moved to feature 
- Change the feature string repr to showing data.name and link_type