### PR TITLE
Add shape when initializing properties to optimize storage

### DIFF
--- a/nixio/property.py
+++ b/nixio/property.py
@@ -98,7 +98,7 @@ class Property(Entity):
 
     @classmethod
     def _create_new(cls, nixparent, h5parent, name,
-                    dtype, oid=None, shape=None):
+                    dtype,shape=None, oid=None):
         if shape is None or shape[0] == 0:
             shape = (8, )
         util.check_entity_name(name)

--- a/nixio/property.py
+++ b/nixio/property.py
@@ -98,7 +98,7 @@ class Property(Entity):
 
     @classmethod
     def _create_new(cls, nixparent, h5parent, name,
-                    dtype,shape=None, oid=None):
+                    dtype, shape=None, oid=None):
         if shape is None or shape[0] == 0:
             shape = (8, )
         util.check_entity_name(name)

--- a/nixio/property.py
+++ b/nixio/property.py
@@ -97,11 +97,14 @@ class Property(Entity):
         self._h5dataset = self._h5group
 
     @classmethod
-    def _create_new(cls, nixparent, h5parent, name, dtype, oid=None):
+    def _create_new(cls, nixparent, h5parent, name,
+                    dtype, oid=None, shape=None):
+        if shape is None or shape[0] == 0:
+            shape = (8, )
         util.check_entity_name(name)
         dtype = cls._make_h5_dtype(dtype)
 
-        h5dataset = h5parent.create_dataset(name, shape=(0,), dtype=dtype)
+        h5dataset = h5parent.create_dataset(name, shape=shape, dtype=dtype)
         h5dataset.set_attr("name", name)
 
         if not util.is_uuid(oid):

--- a/nixio/section.py
+++ b/nixio/section.py
@@ -167,8 +167,9 @@ class Section(Entity):
             for v in vals:
                 if DataType.get_dtype(v) != dtype:
                     raise TypeError("Array contains inconsistent values.")
+        shape = (len(vals),)
 
-        prop = Property._create_new(self, properties, name, dtype, oid)
+        prop = Property._create_new(self, properties, name, dtype, oid, shape)
         prop.values = vals
 
         return prop

--- a/nixio/section.py
+++ b/nixio/section.py
@@ -169,7 +169,7 @@ class Section(Entity):
                     raise TypeError("Array contains inconsistent values.")
         shape = (len(vals),)
 
-        prop = Property._create_new(self, properties, name, dtype, oid, shape)
+        prop = Property._create_new(self, properties, name, dtype, shape, oid)
         prop.values = vals
 
         return prop


### PR DESCRIPTION
Refering to #429 

The sizes before and after, given chunk=True and compression=auto, are 454mb and 225mb.