### PR TITLE
[travis] macOS python3: Prefix path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,8 @@ before_install:
   - export NIX_INCDIR=${nixprefix}/include/nixio-1.0
   - export NIX_LIBDIR=${nixprefix}/lib
   - export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${nixprefix}/lib/pkgconfig
+  # For macOS python3
+  - export PATH="/usr/local/opt/python@3.8/bin:$PATH"
   - alias pip2='pip'
   - if [[ "${TRAVIS_OS_NAME}" != "osx" ]]; then pip${pymajor} install --upgrade numpy; fi
   - pip${pymajor} install --upgrade h5py pytest pytest-xdist pytest-cov six;


### PR DESCRIPTION
Fixes macOS python 3 build on Travis.