### PR TITLE
File ID, header creation modifications, and File Format 1.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,11 @@ matrix:
   include:
     - python: "2.7"
       os: linux
+      dist: xenial
       env: pymajor=2
     - python: "3.6"
       os: linux
+      dist: xenial
       env: pymajor=3
     - python: "3.7"
       os: linux

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -147,6 +147,7 @@ class File(object):
     def _create_header(self):
         self._set_format()
         self._set_version()
+        self._set_id()
 
     def _check_header(self, mode):
         if self.format != FILE_FORMAT:
@@ -166,6 +167,18 @@ class File(object):
 
     def __exit__(self, *args):
         self.close()
+
+    @property
+    def id(self):
+        return self._root.get_attr("id")
+
+    def _set_id(self):
+        # file id attribute should only be set on creation (or format
+        # upgrade), so do nothing if it's already set
+        if self._root.get_attr("id"):
+            return
+
+        self._root.set_attr("id", util.create_id())
 
     @property
     def version(self):

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -105,23 +105,22 @@ class File(object):
                 "Cannot open non-existent file in ReadOnly mode!"
             )
 
-        new = False
         if not os.path.exists(path) or mode == FileMode.Overwrite:
             mode = FileMode.Overwrite
             h5mode = map_file_mode(mode)
             fid = h5py.h5f.create(path, flags=h5mode, fapl=make_fapl(),
                                   fcpl=make_fcpl())
-            new = True
+            self._h5file = h5py.File(fid)
+            self._root = H5Group(self._h5file, "/", create=True)
+            self._create_header()
         else:
             h5mode = map_file_mode(mode)
             fid = h5py.h5f.open(path, flags=h5mode, fapl=make_fapl())
+            self._h5file = h5py.File(fid)
+            self._root = H5Group(self._h5file, "/")
 
-        self._h5file = h5py.File(fid)
-        self._root = H5Group(self._h5file, "/", create=True)
         self._h5group = self._root  # to match behaviour of other objects
         self._time_auto_update = True
-        if new:
-            self._create_header()
         self._check_header(mode)
         self.mode = mode
         self._data = self._root.open_group("data", create=True)

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -29,7 +29,7 @@ from .compression import Compression
 
 
 FILE_FORMAT = "nix"
-HDF_FF_VERSION = (1, 1, 1)
+HDF_FF_VERSION = (1, 2, 0)
 
 
 def can_write(nixfile):

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -146,8 +146,8 @@ class File(object):
         return cls(path, mode, compression, auto_update_time)
 
     def _create_header(self):
-        self.format = FILE_FORMAT
-        self.version = HDF_FF_VERSION
+        self._set_format()
+        self._set_version()
 
     def _check_header(self, mode):
         if self.format != FILE_FORMAT:
@@ -177,16 +177,15 @@ class File(object):
         """
         return tuple(self._root.get_attr("version"))
 
-    @version.setter
-    def version(self, v):
-        util.check_attr_type(v, tuple)
-        for part in v:
-            util.check_attr_type(part, int)
+    def _set_version(self):
+        # file format version should only be set on creation, so do nothing
+        # if it's already set
+        if self._root.get_attr("version"):
+            return
+
         # convert to np.int32 since py3 defaults to 64
-        v = np.array(v, dtype=np.int32)
+        v = np.array(HDF_FF_VERSION, dtype=np.int32)
         self._root.set_attr("version", v)
-        if self.time_auto_update:
-            self.force_updated_at()
 
     @property
     def format(self):
@@ -198,12 +197,8 @@ class File(object):
         """
         return self._root.get_attr("format")
 
-    @format.setter
-    def format(self, f):
-        util.check_attr_type(f, str)
-        self._root.set_attr("format", f.encode("ascii"))
-        if self.time_auto_update:
-            self.force_updated_at()
+    def _set_format(self):
+        self._root.set_attr("format", FILE_FORMAT.encode("ascii"))
 
     @property
     def time_auto_update(self):

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -162,6 +162,11 @@ class File(object):
                 raise RuntimeError("Cannot open file. "
                                    "Incompatible version.")
 
+        if self.version >= (1, 2, 0):  # ID only required for 1.2.0+
+            if not util.is_uuid(self.id):
+                raise RuntimeError("Cannot open file. "
+                                   "The file does not have an ID.")
+
     def __enter__(self):
         return self
 

--- a/nixio/test/test_file.py
+++ b/nixio/test/test_file.py
@@ -184,6 +184,7 @@ class TestFileVer(unittest.TestCase):
             version = self.filever
         self.h5root.attrs["format"] = fformat
         self.h5root.attrs["version"] = version
+        self.h5root.attrs["id"] = nix.util.create_id()
         self.h5root.attrs["created_at"] = 0
         self.h5root.attrs["updated_at"] = 0
         if "data" not in self.h5root:

--- a/nixio/test/test_file.py
+++ b/nixio/test/test_file.py
@@ -177,14 +177,16 @@ class TestFileVer(unittest.TestCase):
         f = nix.File.open(self.testfilename, mode)
         f.close()
 
-    def set_header(self, fformat=None, version=None):
+    def set_header(self, fformat=None, version=None, fileid=None):
         if fformat is None:
             fformat = self.fformat
         if version is None:
             version = self.filever
+        if fileid is None:
+            fileid = nix.util.create_id()
         self.h5root.attrs["format"] = fformat
         self.h5root.attrs["version"] = version
-        self.h5root.attrs["id"] = nix.util.create_id()
+        self.h5root.attrs["id"] = fileid
         self.h5root.attrs["created_at"] = 0
         self.h5root.attrs["updated_at"] = 0
         if "data" not in self.h5root:
@@ -246,3 +248,18 @@ class TestFileVer(unittest.TestCase):
         self.set_header(fformat="NOT_A_NIX_FILE")
         with self.assertRaises(InvalidFile):
             self.try_open(nix.FileMode.ReadOnly)
+
+    def test_bad_id(self):
+        self.set_header(fileid="")
+        with self.assertRaises(RuntimeError):
+            self.try_open(nix.FileMode.ReadOnly)
+
+        # empty file ID OK for versions older than 1.2.0
+        self.set_header(version=(1, 1, 1), fileid="")
+        self.try_open(nix.FileMode.ReadOnly)
+
+        self.set_header(version=(1, 1, 0), fileid="")
+        self.try_open(nix.FileMode.ReadOnly)
+
+        self.set_header(version=(1, 0, 0), fileid="")
+        self.try_open(nix.FileMode.ReadOnly)

--- a/nixio/test/test_validator.py
+++ b/nixio/test/test_validator.py
@@ -154,11 +154,11 @@ class TestValidate (unittest.TestCase):
         assert not res["warnings"], self.print_all_results(res)
 
     def test_check_file(self):
-        self.file.version = tuple()
+        self.file._root.set_attr("version", tuple())
         res = self.file.validate()
         assert VW.NoVersion in res["warnings"][self.file]
 
-        self.file.format = ""
+        self.file._root.set_attr("format", "")
         res = self.file.validate()
         assert VW.NoFormat in res["warnings"][self.file]
 

--- a/nixio/test/test_validator.py
+++ b/nixio/test/test_validator.py
@@ -460,3 +460,14 @@ class TestValidate (unittest.TestCase):
         dim.offset = 10
         res = self.file.validate()
         assert VW.OffsetNoUnit.format(2) in res["warnings"][da]
+
+    @staticmethod
+    def print_all_results(res):
+        print("Errors")
+        for obj, msg in res["errors"].items():
+            name = obj.name if hasattr(obj, "name") else str(obj)
+            print("  {}: {}".format(name, msg))
+        print("Warnings")
+        for obj, msg in res["warnings"].items():
+            name = obj.name if hasattr(obj, "name") else str(obj)
+            print("  {}: {}".format(name, msg))

--- a/nixio/test/test_validator.py
+++ b/nixio/test/test_validator.py
@@ -162,6 +162,11 @@ class TestValidate (unittest.TestCase):
         res = self.file.validate()
         assert VW.NoFormat in res["warnings"][self.file]
 
+        self.file._root.set_attr("version", (1, 2, 0))  # needed for ID check
+        self.file._root.set_attr("id", "")
+        res = self.file.validate()
+        assert VW.NoFileID in res["warnings"][self.file]
+
     def test_check_block(self):
         block = self.file.blocks[0]
         block._h5group.set_attr("name", None)

--- a/nixio/validator.py
+++ b/nixio/validator.py
@@ -81,6 +81,7 @@ class ValidationError(object):
 class ValidationWarning(object):
     NoVersion = "version is not set"
     NoFormat = "format is not set"
+    NoFileID = "file ID is not set"
     InvalidUnit = "unit is not SI or composite of SI units"
     NoExpansionOrigin = ("polynomial coefficients for calibration are set, "
                          "but expansion origin is missing")
@@ -109,6 +110,8 @@ def check_file(nixfile):
         file_warnings.append(ValidationWarning.NoVersion)
     if not nixfile.format:
         file_warnings.append(ValidationWarning.NoFormat)
+    if not nixfile.id and nixfile.version and nixfile.version >= (1, 2, 0):
+        file_warnings.append(ValidationWarning.NoFileID)
     if file_warnings:
         results["warnings"][nixfile] = file_warnings
 


### PR DESCRIPTION
Added ID in the file header.  Attribute key `id`.

Removed header property setters.  See corresponding commit for full explanation.

Updated file format version to 1.2.0.