### PR TITLE
Upgrade script

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
 include LICENSE README.rst
 recursive-include docs *
-recursive-include scripts *
 include nixio/info.json

--- a/nixio/cmd/__init__.py
+++ b/nixio/cmd/__init__.py
@@ -1,3 +1,0 @@
-from .validate import main as validatemain
-
-__all__ = ["validatemain"]

--- a/nixio/cmd/upgrade.py
+++ b/nixio/cmd/upgrade.py
@@ -1,0 +1,19 @@
+import argparse
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Upgrade NIX files to newest version"
+    )
+    parser.add_argument("-f", "--force", action="store_true",
+                        help="overwrite existing files without prompting")
+    parser.add_argument("file", type=str, nargs="+",
+                        help="path to file to upgrade (at least one)")
+    args = parser.parse_args()
+    files = args.file
+
+    print(f"Upgrading {len(files)} files...")
+
+
+if __name__ == "__main__":
+    main()

--- a/nixio/cmd/upgrade.py
+++ b/nixio/cmd/upgrade.py
@@ -1,4 +1,66 @@
 import argparse
+import nixio as nix
+import h5py
+
+
+def get_file_version(fname):
+    with h5py.File(fname, mode="r") as hfile:
+        return tuple(hfile.attrs["version"])
+
+
+def has_valid_file_id(fname):
+    with h5py.File(fname, mode="r") as hfile:
+        fileid = hfile.attrs.get("id")
+        if fileid and nix.util.is_uuid(fileid):
+            return True
+    return False
+
+
+def add_file_id(fname):
+    """
+    Returns a closure that binds the filename. When the return value is
+    called, it adds a UUID to the file header.
+    """
+    def add_id():
+        "Add a UUID to the file header"
+        with h5py.File(fname, mode="a") as hfile:
+            hfile.attrs["id"] = nix.util.create_id()
+    return add_id
+
+
+def update_format_version(fname):
+    """
+    Returns a closure that binds the filename. When the return value is
+    called, it updates the version in the header to the version in the library.
+    """
+    def update_ver():
+        with h5py.File(fname, mode="a") as hfile:
+            hfile.attrs["version"] = nix.file.HDF_FF_VERSION
+    lib_verstr = ".".join(str(v) for v in nix.file.HDF_FF_VERSION)
+    update_ver.__doc__ = f"Update the file format version to {lib_verstr}"
+    return update_ver
+
+
+def collect_tasks(fname):
+    file_ver = get_file_version(fname)
+    file_verstr = ".".join(str(v) for v in file_ver)
+    lib_verstr = ".".join(str(v) for v in nix.file.HDF_FF_VERSION)
+    if file_ver >= nix.file.HDF_FF_VERSION:
+        print(f"{fname}: Up to date ({file_verstr})")
+        return
+
+    # even if the version string indicates the file is old, check format
+    # details before scheduling tasks
+    tasks = list()
+    if not has_valid_file_id(fname):
+        tasks.append(add_file_id(fname))
+
+    # always update the format in the end
+    tasks.append(update_format_version(fname))
+    print(f"{fname}: {file_verstr} -> {lib_verstr}")
+    print("  - " + "\n  - ".join(t.__doc__ for t in tasks) + "\n")
+
+    return tasks
 
 
 def main():
@@ -10,9 +72,45 @@ def main():
     parser.add_argument("file", type=str, nargs="+",
                         help="path to file to upgrade (at least one)")
     args = parser.parse_args()
-    files = args.file
+    filenames = args.file
 
-    print(f"Upgrading {len(files)} files...")
+    tasks = dict()
+    for fname in filenames:
+        tasklist = collect_tasks(fname)
+        if not tasklist:
+            continue
+
+        tasks[fname] = tasklist
+
+    if not tasks:
+        return
+
+    force = args.force
+    if not force:
+        print("""
+PLEASE READ CAREFULLY
+
+If you choose to continue, the changes listed above will be applied to the
+respective files. This will make the files unreadable by older NIX library
+versions. Although this procedure is generally fast and safe, interrupting it
+may leave files in a corrupted state.
+
+MAKE SURE YOUR FILES AND DATA ARE BACKED UP BEFORE CONTINUING.
+        """)
+        conf = None
+
+        while conf not in ("y", "n", "yes", "no"):
+            conf = input("Continue with changes? [yes/no] ")
+            conf = conf.lower()
+    else:
+        conf = "yes"
+
+    if conf in ("y", "yes"):
+        for fname, tasklist in tasks.items():
+            print(f"Processing {fname} ", end="", flush=True)
+            for task in tasklist:
+                task()
+            print("done")
 
 
 if __name__ == "__main__":

--- a/nixio/cmd/upgrade.py
+++ b/nixio/cmd/upgrade.py
@@ -49,6 +49,12 @@ def update_property_values(fname):
         for propname in props:
             with h5py.File(fname, mode="a") as hfile:
                 prop = hfile[propname]
+                if not (isinstance(prop, h5py.Dataset) and len(prop.dtype)):
+                    # File was possibly changed since the tasks were
+                    # collected.  File may have been submitted twice or
+                    # multiple instances of the script could be running.
+                    # skip this prop
+                    continue
 
                 # pull out the old extra attributes
                 uncertainty = prop["uncertainty"]

--- a/nixio/cmd/upgrade.py
+++ b/nixio/cmd/upgrade.py
@@ -31,8 +31,7 @@ def add_file_id(fname):
 def update_property_values(fname):
     """
     Returns a closure that binds the filename. When the return value is
-    called, it modifies rewrites all the metadata Property objects to the new
-    format.
+    called, it rewrites all the metadata Property objects to the new format.
     """
     props = list()
 

--- a/nixio/cmd/upgrade.py
+++ b/nixio/cmd/upgrade.py
@@ -29,7 +29,6 @@ def add_file_id(fname):
         with h5py.File(fname, mode="a") as hfile:
             if has_valid_file_id(fname):
                 return
-            print("Adding file id")
             hfile.attrs["id"] = nix.util.create_id()
     return add_id
 
@@ -66,7 +65,6 @@ def update_property_values(fname):
                     # skip this prop
                     continue
 
-                print(f"Fixing {propname}")
                 # pull out the old extra attributes
                 uncertainty = prop["uncertainty"]
                 reference = prop["reference"]
@@ -76,10 +74,14 @@ def update_property_values(fname):
 
                 # replace base prop
                 values = prop["value"]
+                definition = prop.attrs.get("definition")
+                unit = prop.attrs.get("unit")
                 dt = values.dtype
                 del hfile[propname]
                 newprop = create_property(hfile, propname,
-                                          dtype=dt, data=values)
+                                          dtype=dt, data=values,
+                                          definition=definition,
+                                          unit=unit)
 
                 # Create properties for any extra attrs that are set
                 if len(set(uncertainty)) > 1:
@@ -114,12 +116,16 @@ def update_property_values(fname):
     return update_props
 
 
-def create_property(hfile, name, dtype, data):
+def create_property(hfile, name, dtype, data, definition=None, unit=None):
     prop = hfile.create_dataset(name, dtype=dtype, data=data)
     prop.attrs["name"] = name.split("/")[-1]
     prop.attrs["entity_id"] = nix.util.create_id()
     prop.attrs["created_at"] = nix.util.time_to_str(nix.util.now_int())
     prop.attrs["updated_at"] = nix.util.time_to_str(nix.util.now_int())
+    if definition:
+        prop.attrs["definition"] = definition
+    if unit:
+        prop.attrs["unit"] = unit
     return prop
 
 

--- a/nixio/cmd/validate.py
+++ b/nixio/cmd/validate.py
@@ -1,14 +1,6 @@
-import sys
 import os
+import argparse
 import nixio as nix
-
-
-def usage():
-    print("Usage")
-    print("  nix-validate <nixfile>...")
-    print()
-    print("Args")
-    print("  <nixfile>...    One or more NIX files")
 
 
 def format_obj(obj):
@@ -46,13 +38,15 @@ def validate(filename):
 
 
 def main():
-    args = sys.argv
-    if len(args) < 2:
-        usage()
-        sys.exit(1)
+    parser = argparse.ArgumentParser(
+        description="Validate NIX files"
+    )
+    parser.add_argument("file", type=str, nargs="+",
+                        help="path to file to validate (at least one)")
+    args = parser.parse_args()
+    filenames = args.file
 
-    nixfnames = args[1:]
-    for nixfn in nixfnames:
+    for nixfn in filenames:
         if os.path.exists(nixfn):
             validate(nixfn)
         else:

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -147,6 +147,7 @@ class File(object):
     def _create_header(self):
         self._set_format()
         self._set_version()
+        self._set_id()
 
     def _check_header(self, mode):
         if self.format != FILE_FORMAT:
@@ -166,6 +167,18 @@ class File(object):
 
     def __exit__(self, *args):
         self.close()
+
+    @property
+    def id(self):
+        return self._root.get_attr("id")
+
+    def _set_id(self):
+        # file id attribute should only be set on creation (or format
+        # upgrade), so do nothing if it's already set
+        if self._root.get_attr("id"):
+            return
+
+        self._root.set_attr("id", util.create_id())
 
     @property
     def version(self):

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -105,23 +105,22 @@ class File(object):
                 "Cannot open non-existent file in ReadOnly mode!"
             )
 
-        new = False
         if not os.path.exists(path) or mode == FileMode.Overwrite:
             mode = FileMode.Overwrite
             h5mode = map_file_mode(mode)
             fid = h5py.h5f.create(path, flags=h5mode, fapl=make_fapl(),
                                   fcpl=make_fcpl())
-            new = True
+            self._h5file = h5py.File(fid)
+            self._root = H5Group(self._h5file, "/", create=True)
+            self._create_header()
         else:
             h5mode = map_file_mode(mode)
             fid = h5py.h5f.open(path, flags=h5mode, fapl=make_fapl())
+            self._h5file = h5py.File(fid)
+            self._root = H5Group(self._h5file, "/")
 
-        self._h5file = h5py.File(fid)
-        self._root = H5Group(self._h5file, "/", create=True)
         self._h5group = self._root  # to match behaviour of other objects
         self._time_auto_update = True
-        if new:
-            self._create_header()
         self._check_header(mode)
         self.mode = mode
         self._data = self._root.open_group("data", create=True)

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -124,7 +124,7 @@ class File(object):
         self._check_header(mode)
         self.mode = mode
         self._data = self._root.open_group("data", create=True)
-        self.metadata = self._root.open_group("metadata", create=True)
+        self._metadata = self._root.open_group("metadata", create=True)
         if "created_at" not in self._h5file.attrs:
             self.force_created_at()
         if "updated_at" not in self._h5file.attrs:
@@ -435,9 +435,9 @@ class File(object):
         :returns: The newly created section.
         :rtype: Section
         """
-        if name in self.metadata:
+        if name in self.sections:
             raise DuplicateName("create_section")
-        sec = Section._create_new(self, self.metadata, name, type_, oid)
+        sec = Section._create_new(self, self._metadata, name, type_, oid)
         return sec
 
     @property

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -29,7 +29,7 @@ from .compression import Compression
 
 
 FILE_FORMAT = "nix"
-HDF_FF_VERSION = (1, 1, 1)
+HDF_FF_VERSION = (1, 2, 0)
 
 
 def can_write(nixfile):

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -146,8 +146,8 @@ class File(object):
         return cls(path, mode, compression, auto_update_time)
 
     def _create_header(self):
-        self.format = FILE_FORMAT
-        self.version = HDF_FF_VERSION
+        self._set_format()
+        self._set_version()
 
     def _check_header(self, mode):
         if self.format != FILE_FORMAT:
@@ -177,16 +177,15 @@ class File(object):
         """
         return tuple(self._root.get_attr("version"))
 
-    @version.setter
-    def version(self, v):
-        util.check_attr_type(v, tuple)
-        for part in v:
-            util.check_attr_type(part, int)
+    def _set_version(self):
+        # file format version should only be set on creation, so do nothing
+        # if it's already set
+        if self._root.get_attr("version"):
+            return
+
         # convert to np.int32 since py3 defaults to 64
-        v = np.array(v, dtype=np.int32)
+        v = np.array(HDF_FF_VERSION, dtype=np.int32)
         self._root.set_attr("version", v)
-        if self.time_auto_update:
-            self.force_updated_at()
 
     @property
     def format(self):
@@ -198,12 +197,8 @@ class File(object):
         """
         return self._root.get_attr("format")
 
-    @format.setter
-    def format(self, f):
-        util.check_attr_type(f, str)
-        self._root.set_attr("format", f.encode("ascii"))
-        if self.time_auto_update:
-            self.force_updated_at()
+    def _set_format(self):
+        self._root.set_attr("format", FILE_FORMAT.encode("ascii"))
 
     @property
     def time_auto_update(self):

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -162,6 +162,11 @@ class File(object):
                 raise RuntimeError("Cannot open file. "
                                    "Incompatible version.")
 
+        if self.version >= (1, 2, 0):
+            if not util.is_uuid(self.id):
+                raise RuntimeError("Cannot open file. "
+                                   "The file does not have an ID.")
+
     def __enter__(self):
         return self
 

--- a/nixio/property.py
+++ b/nixio/property.py
@@ -149,8 +149,8 @@ class Property(Entity):
     @property
     def uncertainty(self):
         dataset = self._h5dataset
-        x, y, z = dataset._parent.file.attrs["version"]
-        if x < 1 or (x == 1 and y < 1) or (x == 1 and y == 1 and z < 1):
+        filever = tuple(dataset._parent.file.attrs["version"])
+        if filever < (1, 1, 1):
             val = self._h5dataset.dataset[:]
             v = val[0]["uncertainty"]
             return v
@@ -165,8 +165,8 @@ class Property(Entity):
     @property
     def reference(self):
         dataset = self._h5dataset
-        x, y, z = dataset._parent.file.attrs["version"]
-        if x < 1 or (x == 1 and y < 1) or (x == 1 and y == 1 and z < 1):
+        filever = tuple(dataset._parent.file.attrs["version"])
+        if filever < (1, 1, 1):
             val = self._h5dataset.dataset[:]
             v = val[0]["reference"]
             return v
@@ -241,8 +241,8 @@ class Property(Entity):
     @property
     def values(self):
         dataset = self._h5dataset
-        x, y, z = dataset._parent.file.attrs["version"]
-        if x < 1 or (x == 1 and y < 1) or (x == 1 and y == 1 and z < 1):
+        filever = tuple(dataset._parent.file.attrs["version"])
+        if filever < (1, 1, 1):
             v = self._read_old_values()
             return v
         if not sum(dataset.shape):

--- a/nixio/property.py
+++ b/nixio/property.py
@@ -232,11 +232,7 @@ class Property(Entity):
 
     def _read_old_values(self):
         val = self._h5dataset.dataset[:]
-        val_tu = tuple()
-        for v in val:
-            v = v["value"]
-            val_tu += (v,)
-        return val_tu
+        return tuple(v["value"] for v in val)
 
     @property
     def values(self):

--- a/nixio/test/test_file.py
+++ b/nixio/test/test_file.py
@@ -184,6 +184,7 @@ class TestFileVer(unittest.TestCase):
             version = self.filever
         self.h5root.attrs["format"] = fformat
         self.h5root.attrs["version"] = version
+        self.h5root.attrs["id"] = nix.util.create_id()
         self.h5root.attrs["created_at"] = 0
         self.h5root.attrs["updated_at"] = 0
         if "data" not in self.h5root:

--- a/nixio/test/test_file.py
+++ b/nixio/test/test_file.py
@@ -177,14 +177,16 @@ class TestFileVer(unittest.TestCase):
         f = nix.File.open(self.testfilename, mode)
         f.close()
 
-    def set_header(self, fformat=None, version=None):
+    def set_header(self, fformat=None, version=None, fileid=None):
         if fformat is None:
             fformat = self.fformat
         if version is None:
             version = self.filever
+        if fileid is None:
+            fileid = nix.util.create_id()
         self.h5root.attrs["format"] = fformat
         self.h5root.attrs["version"] = version
-        self.h5root.attrs["id"] = nix.util.create_id()
+        self.h5root.attrs["id"] = fileid
         self.h5root.attrs["created_at"] = 0
         self.h5root.attrs["updated_at"] = 0
         if "data" not in self.h5root:
@@ -246,3 +248,18 @@ class TestFileVer(unittest.TestCase):
         self.set_header(fformat="NOT_A_NIX_FILE")
         with self.assertRaises(InvalidFile):
             self.try_open(nix.FileMode.ReadOnly)
+
+    def test_bad_id(self):
+        self.set_header(fileid="")
+        with self.assertRaises(RuntimeError):
+            self.try_open(nix.FileMode.ReadOnly)
+
+        # empty file ID OK for versions older than 1.2.0
+        self.set_header(version=(1, 1, 1), fileid="")
+        self.try_open(nix.FileMode.ReadOnly)
+
+        self.set_header(version=(1, 1, 0), fileid="")
+        self.try_open(nix.FileMode.ReadOnly)
+
+        self.set_header(version=(1, 0, 0), fileid="")
+        self.try_open(nix.FileMode.ReadOnly)

--- a/nixio/test/test_validator.py
+++ b/nixio/test/test_validator.py
@@ -154,11 +154,11 @@ class TestValidate (unittest.TestCase):
         assert not res["warnings"], self.print_all_results(res)
 
     def test_check_file(self):
-        self.file.version = tuple()
+        self.file._root.set_attr("version", tuple())
         res = self.file.validate()
         assert VW.NoVersion in res["warnings"][self.file]
 
-        self.file.format = ""
+        self.file._root.set_attr("format", "")
         res = self.file.validate()
         assert VW.NoFormat in res["warnings"][self.file]
 

--- a/nixio/test/test_validator.py
+++ b/nixio/test/test_validator.py
@@ -460,3 +460,14 @@ class TestValidate (unittest.TestCase):
         dim.offset = 10
         res = self.file.validate()
         assert VW.OffsetNoUnit.format(2) in res["warnings"][da]
+
+    @staticmethod
+    def print_all_results(res):
+        print("Errors")
+        for obj, msg in res["errors"].items():
+            name = obj.name if hasattr(obj, "name") else str(obj)
+            print("  {}: {}".format(name, msg))
+        print("Warnings")
+        for obj, msg in res["warnings"].items():
+            name = obj.name if hasattr(obj, "name") else str(obj)
+            print("  {}: {}".format(name, msg))

--- a/nixio/test/test_validator.py
+++ b/nixio/test/test_validator.py
@@ -162,6 +162,11 @@ class TestValidate (unittest.TestCase):
         res = self.file.validate()
         assert VW.NoFormat in res["warnings"][self.file]
 
+        self.file._root.set_attr("version", (1, 2, 0))  # needed for ID check
+        self.file._root.set_attr("id", "")
+        res = self.file.validate()
+        assert VW.NoFileID in res["warnings"][self.file]
+
     def test_check_block(self):
         block = self.file.blocks[0]
         block._h5group.set_attr("name", None)

--- a/nixio/validator.py
+++ b/nixio/validator.py
@@ -81,6 +81,7 @@ class ValidationError(object):
 class ValidationWarning(object):
     NoVersion = "version is not set"
     NoFormat = "format is not set"
+    NoFileID = "file ID is not set"
     InvalidUnit = "unit is not SI or composite of SI units"
     NoExpansionOrigin = ("polynomial coefficients for calibration are set, "
                          "but expansion origin is missing")
@@ -109,6 +110,8 @@ def check_file(nixfile):
         file_warnings.append(ValidationWarning.NoVersion)
     if not nixfile.format:
         file_warnings.append(ValidationWarning.NoFormat)
+    if not nixfile.id and nixfile.version and nixfile.version >= (1, 2, 0):
+        file_warnings.append(ValidationWarning.NoFileID)
     if file_warnings:
         results["warnings"][nixfile] = file_warnings
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,5 @@
+# Scripts
+
+This directory contains development related scripts.  These should not be added to releases.
+
+The [dorelease](./dorelease.py) script prepares the repository for a new release.

--- a/setup.py
+++ b/setup.py
@@ -82,5 +82,8 @@ setup(
     include_package_data=True,
     zip_safe=False,
     data_files=get_wheel_data(),
-    entry_points={'console_scripts': ['nixio-validate=nixio.cmd:validatemain']}
+    entry_points={'console_scripts': [
+        'nixio-validate=nixio.cmd.validate:main',
+        'nixio-upgrade=nixio.cmd.upgrade:main',
+    ]}
 )


### PR DESCRIPTION
This PR is mainly for the upgrade script but also includes some fixes and cleanup.

The script first checks the file header version to see if it's older than the current. If it is, it continues to collect tasks that need to be performed to complete the upgrade.

Tasks are created using functions that check if a change is required and if so, they return a closure bound to the specific filename. The returned function is then run after the user confirms they want to apply the changes. If --force is specified, the changes are applied without prompting.

All checks and changes are made in standalone functions that open the file using h5py and close it immediately after. This makes each change atomic (or atomic-ish) and reduces the chances that a file will be left in an invalid state. There's still a chance the user will stop the
procedure after a change has been applied and before the file version in the header is updated. This will put the file in a sort of invalid state but rerunning the upgrade script should finalise the changes.

Regardless of the possibilities of corruption or invalid states, the user is warned to make sure their files and data are backed up.

If you want to test the script, you can use the files in this GIN repository: https://gin.g-node.org/achilleas/nix-files.  This includes two files from the G-Node/nix-examples repository (which come from Jan) and two more I made, one using nixpy v1.4 and the other using v1.5 (current master).