### PR TITLE
Codestyle fixes

### DIFF
--- a/nixio/block.py
+++ b/nixio/block.py
@@ -91,15 +91,15 @@ class Block(Entity):
         try:
             if not isinstance(positions, DataArray):
                 da_name = "{}-positions".format(name)
-                positions = self.create_data_array(da_name,
-                                                   "{}-positions".format(type_),
-                                                   data=positions)
+                positions = self.create_data_array(
+                    da_name, "{}-positions".format(type_), data=positions
+                )
                 poscreated = True
             if not isinstance(extents, DataArray) and extents is not None:
                 da_name = "{}-extents".format(name)
                 extents = self.create_data_array(da_name,
-                                                 "{}-extents".format(type_)
-                                                 , data=extents)
+                                                 "{}-extents".format(type_),
+                                                 data=extents)
                 extcreated = True
             mtag = MultiTag._create_new(self, multi_tags,
                                         name, type_, positions)

--- a/nixio/multi_tag.py
+++ b/nixio/multi_tag.py
@@ -204,9 +204,8 @@ class MultiTag(BaseTag):
 
     def feature_data(self, posidx, featidx):
         if len(self.features) == 0:
-            raise OutOfBounds(
-                "There are no features associated with this tag!"
-            )
+            msg = "There are no features associated with this tag!"
+            raise OutOfBounds(msg)
 
         try:
             feat = self.features[featidx]
@@ -235,8 +234,8 @@ class MultiTag(BaseTag):
             slices.extend(slice(0, stop) for stop in da.data_extent[1:])
 
             if not self._slices_in_data(da, slices):
-                raise OutOfBounds("Requested data slice out of the extent of the "
-                            "Feature!")
+                msg = "Requested data slice out of the extent of the Feature!"
+                raise OutOfBounds(msg)
             return DataView(da, slices)
         # For untagged return the full data
         slices = tuple(slice(0, stop) for stop in da.data_extent)

--- a/nixio/test/test_data_frame.py
+++ b/nixio/test/test_data_frame.py
@@ -201,8 +201,8 @@ class TestDataFrame(unittest.TestCase):
         assert self.df1.dtype[2] == self.df1.dtype[3]
 
     def test_creation_without_name(self):
-        b = np.array([("a",1,2.2), ("b",2,3.3), ("c",3,4.4)], dtype=[('name', 'U10'), ("id", 'i4'), ('val', 'f4')])
-        df = self.block.create_data_frame("without_name", "test", data=b)
+        data = np.array([("a", 1, 2.2), ("b", 2, 3.3), ("c", 3, 4.4)],
+                        dtype=[('name', 'U10'), ("id", 'i4'), ('val', 'f4')])
+        df = self.block.create_data_frame("without_name", "test", data=data)
         assert sorted(list(df.column_names)) == sorted(["name", "id", "val"])
         assert sorted(list(df["name"])) == ["a", "b", "c"]
-

--- a/nixio/test/test_multi_tag.py
+++ b/nixio/test/test_multi_tag.py
@@ -117,34 +117,25 @@ class TestMultiTags(unittest.TestCase):
         # test positions extents deleted if multitag creation failed
         pos = None
         ext = np.random.random((2, 3))
-        self.assertRaises(ValueError ,
-                          lambda: self.block.create_multi_tag("err_test",
-                                                            "test", pos, ext))
+        self.assertRaises(ValueError, self.block.create_multi_tag,
+                          "err_test", "test", pos, ext)
         self.block.create_data_array("dup_test-"
                                      "positions", "test", data=[0])
         pos = np.random.random((2, 3))
         ext = np.random.random((2, 3))
-        self.assertRaises(DuplicateName,
-                          lambda: self.block.create_multi_tag("dup_test",
-                                                              "test", pos,
-                                                              ext))
+        self.assertRaises(DuplicateName, self.block.create_multi_tag,
+                          "dup_test", "test", pos, ext)
         del self.block.data_arrays["dup_test-positions"]
         self.block.create_data_array("dup_test2-"
                                      "extents", "test", data=[0])
         pos = np.random.random((2, 3))
         ext = np.random.random((2, 3))
-        self.assertRaises(DuplicateName,
-                          lambda: self.block.create_multi_tag("dup_test2",
-                                                              "test", pos,
-                                                              ext))
+        self.assertRaises(DuplicateName, self.block.create_multi_tag,
+                          "dup_test2", "test", pos, ext)
         pos = np.random.random((2, 3))
         ext = [None, None]
-        self.assertRaises(TypeError,
-                          lambda: self.block.create_multi_tag("dup_test3",
-                                                              "test", pos,
-                                                              ext))
-
-
+        self.assertRaises(TypeError, self.block.create_multi_tag,
+                          "dup_test3", "test", pos, ext)
 
     def test_multi_tag_flex(self):
         pos1d = self.block.create_data_array("pos1", "pos", data=[[0], [1]])
@@ -286,8 +277,7 @@ class TestMultiTags(unittest.TestCase):
     def test_multi_tag_references(self):
         assert (len(self.my_tag.references) == 0)
 
-        self.assertRaises(TypeError,
-                          lambda _: self.my_tag.references.append(100))
+        self.assertRaises(TypeError, self.my_tag.references.append, 100)
 
         reference1 = self.block.create_data_array("reference1", "stimuli",
                                                   nix.DataType.Int16, (0,))
@@ -451,14 +441,14 @@ class TestMultiTags(unittest.TestCase):
         wrong_pos.append_set_dimension()
         wrong_pos.append_set_dimension()
         postag.positions = wrong_pos
-        self.assertRaises(IndexError, lambda: postag.tagged_data(1, 1))
+        self.assertRaises(IndexError, postag.tagged_data, 1, 1)
         wrong_ext = self.block.create_data_array("incorext", "test",
                                                  data=[[1, 500, 2],
                                                        [0, 4, 1]])
         wrong_ext.append_set_dimension()
         wrong_ext.append_set_dimension()
         segtag.extents = wrong_ext
-        self.assertRaises(IndexError, lambda: segtag.tagged_data(0, 1))
+        self.assertRaises(IndexError, segtag.tagged_data, 0, 1)
 
     def test_multi_tag_tagged_data_1d(self):
         # MultiTags to vectors behave a bit differently

--- a/nixio/test/test_tag.py
+++ b/nixio/test/test_tag.py
@@ -141,8 +141,7 @@ class TestTags(unittest.TestCase):
     def test_tag_references(self):
         assert (len(self.my_tag.references) == 1)
 
-        self.assertRaises(TypeError,
-                          lambda _: self.my_tag.references.append(100))
+        self.assertRaises(TypeError, self.my_tag.references.append, 100)
 
         reference1 = self.block.create_data_array("reference1", "stimuli",
                                                   nix.DataType.Int16, (1,))


### PR DESCRIPTION
Followup to #444.
Codestyle fixes and unnecessary lambda removal.

A few snuck in while the previous PR was open.

@hkchekc Have a look at this PR and note the changes in the `assertRaises()` calls.  I went through and changed all the old ones I had written too so they don't use `lambda` since we can pass arguments to the callable.

There are a few `assertRaises()` calls that use lambda because they're testing indexing failures, so the arguments don't work exactly there.  We could also use `with self.assertRaises(<ErrorType>)`, but for now this should be good enough.