### PR TITLE
[df]Fix bug of getting column property when some unit is None

### DIFF
--- a/nixio/data_frame.py
+++ b/nixio/data_frame.py
@@ -352,7 +352,7 @@ class DataFrame(Entity, DataSet):
 
         :type: list of tuples
         """
-        if self.units:
+        if np.any(self.units):
             cols = [(n, dt, u) for n, dt, u in
                     zip(self.column_names, self.dtype, self.units)]
         else:


### PR DESCRIPTION
Currently accessing the columns property when some values in df.units are None throws an Error.

This PR fixes the bug