### PR TITLE
Support unicode in Property values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ before_install:
   - export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${nixprefix}/lib/pkgconfig
   - alias pip2='pip'
   - if [[ "${TRAVIS_OS_NAME}" != "osx" ]]; then pip${pymajor} install --upgrade numpy; fi
-  - pip${pymajor} install --upgrade h5py pytest pytest-xdist pytest-cov;
+  - pip${pymajor} install --upgrade h5py pytest pytest-xdist pytest-cov six;
   - if [[ "${pymajor}" == 2 ]]; then pip${pymajor} install enum34; fi
   - git clone --branch ${NIX_BRANCH} https://github.com/G-Node/nix /tmp/libnix
   - pushd /tmp/libnix

--- a/nixio/data_set.py
+++ b/nixio/data_set.py
@@ -7,6 +7,8 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 import numpy as np
+from six import ensure_str
+from . import util
 
 
 class DataSet(object):
@@ -122,7 +124,11 @@ class DataSet(object):
 
     def _read_data(self, sl=None):
         dataset = self._h5group.get_dataset("data")
-        return dataset.read_data(sl)
+        data = dataset.read_data(sl)
+        if data.dtype == util.vlen_str_dtype:
+            data = np.array([ensure_str(d) for d in data],
+                            dtype=util.vlen_str_dtype)
+        return data
 
     @property
     def data_extent(self):

--- a/nixio/datatype.py
+++ b/nixio/datatype.py
@@ -36,7 +36,7 @@ class DataType(object):
         elif isinstance(value, Integral):
             return cls.Int64
         elif isinstance(value, Real):
-            return cls.Float
+            return cls.Double
         elif isinstance(value, string_types):
             return cls.String
         else:

--- a/nixio/datatype.py
+++ b/nixio/datatype.py
@@ -26,7 +26,7 @@ class DataType(object):
     Int64 = np.int64
     Float = np.float_
     Double = np.double
-    String = np.string_
+    String = np.unicode_
     Bool = np.bool_
 
     @classmethod

--- a/nixio/datatype.py
+++ b/nixio/datatype.py
@@ -24,7 +24,7 @@ class DataType(object):
     Int16 = np.int16
     Int32 = np.int32
     Int64 = np.int64
-    Float = np.float_
+    Float = np.float32
     Double = np.double
     String = np.unicode_
     Bool = np.bool_

--- a/nixio/property.py
+++ b/nixio/property.py
@@ -13,7 +13,7 @@ except ImportError:
     from collections import Sequence, Iterable
 from enum import Enum
 from numbers import Number
-from six import string_types
+from six import string_types, ensure_str, ensure_text
 import numpy as np
 
 from .datatype import DataType
@@ -249,7 +249,7 @@ class Property(Entity):
 
         def data_to_value(dat):
             if isinstance(dat, bytes):
-                dat = dat.decode()
+                dat = ensure_str(dat)  # py2compat
             return dat
 
         values = tuple(map(data_to_value, data))
@@ -275,11 +275,10 @@ class Property(Entity):
 
         # Make sure all values are of the same data type
         vtype = self._value_type_checking(vals)
-
+        if vtype == DataType.String:
+            vals = [ensure_text(v) for v in vals]  # py2compat
         self._h5dataset.shape = np.shape(vals)
-
         data = np.array(vals, dtype=vtype)
-
         self._h5dataset.write_data(data)
 
     def extend_values(self, data):

--- a/nixio/property.py
+++ b/nixio/property.py
@@ -303,22 +303,34 @@ class Property(Entity):
             single_val = data
             data = [data]
 
-        # Will raise an error, if the data type of the first value is not valid
-        vtype = DataType.get_dtype(single_val)
+        def check_prop_consistent(vtype):
+            # Check if the new data has the same type as the existing property
+            # data
+            if vtype != self.data_type:
+                raise TypeError("New data type '{}' is inconsistent with the "
+                                "Property's data type '{}'".format(
+                                    vtype, self.data_type))
 
-        # Check if the data type has changed and raise an exception otherwise.
-        if vtype != self.data_type:
-            raise TypeError("New data type '{}' is inconsistent with the "
-                            "Properties data type '{}'".format(vtype,
-                                                               self.data_type))
+        def check_new_data_consistent(vtype):
+            # Check if each value in the new data has the same type
+            for val in data:
+                if DataType.get_dtype(val) != vtype:
+                    raise TypeError("Array contains inconsistent values. "
+                                    "Only values of type '{}' can be "
+                                    "assigned".format(vtype))
 
-        # Check all values for data type consistency to ensure clean value add.
-        # Will raise an exception otherwise.
-        for val in data:
-            if DataType.get_dtype(val) != vtype:
-                raise TypeError("Array contains inconsistent values. "
-                                "Only values of type '{}' can be "
-                                "assigned".format(vtype))
+        if hasattr(data, "dtype"):
+            # numpy array: no need to scan values, arrays are consistent but
+            # check for 1D
+            vtype = data.dtype
+            check_prop_consistent(vtype)
+        else:
+            # Will raise an error, if the data type of the first value is not
+            # valid
+            vtype = DataType.get_dtype(single_val)
+            check_prop_consistent(vtype)
+            check_new_data_consistent(vtype)
+
         return vtype
 
     @property

--- a/nixio/property.py
+++ b/nixio/property.py
@@ -274,7 +274,7 @@ class Property(Entity):
             vals = [vals]
 
         # Make sure all values are of the same data type
-        vtype = self._value_type_checking(vals)
+        vtype = self._check_new_value_types(vals)
         if vtype == DataType.String:
             vals = [ensure_text(v) for v in vals]  # py2compat
         self._h5dataset.shape = np.shape(vals)
@@ -286,7 +286,7 @@ class Property(Entity):
         Extends values to existing data.
         Suitable when new data is nested or original data is long.
         """
-        vtype = self._value_type_checking(data)
+        vtype = self._check_new_value_types(data)
 
         arr = np.array(data, dtype=vtype).flatten('C')
         ds = self._h5dataset
@@ -295,7 +295,7 @@ class Property(Entity):
         ds.shape = (src_len+dlen,)
         ds.write_data(arr, sl=np.s_[src_len: src_len+dlen])
 
-    def _value_type_checking(self, data):
+    def _check_new_value_types(self, data):
         if (isinstance(data, (Sequence, Iterable)) and
                 not isinstance(data, string_types)):
             single_val = data[0]

--- a/nixio/test/test_data_array.py
+++ b/nixio/test/test_data_array.py
@@ -289,7 +289,7 @@ class TestDataArray(unittest.TestCase):
         data = ["Καφές", "Café", "咖啡", "☕"]
         da.write_direct(data)
 
-        assert [six.ensure_text(d) for d in data] == list(da[:])  # py2compat
+        assert data == list(da[:])
 
     def test_data_array_dimensions(self):
         assert(len(self.array.dimensions) == 0)

--- a/nixio/test/test_data_array.py
+++ b/nixio/test/test_data_array.py
@@ -14,6 +14,7 @@ import numpy as np
 import nixio as nix
 from nixio.exceptions import IncompatibleDimensions
 from .tmp import TempDir
+import six
 
 
 class TestDataArray(unittest.TestCase):
@@ -281,6 +282,14 @@ class TestDataArray(unittest.TestCase):
         da = self.block.create_data_array('dtype_opaque', 'b', data=void_data)
         assert(da.dtype == np.dtype('V1'))
         assert(np.array_equal(void_data, da[:]))
+
+    def test_array_unicode(self):
+        da = self.block.create_data_array("unicode", "lotsatext",
+                                          nix.DataType.String, shape=(4,))
+        data = ["Καφές", "Café", "咖啡", "☕"]
+        da.write_direct(data)
+
+        assert [six.ensure_text(d) for d in data] == list(da[:])  # py2compat
 
     def test_data_array_dimensions(self):
         assert(len(self.array.dimensions) == 0)

--- a/nixio/test/test_nix_compatibility.py
+++ b/nixio/test/test_nix_compatibility.py
@@ -459,7 +459,8 @@ def test_properties(tmpdir):
 
     sec.props[0].values = [101]
     sec.props[1].values = ["foo", "bar", "baz"]
-    sec.props["prop Float"].values = [10.0, 33.3, 1.345, 90.2]
+    sec.props["prop Float"].values = np.array([10.0, 33.3, 1.345, 90.2],
+                                              dtype=nix.DataType.Float)
 
     nix_file.close()
     # validate(nixfilepath)
@@ -669,9 +670,9 @@ def test_full_file_write(tmpdir, bindir):
     numbermd = proptypesmd.create_section("numerical metadata",
                                           "test metadata section")
     numbermd["integer"] = 42
-    numbermd["float"] = 4.2
+    numbermd["double"] = 4.2
     numbermd["integers"] = [40, 41, 42, 43, 44, 45]
-    numbermd["floats"] = [1.1, 10.10]
+    numbermd["doubles"] = [1.1, 10.10]
 
     othermd = proptypesmd.create_section("other metadata",
                                          "test metadata section")

--- a/nixio/test/test_nix_compatibility.py
+++ b/nixio/test/test_nix_compatibility.py
@@ -515,7 +515,7 @@ def test_full_write(tmpdir):
 
 
 @pytest.mark.compatibility
-def test_full_file(tmpdir, bindir):
+def test_full_file_write(tmpdir, bindir):
     nixfilepath = os.path.join(str(tmpdir), "filetest-writepy.nix")
     nix_file = nix.File.open(nixfilepath, mode=nix.FileMode.Overwrite)
 
@@ -680,6 +680,7 @@ def test_full_file(tmpdir, bindir):
     othermd["bools"] = [True, False, True]
     othermd["string"] = "I am a string. Rawr."
     othermd["strings"] = ["one", "two", "twenty"]
+    othermd["unicode"] = ["Μπύρα", "Bräu", "啤酒", "🍺"]
 
     # All types of data
     dtypeblock = nix_file.create_block("datablock", "block of data")
@@ -1014,7 +1015,7 @@ def test_full_file_read(tmpdir, bindir):
     othermd = proptypesmd.sections[1]
     compare("other metadata", othermd.name)
     compare("test metadata section", othermd.type)
-    compare(5, len(othermd.props))
+    compare(6, len(othermd.props))
 
     prop = othermd.props["bool"]
     compare(1, len(prop.values))
@@ -1034,7 +1035,11 @@ def test_full_file_read(tmpdir, bindir):
 
     prop = othermd.props["strings"]
     compare(3, len(prop.values))
-    compare([v for v in ["one", "two", "twenty"]], prop.values)
+    compare(["one", "two", "twenty"], prop.values)
+
+    prop = othermd.props["unicode"]
+    compare(4, len(prop.values))
+    compare(["Μπύρα", "Bräu", "啤酒", "🍺"], prop.values)
 
     # TODO: Check type compatibilities
     # for idx in range(len(dtypes)):

--- a/nixio/test/test_nix_compatibility.py
+++ b/nixio/test/test_nix_compatibility.py
@@ -689,6 +689,12 @@ def test_full_file_write(tmpdir, bindir):
         dtypeblock.create_data_array(str(n), "dtype-test-array",
                                      dtype=dt, data=dt(0))
 
+    # Unicode DataArray on last Block
+    data = ["Καφές", "Café", "咖啡", "☕"]
+    dtypeblock.create_data_array("unicodedata", "coffeestuff",
+                                 dtype=nix.DataType.String,
+                                 data=data)
+
     nix_file.close()
     cmd = os.path.join(bindir, "readfullfile")
     runcpp(cmd, nixfilepath)
@@ -738,7 +744,7 @@ def test_full_file_read(tmpdir, bindir):
     check_block_children_counts(nix_file.blocks[0], 2, 4, 1, 1)
     check_block_children_counts(nix_file.blocks[1], 2, 2, 0, 0)
     check_block_children_counts(nix_file.blocks[2], 2, 3, 1, 1)
-    check_block_children_counts(nix_file.blocks[3], 0, 12, 0, 0)
+    check_block_children_counts(nix_file.blocks[3], 0, 13, 0, 0)
 
     check_group_children_counts(nix_file.blocks[0].groups[0], 1, 1, 0)
     check_group_children_counts(nix_file.blocks[0].groups[1], 0, 0, 0)
@@ -1041,12 +1047,20 @@ def test_full_file_read(tmpdir, bindir):
     compare(4, len(prop.values))
     compare(["Μπύρα", "Bräu", "啤酒", "🍺"], prop.values)
 
-    # TODO: Check type compatibilities
-    # for idx in range(len(dtypes)):
-    #     da = block.data_arrays[idx]
-    #     dt = dtypes[idx]
-    #     compare(dt, da.data_type)
-    #     compare([1], da.shape)
+    block = nix_file.blocks["datablock"]
+    for idx in range(len(dtypes)):
+        print(da.name)
+        da = block.data_arrays[idx]
+        dt = dtypes[idx]
+        if dt == nix.DataType.String:
+            dt = nix.util.vlen_str_dtype
+        compare(dt, da.data_type)
+        compare([0], da.shape)
+
+    da = block.data_arrays["unicodedata"]
+    unicodedata = ["Καφές", "Café", "咖啡", "☕"]
+    dadata = da[:]
+    compare(unicodedata, dadata)
 
     nix_file.close()
     # validate(nixfilepath)

--- a/nixio/test/test_property.py
+++ b/nixio/test/test_property.py
@@ -191,7 +191,7 @@ class TestProperties(unittest.TestCase):
     def test_unicode_values(self):
         sec = self.section
         unistrings = {
-            "unlaut": ["ü"],
+            "umlaut": ["ü"],
             "gr": ["ω"],
             "deg": ["°"],
             "chinese-simplified": ["汉字"]

--- a/nixio/test/test_property.py
+++ b/nixio/test/test_property.py
@@ -186,3 +186,20 @@ class TestProperties(unittest.TestCase):
         number_extend = (1, 1.2)
         self.assertRaises(TypeError,
                           lambda: self.prop.extend_values(number_extend))
+
+    def test_unicode_values(self):
+        sec = self.section
+        unistrings = {
+            "unlaut": ["ü"],
+            "gr": ["ω"],
+            "deg": ["°"],
+            "chinese-simplified": ["汉字"]
+        }
+
+        # test writing
+        for name, value in unistrings.items():
+            sec.create_property(name, value)
+
+        # read them back
+        for name, value in unistrings.items():
+            assert tuple(value) == sec.props[name].values

--- a/nixio/test/test_property.py
+++ b/nixio/test/test_property.py
@@ -8,6 +8,7 @@
 # LICENSE file in the root of the Project.
 import os
 import unittest
+import six
 import nixio as nix
 from .tmp import TempDir
 
@@ -202,4 +203,5 @@ class TestProperties(unittest.TestCase):
 
         # read them back
         for name, value in unistrings.items():
+            value = [six.ensure_text(v) for v in value]  # py2compat
             assert tuple(value) == sec.props[name].values

--- a/nixio/test/test_property.py
+++ b/nixio/test/test_property.py
@@ -167,19 +167,22 @@ class TestProperties(unittest.TestCase):
         assert(self.prop_s.data_type == nix.DataType.String)
 
     def test_extend_values(self):
-        da = (1, 2, 3)
-        self.prop.extend_values(da)
-        da = 10
-        self.prop.extend_values(da)
-        sda = ["foo", "bar"]
-        self.prop_s.extend_values(sda)
-        sda = "bla"
-        self.prop_s.extend_values(sda)
+        values = (1, 2, 3)
+        self.prop.extend_values(values)
+        value_extend = 10
+        self.prop.extend_values(value_extend)
+        string_values = ["foo", "bar"]
+        self.prop_s.extend_values(string_values)
+        string_extend = "bla"
+        self.prop_s.extend_values(string_extend)
         self.assertRaises(TypeError, lambda: self.prop_s.extend_values(1))
-        sda = ["str", 1]
-        self.assertRaises(TypeError, lambda: self.prop_s.extend_values(sda))
+        mixed_list = ["str", 1]
+        self.assertRaises(TypeError,
+                          lambda: self.prop_s.extend_values(mixed_list))
         self.assertRaises(TypeError, lambda: self.prop.extend_values(1.0))
-        da = (1.1, 1.2, 1.3)
-        self.assertRaises(TypeError, lambda: self.prop.extend_values(da))
-        da = (1, 1.2)
-        self.assertRaises(TypeError, lambda: self.prop.extend_values(da))
+        float_data = (1.1, 1.2, 1.3)
+        self.assertRaises(TypeError,
+                          lambda: self.prop.extend_values(float_data))
+        number_extend = (1, 1.2)
+        self.assertRaises(TypeError,
+                          lambda: self.prop.extend_values(number_extend))

--- a/nixio/test/xcompat/readfullfile.cpp
+++ b/nixio/test/xcompat/readfullfile.cpp
@@ -47,7 +47,7 @@ int checkObjectCounts(const nix::File &nf) {
     errcount += checkChildrenCounts(nf.getBlock(0), 2, 4, 1, 1);
     errcount += checkChildrenCounts(nf.getBlock(1), 2, 2, 0, 0);
     errcount += checkChildrenCounts(nf.getBlock(2), 2, 3, 1, 1);
-    errcount += checkChildrenCounts(nf.getBlock(3), 0, 12, 0, 0);
+    errcount += checkChildrenCounts(nf.getBlock(3), 0, 13, 0, 0);
 
     errcount += checkChildrenCounts(nf.getBlock(0).getGroup(0), 1, 1, 0);
     errcount += checkChildrenCounts(nf.getBlock(0).getGroup(1), 0, 0, 0);
@@ -424,6 +424,12 @@ int main(int argc, char* argv[]) {
         errcount += compare(dt, da.dataType());
         errcount += compare({1}, da.dataExtent());
     }
+
+    // Unicode data
+    auto unicodeda = block.getDataArray("unicodedata");
+    std::vector<std::string> unicode_array(4);
+    unicodeda.getData(nix::DataType::String, unicode_array.data(), {4}, {});
+    errcount += compare({"Καφές", "Café", "咖啡", "☕"}, unicode_array);
 
     return errcount;
 }

--- a/nixio/test/xcompat/readfullfile.cpp
+++ b/nixio/test/xcompat/readfullfile.cpp
@@ -11,9 +11,7 @@ std::vector<nix::DataType> dtypes = {
     nix::DataType::Int16,
     nix::DataType::Int32,
     nix::DataType::Int64,
-    // NOTE: NIXPy doesn't do 'Float' (32)
-    // It will probably be easier to add when the bindings are removed
-    nix::DataType::Double,
+    nix::DataType::Float,
     nix::DataType::Double,
     nix::DataType::String,
     nix::DataType::Bool
@@ -371,7 +369,7 @@ int main(int argc, char* argv[]) {
     errcount += compare(nix::ndsize_t{1}, prop.valueCount());
     errcount += compare({nix::Variant{int64_t(42)}}, prop.values());
 
-    prop = numbermd.getProperty("float");
+    prop = numbermd.getProperty("double");
     errcount += compare(nix::ndsize_t{1}, prop.valueCount());
     errcount += compare({nix::Variant{double(4.2)}}, prop.values());
 
@@ -382,7 +380,7 @@ int main(int argc, char* argv[]) {
         values[idx] = nix::Variant{int64_t(40 + idx)};
     errcount += compare(values, prop.values());
 
-    prop = numbermd.getProperty("floats");
+    prop = numbermd.getProperty("doubles");
     errcount += compare(nix::ndsize_t{2}, prop.valueCount());
     errcount += compare({nix::Variant{double(1.1)}, nix::Variant{double(10.10)}}, prop.values());
 

--- a/nixio/test/xcompat/readfullfile.cpp
+++ b/nixio/test/xcompat/readfullfile.cpp
@@ -389,7 +389,7 @@ int main(int argc, char* argv[]) {
     auto othermd = proptypesmd.getSection(1);
     errcount += compare("other metadata", othermd.name());
     errcount += compare("test metadata section", othermd.type());
-    errcount += compare(nix::ndsize_t{5}, othermd.propertyCount());
+    errcount += compare(nix::ndsize_t{6}, othermd.propertyCount());
 
     prop = othermd.getProperty("bool");
     errcount += compare(nix::ndsize_t{1}, prop.valueCount());
@@ -410,6 +410,10 @@ int main(int argc, char* argv[]) {
     prop = othermd.getProperty("strings");
     errcount += compare(nix::ndsize_t{3}, prop.valueCount());
     errcount += compare({nix::Variant{"one"}, nix::Variant{"two"}, nix::Variant{"twenty"}}, prop.values());
+
+    prop = othermd.getProperty("unicode");
+    errcount += compare(nix::ndsize_t{4}, prop.valueCount());
+    errcount += compare({nix::Variant("Μπύρα"), nix::Variant("Bräu"), nix::Variant("啤酒"), nix::Variant("🍺")}, prop.values());
 
     block = nf.getBlock("datablock");
     errcount += compare("block of data", block.type());

--- a/nixio/test/xcompat/writefullfile.cpp
+++ b/nixio/test/xcompat/writefullfile.cpp
@@ -209,6 +209,7 @@ int main(int argc, char* argv[]) {
     othermd.createProperty("bools", {nix::Variant(true), nix::Variant(false), nix::Variant(true)});
     othermd.createProperty("string", nix::Variant("I am a string. Rawr."));
     othermd.createProperty("strings", {nix::Variant("one"), nix::Variant("two"), nix::Variant("twenty")});
+    othermd.createProperty("unicode", {nix::Variant("Μπύρα"), nix::Variant("Bräu"), nix::Variant("啤酒"), nix::Variant("🍺")});
 
     // All types of data
     block = nf.createBlock("datablock", "block of data");

--- a/nixio/test/xcompat/writefullfile.cpp
+++ b/nixio/test/xcompat/writefullfile.cpp
@@ -218,5 +218,10 @@ int main(int argc, char* argv[]) {
         block.createDataArray(nix::data_type_to_string(dt), "dtype-test-array", dt, nix::NDSize{0});
     }
 
+    // Unicode data
+    auto unicodeda = block.createDataArray("unicodedata", "dtype-test-array", nix::DataType::String, nix::NDSize{4});
+    std::vector<std::string> unicode_array = {"Καφές", "Café", "咖啡", "☕"};
+    unicodeda.setData(nix::DataType::String, unicode_array.data(), nix::NDSize{4}, nix::NDSize{0});
+
     return 0;
 }

--- a/nixio/util/util.py
+++ b/nixio/util/util.py
@@ -14,17 +14,10 @@ from datetime import datetime
 from uuid import uuid4, UUID
 from ..exceptions import exceptions
 from . import names
-
-from nixio.link_type import LinkType
-
-
-try:
-    vstype = unicode
-except NameError:
-    vstype = str
+import six
 
 
-vlen_str_dtype = h5py.special_dtype(vlen=vstype)
+vlen_str_dtype = h5py.special_dtype(vlen=six.text_type)
 
 
 def create_id():

--- a/nixio/util/util.py
+++ b/nixio/util/util.py
@@ -6,7 +6,7 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
-from six import string_types
+from six import string_types, text_type
 import numpy as np
 
 import h5py
@@ -14,10 +14,9 @@ from datetime import datetime
 from uuid import uuid4, UUID
 from ..exceptions import exceptions
 from . import names
-import six
 
 
-vlen_str_dtype = h5py.special_dtype(vlen=six.text_type)
+vlen_str_dtype = h5py.special_dtype(vlen=text_type)
 
 
 def create_id():

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
     tests_require=['pytest'],
     test_suite='pytest',
     setup_requires=['pytest-runner'],
-    install_requires=['numpy', 'h5py', 'enum34;python_version<"3.4"'],
+    install_requires=['numpy', 'h5py', 'six', 'enum34;python_version<"3.4"'],
     package_data={'nixio': [license_text, description_text]},
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
Fixed support for Unicode in Property values and added tests for Property and DataArray data.

### Property
When writing values, string types are run through ensure_text.  In Python 3 this converts to `str` and for Python 2 it converts to unicode.
When reading values, bytes are run through ensure_str.  In Python 3 this converts to str and for Python 2 it converts to basestring.

Added new test `test_unicode_values`.  The `ensure_str` conversion is replicated here to cover the case for Python2.

### DataArray
No write conversions are necessary since they're taken cafe of by the numpy array type.  The read conversion occurs in the same way as for the Property values, but in this case, it's returned as a numpy array with the vlen_str_dtype.

Added new test `test_array_unicode`.

### NIX Compatibility

Unicode property values and DataArray data are added to the NIX compatibility tests as well.