### PR TITLE
File references

### DIFF
--- a/nixio/block.py
+++ b/nixio/block.py
@@ -49,9 +49,9 @@ class Block(Entity):
         self._data_frames = None
 
     @classmethod
-    def _create_new(cls, nixparent, h5parent, name, type_, compression):
-        newentity = super(Block, cls)._create_new(nixparent, h5parent,
-                                                  name, type_)
+    def create_new(cls, nixparent, h5parent, name, type_, compression):
+        newentity = super(Block, cls).create_new(nixparent, h5parent,
+                                                 name, type_)
         newentity._compr = compression
         return newentity
 
@@ -101,8 +101,8 @@ class Block(Entity):
                                                  "{}-extents".format(type_),
                                                  data=extents)
                 extcreated = True
-            mtag = MultiTag._create_new(self, multi_tags,
-                                        name, type_, positions)
+            mtag = MultiTag.create_new(self, multi_tags,
+                                       name, type_, positions)
         except Exception as e:
             msg = "MultiTag Creation Failed"
             if poscreated:
@@ -150,7 +150,7 @@ class Block(Entity):
         tags = self._h5group.open_group("tags")
         if name in tags:
             raise exceptions.DuplicateName("create_tag")
-        tag = Tag._create_new(self, tags, name, type_, position)
+        tag = Tag.create_new(self, tags, name, type_, position)
         return tag
 
     # Source
@@ -170,7 +170,7 @@ class Block(Entity):
         sources = self._h5group.open_group("sources")
         if name in sources:
             raise exceptions.DuplicateName("create_source")
-        src = Source._create_new(self, sources, name, type_)
+        src = Source.create_new(self, sources, name, type_)
         return src
 
     # Group
@@ -190,7 +190,7 @@ class Block(Entity):
         groups = self._h5group.open_group("groups")
         if name in groups:
             raise exceptions.DuplicateName("open_group")
-        grp = Group._create_new(self, groups, name, type_)
+        grp = Group.create_new(self, groups, name, type_)
         return grp
 
     def create_data_array(self, name="", array_type="", dtype=None, shape=None,
@@ -250,8 +250,8 @@ class Block(Entity):
             raise exceptions.DuplicateName("create_data_array")
         if compression == Compression.Auto:
             compression = self._compr
-        da = DataArray._create_new(self, data_arrays, name, array_type,
-                                   dtype, shape, compression)
+        da = DataArray.create_new(self, data_arrays, name, array_type,
+                                  dtype, shape, compression)
         if data is not None:
             da.write_direct(data)
         return da
@@ -328,7 +328,7 @@ class Block(Entity):
                     )
                 else:  # col_dtypes is None and data is None
                     raise ValueError(
-                           "The data type of each column have to be specified"
+                        "The data type of each column have to be specified"
                     )
                 if len(col_names) != len(col_dict):
                     raise exceptions.DuplicateColumnName
@@ -348,7 +348,7 @@ class Block(Entity):
                     # data is None or type(data[0]) != np.void
                     # data_type doesnt matter
                     raise ValueError(
-                           "No information about column names is provided!"
+                        "No information about column names is provided!"
                     )
 
         if col_dict is not None:
@@ -362,8 +362,8 @@ class Block(Entity):
             dt_arr = list(col_dict.items())
             col_dtype = np.dtype(dt_arr)
 
-        df = DataFrame._create_new(self, data_frames, name,
-                                   type_, shape, col_dtype, compression)
+        df = DataFrame.create_new(self, data_frames, name,
+                                  type_, shape, col_dtype, compression)
 
         if data is not None:
             if type(data[0]) == np.void:

--- a/nixio/container.py
+++ b/nixio/container.py
@@ -57,10 +57,7 @@ class Container(object):
                     self._itemclass.__name__)
             )
 
-        root = self._backend.h5root
-        if not root:
-            root = self._parent._h5group
-        root.delete_all([item.id])
+        self._file._h5group.delete_all([item.id])
 
     def __iter__(self):
         for group in self._backend:
@@ -122,8 +119,7 @@ class SectionContainer(Container):
         # the root block
         secids = [s.id for s in item.find_sections()]
 
-        root = self._backend.file
-        root.delete_all(secids)
+        self._file._h5group.delete_all(secids)
 
 
 class SourceContainer(Container):
@@ -146,9 +142,7 @@ class SourceContainer(Container):
         # the root block
         srcids = [s.id for s in item.find_sources()]
         srcids.append(item.id)
-
-        root = self._backend.h5root
-        root.delete_all(srcids)
+        self._file._h5group.delete_all(srcids)
 
 
 class LinkContainer(Container):

--- a/nixio/container.py
+++ b/nixio/container.py
@@ -23,14 +23,15 @@ class Container(object):
     checking and instantiations)
     """
 
-    def __init__(self, name, parent, itemclass):
+    def __init__(self, name, nixfile, parent, itemclass):
         self._backend = parent._h5group.open_group(name)
         self._itemclass = itemclass
+        self._file = nixfile
         self._parent = parent
         self._name = name
 
     def _inst_item(self, item):
-        return self._itemclass(self._parent, item)
+        return self._itemclass(self._file, self._parent, item)
 
     def __len__(self):
         return len(self._backend)
@@ -180,7 +181,8 @@ class LinkContainer(Container):
     """
 
     def __init__(self, name, parent, itemclass, itemstore):
-        super(LinkContainer, self).__init__(name, parent, itemclass)
+        super(LinkContainer, self).__init__(name, parent.file,
+                                            parent, itemclass)
         self._itemstore = itemstore
 
     def __delitem__(self, item):
@@ -249,7 +251,7 @@ class LinkContainer(Container):
         return False
 
     def _inst_item(self, item):
-        return self._itemclass(self._itemstore._parent, item)
+        return self._itemclass(self._file, self._itemstore._parent, item)
 
     @staticmethod
     def _item_key(item):

--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -188,7 +188,10 @@ class DataArray(Entity, DataSet):
                     "Current SI unit is {}".format(u),
                     "DataArray.append_alias_range_dimension"
                 )
-        return RangeDimension.create_new_alias(self, 1)
+        aliasdim = RangeDimension.create_new_alias(self, 1)
+        if self.file.auto_update_timestamps:
+            self.force_updated_at()
+        return aliasdim
 
     def delete_dimensions(self):
         """

--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -89,7 +89,7 @@ class DataArray(Entity, DataSet):
         setdim = SetDimension.create_new(self, index)
         if labels:
             setdim.labels = labels
-        if self._parent._parent.time_auto_update:
+        if self.file.time_auto_update:
             self.force_updated_at()
         return setdim
 
@@ -114,7 +114,7 @@ class DataArray(Entity, DataSet):
             smpldim.unit = unit
         if offset:
             smpldim.offset = offset
-        if self._parent._parent.time_auto_update:
+        if self.file.time_auto_update:
             self.force_updated_at()
         return smpldim
 
@@ -134,7 +134,7 @@ class DataArray(Entity, DataSet):
         if label:
             rdim.label = label
             rdim.unit = unit
-        if self._parent._parent.time_auto_update:
+        if self.file.time_auto_update:
             self.force_updated_at()
         return rdim
 
@@ -157,7 +157,7 @@ class DataArray(Entity, DataSet):
         index = len(self.dimensions) + 1
         dfdim = DataFrameDimension.create_new(self, index,
                                               data_frame, column_idx)
-        if self._parent._parent.time_auto_update:
+        if self.file.time_auto_update:
             self.force_updated_at()
         return dfdim
 
@@ -252,7 +252,7 @@ class DataArray(Entity, DataSet):
         else:
             dtype = DataType.Double
             self._h5group.write_data("polynom_coefficients", coeff, dtype)
-        if self._parent._parent.time_auto_update:
+        if self.file.time_auto_update:
             self.force_updated_at()
 
     @property
@@ -270,7 +270,7 @@ class DataArray(Entity, DataSet):
     def expansion_origin(self, eo):
         util.check_attr_type(eo, Number)
         self._h5group.set_attr("expansion_origin", eo)
-        if self._parent._parent.time_auto_update:
+        if self.file.time_auto_update:
             self.force_updated_at()
 
     @property
@@ -288,7 +288,7 @@ class DataArray(Entity, DataSet):
     def label(self, l):
         util.check_attr_type(l, str)
         self._h5group.set_attr("label", l)
-        if self._parent._parent.time_auto_update:
+        if self.file.time_auto_update:
             self.force_updated_at()
 
     @property
@@ -318,7 +318,7 @@ class DataArray(Entity, DataSet):
                     "DataArray.unit"
                 )
         self._h5group.set_attr("unit", u)
-        if self._parent._parent.time_auto_update:
+        if self.file.time_auto_update:
             self.force_updated_at()
 
     def get_slice(self, positions, extents=None, mode=DataSliceMode.Index):

--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -38,10 +38,10 @@ class DataArray(Entity, DataSet):
         self._dimensions = None
 
     @classmethod
-    def _create_new(cls, nixparent, h5parent, name, type_, data_type, shape,
-                    compression):
-        newentity = super(DataArray, cls)._create_new(nixparent, h5parent,
-                                                      name, type_)
+    def create_new(cls, nixparent, h5parent, name, type_, data_type, shape,
+                   compression):
+        newentity = super(DataArray, cls).create_new(nixparent, h5parent,
+                                                     name, type_)
         datacompr = False
         if compression == Compression.DeflateNormal:
             datacompr = True
@@ -87,7 +87,7 @@ class DataArray(Entity, DataSet):
         """
         dimgroup = self._h5group.open_group("dimensions")
         index = len(dimgroup) + 1
-        setdim = SetDimension._create_new(dimgroup, index)
+        setdim = SetDimension.create_new(dimgroup, index)
         if labels:
             setdim.labels = labels
         if self._parent._parent.time_auto_update:
@@ -109,8 +109,8 @@ class DataArray(Entity, DataSet):
         """
         dimgroup = self._h5group.open_group("dimensions")
         index = len(dimgroup) + 1
-        smpldim = SampledDimension._create_new(dimgroup, index,
-                                               sampling_interval)
+        smpldim = SampledDimension.create_new(dimgroup, index,
+                                              sampling_interval)
         if label:
             smpldim.label = label
         if unit:
@@ -134,7 +134,7 @@ class DataArray(Entity, DataSet):
         """
         dimgroup = self._h5group.open_group("dimensions")
         index = len(dimgroup) + 1
-        rdim = RangeDimension._create_new(dimgroup, index, ticks)
+        rdim = RangeDimension.create_new(dimgroup, index, ticks)
         if label:
             rdim.label = label
             rdim.unit = unit
@@ -160,8 +160,8 @@ class DataArray(Entity, DataSet):
         """
         dimgroup = self._h5group.open_group("dimensions")
         index = len(dimgroup) + 1
-        dfdim = DataFrameDimension._create_new(dimgroup, index,
-                                               data_frame, column_idx)
+        dfdim = DataFrameDimension.create_new(dimgroup, index,
+                                              data_frame, column_idx)
         if self._parent._parent.time_auto_update:
             self.force_updated_at()
         return dfdim
@@ -194,7 +194,7 @@ class DataArray(Entity, DataSet):
                     "Current SI unit is {}".format(u),
                     "DataArray.append_alias_range_dimension"
                 )
-        return RangeDimension._create_new_alias(dimgroup, 1, self)
+        return RangeDimension.create_new_alias(dimgroup, 1, self)
 
     def delete_dimensions(self):
         """
@@ -315,7 +315,7 @@ class DataArray(Entity, DataSet):
             u = None
         util.check_attr_type(u, str)
         if (self._dimension_count() == 1 and
-            self.dimensions[0].dimension_type == DimensionType.Range and
+                self.dimensions[0].dimension_type == DimensionType.Range and
                 self.dimensions[0].is_alias and u is not None):
             if not (util.units.is_si(u) or util.units.is_compound(u)):
                 raise InvalidUnit(

--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -89,7 +89,7 @@ class DataArray(Entity, DataSet):
         setdim = SetDimension.create_new(self, index)
         if labels:
             setdim.labels = labels
-        if self.file.time_auto_update:
+        if self.file.auto_update_timestamps:
             self.force_updated_at()
         return setdim
 
@@ -114,7 +114,7 @@ class DataArray(Entity, DataSet):
             smpldim.unit = unit
         if offset:
             smpldim.offset = offset
-        if self.file.time_auto_update:
+        if self.file.auto_update_timestamps:
             self.force_updated_at()
         return smpldim
 
@@ -134,7 +134,7 @@ class DataArray(Entity, DataSet):
         if label:
             rdim.label = label
             rdim.unit = unit
-        if self.file.time_auto_update:
+        if self.file.auto_update_timestamps:
             self.force_updated_at()
         return rdim
 
@@ -157,7 +157,7 @@ class DataArray(Entity, DataSet):
         index = len(self.dimensions) + 1
         dfdim = DataFrameDimension.create_new(self, index,
                                               data_frame, column_idx)
-        if self.file.time_auto_update:
+        if self.file.auto_update_timestamps:
             self.force_updated_at()
         return dfdim
 
@@ -252,7 +252,7 @@ class DataArray(Entity, DataSet):
         else:
             dtype = DataType.Double
             self._h5group.write_data("polynom_coefficients", coeff, dtype)
-        if self.file.time_auto_update:
+        if self.file.auto_update_timestamps:
             self.force_updated_at()
 
     @property
@@ -270,7 +270,7 @@ class DataArray(Entity, DataSet):
     def expansion_origin(self, eo):
         util.check_attr_type(eo, Number)
         self._h5group.set_attr("expansion_origin", eo)
-        if self.file.time_auto_update:
+        if self.file.auto_update_timestamps:
             self.force_updated_at()
 
     @property
@@ -288,7 +288,7 @@ class DataArray(Entity, DataSet):
     def label(self, l):
         util.check_attr_type(l, str)
         self._h5group.set_attr("label", l)
-        if self.file.time_auto_update:
+        if self.file.auto_update_timestamps:
             self.force_updated_at()
 
     @property
@@ -318,7 +318,7 @@ class DataArray(Entity, DataSet):
                     "DataArray.unit"
                 )
         self._h5group.set_attr("unit", u)
-        if self.file.time_auto_update:
+        if self.file.auto_update_timestamps:
             self.force_updated_at()
 
     def get_slice(self, positions, extents=None, mode=DataSliceMode.Index):

--- a/nixio/data_frame.py
+++ b/nixio/data_frame.py
@@ -348,7 +348,7 @@ class DataFrame(Entity, DataSet):
                 util.check_attr_type(i, str)
         unit = np.array(u, util.vlen_str_dtype)
         self._h5group.set_attr("units", unit)
-        if self.file.time_auto_update:
+        if self.file.auto_update_timestamps:
             self.force_updated_at()
 
     @property

--- a/nixio/data_frame.py
+++ b/nixio/data_frame.py
@@ -348,7 +348,7 @@ class DataFrame(Entity, DataSet):
                 util.check_attr_type(i, str)
         unit = np.array(u, util.vlen_str_dtype)
         self._h5group.set_attr("units", unit)
-        if self._parent._parent.time_auto_update:
+        if self.file.time_auto_update:
             self.force_updated_at()
 
     @property

--- a/nixio/data_frame.py
+++ b/nixio/data_frame.py
@@ -33,10 +33,10 @@ class DataFrame(Entity, DataSet):
         self._rows = None
 
     @classmethod
-    def _create_new(cls, nixparent, h5parent,
-                    name, type_, shape, col_dtype, compression):
-        newentity = super(DataFrame, cls)._create_new(nixparent, h5parent,
-                                                      name, type_)
+    def create_new(cls, nixparent, h5parent, name, type_,
+                   shape, col_dtype, compression):
+        newentity = super(DataFrame, cls).create_new(nixparent, h5parent,
+                                                     name, type_)
         newentity._h5group.create_dataset("data", (shape, ), col_dtype)
         return newentity
 

--- a/nixio/data_frame.py
+++ b/nixio/data_frame.py
@@ -26,17 +26,17 @@ import csv
 
 class DataFrame(Entity, DataSet):
 
-    def __init__(self, nixparent, h5group):
-        super(DataFrame, self).__init__(nixparent, h5group)
+    def __init__(self, nixfile, nixparent, h5group):
+        super(DataFrame, self).__init__(nixfile, nixparent, h5group)
         self._sources = None
         self._columns = None
         self._rows = None
 
     @classmethod
-    def create_new(cls, nixparent, h5parent, name, type_,
+    def create_new(cls, nixfile, nixparent, h5parent, name, type_,
                    shape, col_dtype, compression):
-        newentity = super(DataFrame, cls).create_new(nixparent, h5parent,
-                                                     name, type_)
+        newentity = super(DataFrame, cls).create_new(nixfile, nixparent,
+                                                     h5parent, name, type_)
         newentity._h5group.create_dataset("data", (shape, ), col_dtype)
         return newentity
 
@@ -423,7 +423,8 @@ class DataFrame(Entity, DataSet):
         :type: Section
         """
         if "metadata" in self._h5group:
-            return Section(None, self._h5group.open_group("metadata"))
+            return Section(self.file, None,
+                           self._h5group.open_group("metadata"))
         else:
             return None
 

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -42,7 +42,7 @@ class Dimension(object):
         self.dim_index = int(index)
 
     @classmethod
-    def _create_new(cls, parent, index):
+    def create_new(cls, parent, index):
         h5group = parent.open_group(str(index))
         newdim = cls(h5group, index)
         return newdim
@@ -76,8 +76,8 @@ class SampledDimension(Dimension):
         super(SampledDimension, self).__init__(h5group, index)
 
     @classmethod
-    def _create_new(cls, parent, index, sample):
-        newdim = super(SampledDimension, cls)._create_new(parent, index)
+    def create_new(cls, parent, index, sample):
+        newdim = super(SampledDimension, cls).create_new(parent, index)
         newdim._set_dimension_type(DimensionType.Sample)
         newdim.sampling_interval = sample
         return newdim
@@ -172,15 +172,15 @@ class RangeDimension(Dimension):
         super(RangeDimension, self).__init__(h5group, index)
 
     @classmethod
-    def _create_new(cls, parent, index, ticks):
-        newdim = super(RangeDimension, cls)._create_new(parent, index)
+    def create_new(cls, parent, index, ticks):
+        newdim = super(RangeDimension, cls).create_new(parent, index)
         newdim._set_dimension_type(DimensionType.Range)
         newdim._h5group.write_data("ticks", ticks, dtype=DataType.Double)
         return newdim
 
     @classmethod
-    def _create_new_alias(cls, parent, index, da):
-        newdim = super(RangeDimension, cls)._create_new(parent, index)
+    def create_new_alias(cls, parent, index, da):
+        newdim = super(RangeDimension, cls).create_new(parent, index)
         newdim._set_dimension_type(DimensionType.Range)
         newdim._h5group.create_link(da, da.id)
         return newdim
@@ -301,8 +301,8 @@ class SetDimension(Dimension):
         super(SetDimension, self).__init__(h5group, index)
 
     @classmethod
-    def _create_new(cls, parent, index):
-        newdim = super(SetDimension, cls)._create_new(parent, index)
+    def create_new(cls, parent, index):
+        newdim = super(SetDimension, cls).create_new(parent, index)
         newdim._set_dimension_type(DimensionType.Set)
         return newdim
 
@@ -325,7 +325,7 @@ class DataFrameDimension(Dimension):
         super(DataFrameDimension, self).__init__(h5group, index)
 
     @classmethod
-    def _create_new(cls, parent, index, data_frame, column):
+    def create_new(cls, parent, index, data_frame, column):
         """
         Create a new Dimension that points to a DataFrame
 
@@ -338,7 +338,7 @@ class DataFrameDimension(Dimension):
 
         :return: The new DataFrameDimension
         """
-        newdim = super(DataFrameDimension, cls)._create_new(parent, index)
+        newdim = super(DataFrameDimension, cls).create_new(parent, index)
         newdim.data_frame = data_frame
         newdim.column_idx = column
         newdim._set_dimension_type(DimensionType.DataFrame)

--- a/nixio/entity.py
+++ b/nixio/entity.py
@@ -16,6 +16,7 @@ class Entity(object):
         util.check_entity_id(h5group.get_attr("entity_id"))
         self._h5group = h5group
         self._parent = nixparent
+        self._file = None
 
     @classmethod
     def create_new(cls, nixparent, h5parent, name=None, type_=None):
@@ -53,6 +54,16 @@ class Entity(object):
         :rtype: int
         """
         return util.str_to_time(self._h5group.get_attr("created_at"))
+
+    @property
+    def file(self):
+        """
+        Reference to the NIX File object.
+        This is a read-only property.
+
+        :rtype: nixio.File
+        """
+        return self._file
 
     def force_created_at(self, t=None):
         """

--- a/nixio/entity.py
+++ b/nixio/entity.py
@@ -12,14 +12,14 @@ from . import util
 
 class Entity(object):
 
-    def __init__(self, nixparent, h5group):
+    def __init__(self, nixfile, nixparent, h5group):
         util.check_entity_id(h5group.get_attr("entity_id"))
         self._h5group = h5group
         self._parent = nixparent
-        self._file = None
+        self._file = nixfile
 
     @classmethod
-    def create_new(cls, nixparent, h5parent, name=None, type_=None):
+    def create_new(cls, nixfile, nixparent, h5parent, name=None, type_=None):
         if name and type_:
             util.check_entity_name_and_type(name, type_)
             id_ = util.create_id()
@@ -30,7 +30,8 @@ class Entity(object):
         h5group.set_attr("name", name)
         h5group.set_attr("type", type_)
         h5group.set_attr("entity_id", id_)
-        newentity = cls(nixparent, h5group)
+
+        newentity = cls(nixfile, nixparent, h5group)
         newentity.force_created_at()
         newentity.force_updated_at()
         return newentity

--- a/nixio/entity.py
+++ b/nixio/entity.py
@@ -120,10 +120,7 @@ class Entity(object):
     def definition(self, d):
         util.check_attr_type(d, str)
         self._h5group.set_attr("definition", d)
-        par = self._parent
-        while isinstance(par, Entity):
-            par = par._parent
-        if par.time_auto_update:
+        if self.file.time_auto_update:
             self.force_updated_at()
 
     @property
@@ -154,10 +151,7 @@ class Entity(object):
             raise AttributeError("type can't be None")
         util.check_attr_type(t, str)
         self._h5group.set_attr("type", t)
-        par = self._parent
-        while isinstance(par, Entity):
-            par = par._parent
-        if par.time_auto_update:
+        if self.file.time_auto_update:
             self.force_updated_at()
 
     def __eq__(self, other):

--- a/nixio/entity.py
+++ b/nixio/entity.py
@@ -18,7 +18,7 @@ class Entity(object):
         self._parent = nixparent
 
     @classmethod
-    def _create_new(cls, nixparent, h5parent, name=None, type_=None):
+    def create_new(cls, nixparent, h5parent, name=None, type_=None):
         if name and type_:
             util.check_entity_name_and_type(name, type_)
             id_ = util.create_id()

--- a/nixio/entity.py
+++ b/nixio/entity.py
@@ -120,7 +120,7 @@ class Entity(object):
     def definition(self, d):
         util.check_attr_type(d, str)
         self._h5group.set_attr("definition", d)
-        if self.file.time_auto_update:
+        if self.file.auto_update_timestamps:
             self.force_updated_at()
 
     @property
@@ -151,7 +151,7 @@ class Entity(object):
             raise AttributeError("type can't be None")
         util.check_attr_type(t, str)
         self._h5group.set_attr("type", t)
-        if self.file.time_auto_update:
+        if self.file.auto_update_timestamps:
             self.force_updated_at()
 
     def __eq__(self, other):

--- a/nixio/feature.py
+++ b/nixio/feature.py
@@ -40,6 +40,10 @@ class Feature(object):
         return self._h5group.get_attr("entity_id")
 
     @property
+    def file(self):
+        return self._file
+
+    @property
     def link_type(self):
         return LinkType(self._h5group.get_attr("link_type"))
 
@@ -49,7 +53,7 @@ class Feature(object):
             lt = lt.lower()
         lt = LinkType(lt)
         self._h5group.set_attr("link_type", lt.value)
-        if self._file.time_auto_update:
+        if self.file.time_auto_update:
             t = util.now_int()
             self._h5group.set_attr("updated_at", util.time_to_str(t))
 
@@ -57,7 +61,7 @@ class Feature(object):
     def data(self):
         if "data" not in self._h5group:
             raise RuntimeError("Feature.data: DataArray not found!")
-        return DataArray(self._file, self._parent._parent,
+        return DataArray(self.file, self._parent._parent,
                          self._h5group.open_group("data"))
 
     @data.setter
@@ -70,7 +74,7 @@ class Feature(object):
         if "data" in self._h5group:
             del self._h5group["data"]
         self._h5group.create_link(da, "data")
-        if self._file.time_auto_update:
+        if self.file.time_auto_update:
             t = util.now_int()
             self._h5group.set_attr("updated_at", util.time_to_str(t))
 

--- a/nixio/feature.py
+++ b/nixio/feature.py
@@ -14,17 +14,18 @@ from .util import util
 
 class Feature(object):
 
-    def __init__(self, nixparent, h5group):
+    def __init__(self, nixfile, nixparent, h5group):
         util.check_entity_id(h5group.get_attr("entity_id"))
         self._h5group = h5group
         self._parent = nixparent
+        self._file = nixfile
 
     @classmethod
-    def create_new(cls, nixparent, h5parent, data, link_type):
+    def create_new(cls, nixfile, nixparent, h5parent, data, link_type):
         id_ = util.create_id()
         h5group = h5parent.open_group(id_)
         h5group.set_attr("entity_id", id_)
-        newfeature = cls(nixparent, h5group)
+        newfeature = cls(nixfile, nixparent, h5group)
         newfeature.link_type = link_type
         newfeature.data = data
         newfeature._h5group.set_attr("created_at",
@@ -56,7 +57,7 @@ class Feature(object):
     def data(self):
         if "data" not in self._h5group:
             raise RuntimeError("Feature.data: DataArray not found!")
-        return DataArray(self._parent._parent,
+        return DataArray(self._file, self._parent._parent,
                          self._h5group.open_group("data"))
 
     @data.setter

--- a/nixio/feature.py
+++ b/nixio/feature.py
@@ -53,7 +53,7 @@ class Feature(object):
             lt = lt.lower()
         lt = LinkType(lt)
         self._h5group.set_attr("link_type", lt.value)
-        if self.file.time_auto_update:
+        if self.file.auto_update_timestamps:
             t = util.now_int()
             self._h5group.set_attr("updated_at", util.time_to_str(t))
 
@@ -74,7 +74,7 @@ class Feature(object):
         if "data" in self._h5group:
             del self._h5group["data"]
         self._h5group.create_link(da, "data")
-        if self.file.time_auto_update:
+        if self.file.auto_update_timestamps:
             t = util.now_int()
             self._h5group.set_attr("updated_at", util.time_to_str(t))
 

--- a/nixio/feature.py
+++ b/nixio/feature.py
@@ -20,7 +20,7 @@ class Feature(object):
         self._parent = nixparent
 
     @classmethod
-    def _create_new(cls, nixparent, h5parent, data, link_type):
+    def create_new(cls, nixparent, h5parent, data, link_type):
         id_ = util.create_id()
         h5group = h5parent.open_group(id_)
         h5group.set_attr("entity_id", id_)

--- a/nixio/feature.py
+++ b/nixio/feature.py
@@ -49,7 +49,7 @@ class Feature(object):
             lt = lt.lower()
         lt = LinkType(lt)
         self._h5group.set_attr("link_type", lt.value)
-        if self._parent._parent._parent.time_auto_update:
+        if self._file.time_auto_update:
             t = util.now_int()
             self._h5group.set_attr("updated_at", util.time_to_str(t))
 
@@ -70,7 +70,7 @@ class Feature(object):
         if "data" in self._h5group:
             del self._h5group["data"]
         self._h5group.create_link(da, "data")
-        if self._parent._parent._parent.time_auto_update:
+        if self._file.time_auto_update:
             t = util.now_int()
             self._h5group.set_attr("updated_at", util.time_to_str(t))
 

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -437,7 +437,7 @@ class File(object):
         """
         if name in self.sections:
             raise DuplicateName("create_section")
-        sec = Section.create_new(self, self._metadata, name, type_, oid)
+        sec = Section.create_new(self, self, self._metadata, name, type_, oid)
         return sec
 
     @property
@@ -450,7 +450,7 @@ class File(object):
         create_block method of File. This is a read-only attribute.
         """
         if self._blocks is None:
-            self._blocks = Container("data", self, Block)
+            self._blocks = Container("data", self, self, Block)
         return self._blocks
 
     def find_sections(self, filtr=lambda _: True, limit=None):
@@ -486,7 +486,7 @@ class File(object):
         This is a read-only property.
         """
         if self._sections is None:
-            self._sections = SectionContainer("metadata", self, Section)
+            self._sections = SectionContainer("metadata", self, self, Section)
         return self._sections
 
 

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -416,7 +416,7 @@ class File(object):
             raise ValueError("Block with the given name already exists!")
         if compression == Compression.Auto:
             compression = self._compr
-        block = Block._create_new(self, self._data, name, type_, compression)
+        block = Block.create_new(self, self._data, name, type_, compression)
         return block
 
     # Section
@@ -437,7 +437,7 @@ class File(object):
         """
         if name in self.sections:
             raise DuplicateName("create_section")
-        sec = Section._create_new(self, self._metadata, name, type_, oid)
+        sec = Section.create_new(self, self._metadata, name, type_, oid)
         return sec
 
     @property

--- a/nixio/group.py
+++ b/nixio/group.py
@@ -28,9 +28,9 @@ class Group(Entity):
         self._sources = None
 
     @classmethod
-    def _create_new(cls, nixparent, h5parent, name, type_):
-        newentity = super(Group, cls)._create_new(nixparent, h5parent,
-                                                  name, type_)
+    def create_new(cls, nixparent, h5parent, name, type_):
+        newentity = super(Group, cls).create_new(nixparent, h5parent,
+                                                 name, type_)
         return newentity
 
     @property

--- a/nixio/group.py
+++ b/nixio/group.py
@@ -19,8 +19,8 @@ from .section import Section
 
 class Group(Entity):
 
-    def __init__(self, nixparent, h5group):
-        super(Group, self).__init__(nixparent, h5group)
+    def __init__(self, nixfile, nixparent, h5group):
+        super(Group, self).__init__(nixfile, nixparent, h5group)
         self._data_arrays = None
         self._data_frames = None
         self._tags = None
@@ -28,8 +28,8 @@ class Group(Entity):
         self._sources = None
 
     @classmethod
-    def create_new(cls, nixparent, h5parent, name, type_):
-        newentity = super(Group, cls).create_new(nixparent, h5parent,
+    def create_new(cls, nixfile, nixparent, h5parent, name, type_):
+        newentity = super(Group, cls).create_new(nixfile, nixparent, h5parent,
                                                  name, type_)
         return newentity
 
@@ -115,7 +115,8 @@ class Group(Entity):
         :type: Section
         """
         if "metadata" in self._h5group:
-            return Section(None, self._h5group.open_group("metadata"))
+            return Section(self.file, None,
+                           self._h5group.open_group("metadata"))
         else:
             return None
 

--- a/nixio/hdf5/h5group.py
+++ b/nixio/hdf5/h5group.py
@@ -12,11 +12,8 @@ import numpy as np
 
 from .h5dataset import H5DataSet
 from ..datatype import DataType
-from ..block import Block
-from ..section import Section
 
 from .. import util
-from ..exceptions import InvalidEntity
 
 
 class H5Group(object):
@@ -296,56 +293,6 @@ class H5Group(object):
             g.attrs.modify("entity_id", np.string_(id_))
             g.visititems(change_id)
         return g
-
-    @property
-    def file(self):
-        """
-        An H5Group object which represents the file root.
-
-        :return: H5Group at '/'
-        """
-        return H5Group(self.group.file, "/", create=False)
-
-    @property
-    def h5root(self):
-        """
-        Returns the H5Group of the Block or top-level Section which contains
-        this object. Returns None if requested on the file root '/' or the
-        /data or /metadata groups.
-
-        :return: Top level object containing this group (H5Group)
-        """
-        pathparts = self.group.name.split("/")
-        if len(pathparts) == 3:
-            return self
-        if self.group.name == "/":
-            return None
-        if len(pathparts) == 2:
-            return None
-
-        return self.parent.h5root
-
-    @property
-    def root(self):
-        """
-        Returns the Block or top-level Section which contains this object.
-        Returns None if requested on the file root '/' or the /data or
-        /metadata groups.
-
-        :return: Top level object containing this group (Block or Section)
-        """
-        h5root = self.h5root
-        if h5root is None:
-            return None
-        topgroup = self.group.name.split("/")[1]
-        if topgroup == "data":
-            cls = Block
-            return cls(h5root.parent, h5root)
-        elif topgroup == "metadata":
-            cls = Section
-            return cls(h5root.parent, h5root)
-        else:
-            raise InvalidEntity
 
     @property
     def parent(self):

--- a/nixio/multi_tag.py
+++ b/nixio/multi_tag.py
@@ -29,9 +29,9 @@ class MultiTag(BaseTag):
         self._features = None
 
     @classmethod
-    def _create_new(cls, nixparent, h5parent, name, type_, positions):
-        newentity = super(MultiTag, cls)._create_new(nixparent, h5parent,
-                                                     name, type_)
+    def create_new(cls, nixparent, h5parent, name, type_, positions):
+        newentity = super(MultiTag, cls).create_new(nixparent, h5parent,
+                                                    name, type_)
         newentity.positions = positions
         return newentity
 

--- a/nixio/multi_tag.py
+++ b/nixio/multi_tag.py
@@ -109,11 +109,6 @@ class MultiTag(BaseTag):
             self._features = FeatureContainer("features", self, Feature)
         return self._features
 
-    def _get_slice(self, data, index):
-        offset, count = self._get_offset_and_count(data, index)
-        sl = tuple(slice(o, o + c) for o, c in zip(offset, count))
-        return sl
-
     def _calc_data_slices(self, data, index):
         positions = self.positions
         extents = self.extents

--- a/nixio/multi_tag.py
+++ b/nixio/multi_tag.py
@@ -22,16 +22,16 @@ from .section import Section
 
 class MultiTag(BaseTag):
 
-    def __init__(self, nixparent, h5group):
-        super(MultiTag, self).__init__(nixparent, h5group)
+    def __init__(self, nixfile, nixparent, h5group):
+        super(MultiTag, self).__init__(nixfile, nixparent, h5group)
         self._sources = None
         self._references = None
         self._features = None
 
     @classmethod
-    def create_new(cls, nixparent, h5parent, name, type_, positions):
-        newentity = super(MultiTag, cls).create_new(nixparent, h5parent,
-                                                    name, type_)
+    def create_new(cls, nixfile, nixparent, h5parent, name, type_, positions):
+        newentity = super(MultiTag, cls).create_new(nixfile, nixparent,
+                                                    h5parent, name, type_)
         newentity.positions = positions
         return newentity
 
@@ -44,7 +44,8 @@ class MultiTag(BaseTag):
         """
         if "positions" not in self._h5group:
             raise RuntimeError("MultiTag.positions: DataArray not found!")
-        return DataArray(self._parent, self._h5group.open_group("positions"))
+        return DataArray(self.file, self._parent,
+                         self._h5group.open_group("positions"))
 
     @positions.setter
     def positions(self, da):
@@ -65,9 +66,9 @@ class MultiTag(BaseTag):
         :type: DataArray or None
         """
         if "extents" in self._h5group:
-            return DataArray(self._parent, self._h5group.open_group("extents"))
-        else:
-            return None
+            return DataArray(self.file, self._parent,
+                             self._h5group.open_group("extents"))
+        return None
 
     @extents.setter
     def extents(self, da):
@@ -106,7 +107,8 @@ class MultiTag(BaseTag):
         :type: Container of Feature.
         """
         if self._features is None:
-            self._features = FeatureContainer("features", self, Feature)
+            self._features = FeatureContainer("features", self.file,
+                                              self, Feature)
         return self._features
 
     def _calc_data_slices(self, data, index):
@@ -261,7 +263,7 @@ class MultiTag(BaseTag):
         :type: Section
         """
         if "metadata" in self._h5group:
-            return Section(None, self._h5group.open_group("metadata"))
+            return Section(self.file, None, self._h5group.open_group("metadata"))
         else:
             return None
 

--- a/nixio/multi_tag.py
+++ b/nixio/multi_tag.py
@@ -54,7 +54,7 @@ class MultiTag(BaseTag):
         if "positions" in self._h5group:
             del self._h5group["positions"]
         self._h5group.create_link(da, "positions")
-        if self._parent._parent.time_auto_update:
+        if self.file.time_auto_update:
             self.force_updated_at()
 
     @property
@@ -76,7 +76,7 @@ class MultiTag(BaseTag):
             del self._h5group["extents"]
         else:
             self._h5group.create_link(da, "extents")
-        if self._parent._parent.time_auto_update:
+        if self.file.time_auto_update:
             self.force_updated_at()
 
     @property

--- a/nixio/multi_tag.py
+++ b/nixio/multi_tag.py
@@ -54,7 +54,7 @@ class MultiTag(BaseTag):
         if "positions" in self._h5group:
             del self._h5group["positions"]
         self._h5group.create_link(da, "positions")
-        if self.file.time_auto_update:
+        if self.file.auto_update_timestamps:
             self.force_updated_at()
 
     @property
@@ -76,7 +76,7 @@ class MultiTag(BaseTag):
             del self._h5group["extents"]
         else:
             self._h5group.create_link(da, "extents")
-        if self.file.time_auto_update:
+        if self.file.auto_update_timestamps:
             self.force_updated_at()
 
     @property

--- a/nixio/property.py
+++ b/nixio/property.py
@@ -97,8 +97,8 @@ class Property(Entity):
         self._h5dataset = self._h5group
 
     @classmethod
-    def _create_new(cls, nixparent, h5parent, name,
-                    dtype, shape=None, oid=None):
+    def create_new(cls, nixparent, h5parent, name,
+                   dtype, shape=None, oid=None):
         if shape is None or shape[0] == 0:
             shape = (8, )
         util.check_entity_name(name)

--- a/nixio/property.py
+++ b/nixio/property.py
@@ -92,12 +92,12 @@ class OdmlType(Enum):
 
 class Property(Entity):
     """An odML Property"""
-    def __init__(self, nixparent, h5dataset):
-        super(Property, self).__init__(nixparent, h5dataset)
+    def __init__(self, nixfile, nixparent, h5dataset):
+        super(Property, self).__init__(nixfile, nixparent, h5dataset)
         self._h5dataset = self._h5group
 
     @classmethod
-    def create_new(cls, nixparent, h5parent, name,
+    def create_new(cls, nixfile, nixparent, h5parent, name,
                    dtype, shape=None, oid=None):
         if shape is None or shape[0] == 0:
             shape = (8, )
@@ -112,7 +112,7 @@ class Property(Entity):
 
         h5dataset.set_attr("entity_id", oid)
 
-        newentity = cls(nixparent, h5dataset)
+        newentity = cls(nixfile, nixparent, h5dataset)
         newentity.force_created_at()
         newentity.force_updated_at()
 

--- a/nixio/section.py
+++ b/nixio/section.py
@@ -293,9 +293,8 @@ class Section(Entity):
         """
         if self._sec_parent is not None:
             return self._sec_parent
-        rootmd = self._h5group.file.open_group("metadata")
         # BFS
-        sections = [Section(self.file, None, sg) for sg in rootmd]
+        sections = list(self.file.sections)
         if self in sections:
             # Top-level section
             return None
@@ -308,18 +307,6 @@ class Section(Entity):
             sections.extend(sect.sections)
 
         return None
-
-    @property
-    def file(self):
-        """
-        Root file object.
-
-        :type: File
-        """
-        par = self._parent
-        while isinstance(par, Entity):
-            par = par._parent
-        return par
 
     @property
     def referring_objects(self):

--- a/nixio/section.py
+++ b/nixio/section.py
@@ -55,9 +55,9 @@ class Section(Entity):
         self._properties = None
 
     @classmethod
-    def _create_new(cls, nixparent, h5parent, name, type_, oid=None):
-        newentity = super(Section, cls)._create_new(nixparent, h5parent,
-                                                    name, type_)
+    def create_new(cls, nixparent, h5parent, name, type_, oid=None):
+        newentity = super(Section, cls).create_new(nixparent, h5parent,
+                                                   name, type_)
         if util.is_uuid(oid):
             newentity._h5group.set_attr("entity_id", oid)
 
@@ -83,7 +83,7 @@ class Section(Entity):
         sections = self._h5group.open_group("sections", True)
         if name in sections:
             raise exceptions.DuplicateName("create_section")
-        sec = Section._create_new(self, sections, name, type_, oid)
+        sec = Section.create_new(self, sections, name, type_, oid)
         sec._sec_parent = self
         return sec
 
@@ -169,7 +169,7 @@ class Section(Entity):
                     raise TypeError("Array contains inconsistent values.")
         shape = (len(vals),)
 
-        prop = Property._create_new(self, properties, name, dtype, shape, oid)
+        prop = Property.create_new(self, properties, name, dtype, shape, oid)
         prop.values = vals
 
         return prop
@@ -293,7 +293,7 @@ class Section(Entity):
         if self._sec_parent is not None:
             return self._sec_parent
         rootmd = self._h5group.file.open_group("metadata")
-        # Assuming most metadata trees are shallow---doing BFS
+        # BFS
         sections = [Section(None, sg) for sg in rootmd]
         if self in sections:
             # Top-level section

--- a/nixio/section.py
+++ b/nixio/section.py
@@ -226,7 +226,7 @@ class Section(Entity):
     def reference(self, ref):
         util.check_attr_type(ref, str)
         self._h5group.set_attr("reference", ref)
-        if self.file.time_auto_update:
+        if self.file.auto_update_timestamps:
             self.force_updated_at()
 
     @property
@@ -254,7 +254,7 @@ class Section(Entity):
             sec = rootsec.find_sections(filtr=lambda x: x.id == id_or_sec)
 
         self._h5group.create_link(sec, "link")
-        if self.file.time_auto_update:
+        if self.file.auto_update_timestamps:
             self.force_updated_at()
 
     def inherited_properties(self):
@@ -278,7 +278,7 @@ class Section(Entity):
     def repository(self, r):
         util.check_attr_type(r, str)
         self._h5group.set_attr("repository", r)
-        if self.file.time_auto_update:
+        if self.file.auto_update_timestamps:
             self.force_updated_at()
 
     @property

--- a/nixio/source.py
+++ b/nixio/source.py
@@ -18,13 +18,13 @@ from .section import Section
 
 class Source(Entity):
 
-    def __init__(self, nixparent, h5group):
-        super(Source, self).__init__(nixparent, h5group)
+    def __init__(self, nixfile, nixparent, h5group):
+        super(Source, self).__init__(nixfile, nixparent, h5group)
         self._sources = None
 
     @classmethod
-    def create_new(cls, nixparent, h5parent, name, type_):
-        newentity = super(Source, cls).create_new(nixparent, h5parent,
+    def create_new(cls, nixfile, nixparent, h5parent, name, type_):
+        newentity = super(Source, cls).create_new(nixfile, nixparent, h5parent,
                                                   name, type_)
         return newentity
 
@@ -45,7 +45,7 @@ class Source(Entity):
         sources = self._h5group.open_group("sources", True)
         if name in sources:
             raise exceptions.DuplicateName("create_source")
-        src = Source.create_new(self, sources, name, type_)
+        src = Source.create_new(self.file, self, sources, name, type_)
         return src
 
     @property
@@ -99,7 +99,7 @@ class Source(Entity):
         This is a read only attribute.
         """
         if self._sources is None:
-            self._sources = SourceContainer("sources", self, Source)
+            self._sources = SourceContainer("sources", self.file, self, Source)
         return self._sources
 
     # metadata
@@ -114,7 +114,7 @@ class Source(Entity):
         :type: Section
         """
         if "metadata" in self._h5group:
-            return Section(None, self._h5group.open_group("metadata"))
+            return Section(self.file, None, self._h5group.open_group("metadata"))
         else:
             return None
 

--- a/nixio/source.py
+++ b/nixio/source.py
@@ -23,9 +23,9 @@ class Source(Entity):
         self._sources = None
 
     @classmethod
-    def _create_new(cls, nixparent, h5parent, name, type_):
-        newentity = super(Source, cls)._create_new(nixparent, h5parent,
-                                                   name, type_)
+    def create_new(cls, nixparent, h5parent, name, type_):
+        newentity = super(Source, cls).create_new(nixparent, h5parent,
+                                                  name, type_)
         return newentity
 
     # Source
@@ -45,7 +45,7 @@ class Source(Entity):
         sources = self._h5group.open_group("sources", True)
         if name in sources:
             raise exceptions.DuplicateName("create_source")
-        src = Source._create_new(self, sources, name, type_)
+        src = Source.create_new(self, sources, name, type_)
         return src
 
     @property

--- a/nixio/tag.py
+++ b/nixio/tag.py
@@ -105,7 +105,7 @@ class BaseTag(Entity):
             link_type = link_type.lower()
         link_type = LinkType(link_type)
         features = self._h5group.open_group("features")
-        feat = Feature._create_new(self, features, data, link_type)
+        feat = Feature.create_new(self, features, data, link_type)
         return feat
 
     @staticmethod
@@ -173,9 +173,9 @@ class Tag(BaseTag):
         self._features = None
 
     @classmethod
-    def _create_new(cls, nixparent, h5parent, name, type_, position):
-        newentity = super(Tag, cls)._create_new(nixparent, h5parent,
-                                                name, type_)
+    def create_new(cls, nixparent, h5parent, name, type_, position):
+        newentity = super(Tag, cls).create_new(nixparent, h5parent,
+                                               name, type_)
         newentity.position = position
         return newentity
 

--- a/nixio/tag.py
+++ b/nixio/tag.py
@@ -105,7 +105,7 @@ class BaseTag(Entity):
             link_type = link_type.lower()
         link_type = LinkType(link_type)
         features = self._h5group.open_group("features")
-        feat = Feature.create_new(self, features, data, link_type)
+        feat = Feature.create_new(self.file, self, features, data, link_type)
         return feat
 
     @staticmethod
@@ -166,15 +166,15 @@ class BaseTag(Entity):
 
 class Tag(BaseTag):
 
-    def __init__(self, nixparent, h5group):
-        super(Tag, self).__init__(nixparent, h5group)
+    def __init__(self, nixfile, nixparent, h5group):
+        super(Tag, self).__init__(nixfile, nixparent, h5group)
         self._sources = None
         self._references = None
         self._features = None
 
     @classmethod
-    def create_new(cls, nixparent, h5parent, name, type_, position):
-        newentity = super(Tag, cls).create_new(nixparent, h5parent,
+    def create_new(cls, nixfile, nixparent, h5parent, name, type_, position):
+        newentity = super(Tag, cls).create_new(nixfile, nixparent, h5parent,
                                                name, type_)
         newentity.position = position
         return newentity
@@ -347,7 +347,8 @@ class Tag(BaseTag):
         :type: Container of Feature.
         """
         if self._features is None:
-            self._features = FeatureContainer("features", self, Feature)
+            self._features = FeatureContainer("features", self.file,
+                                              self, Feature)
         return self._features
 
     @property
@@ -375,9 +376,8 @@ class Tag(BaseTag):
         :type: Section
         """
         if "metadata" in self._h5group:
-            return Section(None, self._h5group.open_group("metadata"))
-        else:
-            return None
+            return Section(self.file, None, self._h5group.open_group("metadata"))
+        return None
 
     @metadata.setter
     def metadata(self, sect):

--- a/nixio/tag.py
+++ b/nixio/tag.py
@@ -86,7 +86,7 @@ class BaseTag(Entity):
 
             dtype = DataType.String
             self._h5group.write_data("units", sanitized, dtype)
-        if self.file.time_auto_update:
+        if self.file.auto_update_timestamps:
             self.force_updated_at()
 
     def create_feature(self, data, link_type):
@@ -196,7 +196,7 @@ class Tag(BaseTag):
         else:
             dtype = DataType.Double
             self._h5group.write_data("position", pos, dtype)
-        if self.file.time_auto_update:
+        if self.file.auto_update_timestamps:
             self.force_updated_at()
 
     @property
@@ -217,7 +217,7 @@ class Tag(BaseTag):
         else:
             dtype = DataType.Double
             self._h5group.write_data("extent", ext, dtype)
-        if self.file.time_auto_update:
+        if self.file.auto_update_timestamps:
             self.force_updated_at()
 
     def _calc_data_slices(self, data):

--- a/nixio/tag.py
+++ b/nixio/tag.py
@@ -86,7 +86,7 @@ class BaseTag(Entity):
 
             dtype = DataType.String
             self._h5group.write_data("units", sanitized, dtype)
-        if self._parent._parent.time_auto_update:
+        if self.file.time_auto_update:
             self.force_updated_at()
 
     def create_feature(self, data, link_type):
@@ -196,7 +196,7 @@ class Tag(BaseTag):
         else:
             dtype = DataType.Double
             self._h5group.write_data("position", pos, dtype)
-        if self._parent._parent.time_auto_update:
+        if self.file.time_auto_update:
             self.force_updated_at()
 
     @property
@@ -217,7 +217,7 @@ class Tag(BaseTag):
         else:
             dtype = DataType.Double
             self._h5group.write_data("extent", ext, dtype)
-        if self._parent._parent.time_auto_update:
+        if self.file.time_auto_update:
             self.force_updated_at()
 
     def _calc_data_slices(self, data):

--- a/nixio/test/test_container.py
+++ b/nixio/test/test_container.py
@@ -73,13 +73,53 @@ class TestContainer(unittest.TestCase):
         self.assertEqual(self.multi_tag,
                          self.group.multi_tags[0])
 
+    def test_file_references(self):
+        # add some sources
+        self.source = self.block.create_source("test source", "containertest")
+        self.child_source = self.source.create_source("test source 2",
+                                                      "containertest")
+        # using assertIs since the reference should be the same instance as
+        # the original
+
+        # created objects
+        self.assertIs(self.block.file, self.file)
+        self.assertIs(self.group.file, self.file)
+        self.assertIs(self.dataarray.file, self.file)
+        self.assertIs(self.tag.file, self.file)
+        self.assertIs(self.multi_tag.file, self.file)
+        self.assertIs(self.positions.file, self.file)
+        self.assertIs(self.source.file, self.file)
+        self.assertIs(self.child_source.file, self.file)
+
+        # instantiated through container getters
+        blk = self.file.blocks[0]
+        self.assertIs(blk.file, self.file)
+        self.assertIs(blk.groups[0].file, self.file)
+        self.assertIs(blk.data_arrays[0].file, self.file)
+        self.assertIs(blk.tags[0].file, self.file)
+        self.assertIs(blk.multi_tags[0].file, self.file)
+        self.assertIs(blk.sources[0].file, self.file)
+        self.assertIs(blk.sources[0].sources[0].file, self.file)
+
+        # linked through group
+        self.assertIs(self.group.data_arrays[0].file, self.file)
+        self.assertIs(self.group.tags[0].file, self.file)
+        self.assertIs(self.group.multi_tags[0].file, self.file)
+
     def test_parent_references(self):
+        # add some sources
+        self.source = self.block.create_source("test source", "containertest")
+        self.child_source = self.source.create_source("test source 2",
+                                                      "containertest")
+
         self.assertEqual(self.block._parent, self.file)
         self.assertEqual(self.group._parent, self.block)
         self.assertEqual(self.dataarray._parent, self.block)
         self.assertEqual(self.tag._parent, self.block)
         self.assertEqual(self.multi_tag._parent, self.block)
         self.assertEqual(self.positions._parent, self.block)
+        self.assertEqual(self.source._parent, self.block)
+        self.assertEqual(self.child_source._parent, self.source)
 
     def test_link_parent_references(self):
         self.assertEqual(self.group.data_arrays[0]._parent, self.block)

--- a/nixio/test/test_data_array.py
+++ b/nixio/test/test_data_array.py
@@ -7,6 +7,7 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 import os
+import time
 from six import string_types
 import sys
 import unittest
@@ -476,3 +477,114 @@ class TestDataArray(unittest.TestCase):
         for idx, dim in dim_container_one_based:
             assert self.array.dimensions[idx-1].dimension_type ==\
                 dim.dimension_type
+
+    def test_timestamp_autoupdate(self):
+        array = self.block.create_data_array("array.time", "signal",
+                                             nix.DataType.Double, (100, ))
+        # Append dimensions and check time
+        datime = array.updated_at
+        time.sleep(1)
+        array.append_set_dimension()
+        self.assertNotEqual(datime, array.updated_at)
+
+        datime = array.updated_at
+        time.sleep(1)
+        array.append_sampled_dimension(sampling_interval=0.1)
+        self.assertNotEqual(datime, array.updated_at)
+
+        datime = array.updated_at
+        time.sleep(1)
+        array.append_range_dimension(ticks=[0.1])
+        self.assertNotEqual(datime, array.updated_at)
+
+        datime = array.updated_at
+        time.sleep(1)
+        df = self.block.create_data_frame(
+            "df", "test.data_array.timestamp.data_frame",
+            col_dict={"idx": int}
+        )
+        array.append_data_frame_dimension(data_frame=df)
+        self.assertNotEqual(datime, array.updated_at)
+
+        array.delete_dimensions()
+        datime = array.updated_at
+        time.sleep(1)
+        array.append_alias_range_dimension()
+        self.assertNotEqual(datime, array.updated_at)
+
+        # other properties
+        datime = array.updated_at
+        time.sleep(1)
+        array.polynom_coefficients = [1.1, 2.2]
+        self.assertNotEqual(datime, array.updated_at)
+
+        datime = array.updated_at
+        time.sleep(1)
+        array.expansion_origin = -1
+        self.assertNotEqual(datime, array.updated_at)
+
+        datime = array.updated_at
+        time.sleep(1)
+        array.label = "lbl"
+        self.assertNotEqual(datime, array.updated_at)
+
+        datime = array.updated_at
+        time.sleep(1)
+        array.unit = "Ms"
+        self.assertNotEqual(datime, array.updated_at)
+
+    def test_timestamp_noautoupdate(self):
+        self.file.auto_update_timestamps = False
+        array = self.block.create_data_array("array.time", "signal",
+                                             nix.DataType.Double, (100, ))
+        # Append dimensions and check time
+        datime = array.updated_at
+        time.sleep(1)
+        array.append_set_dimension()
+        self.assertEqual(datime, array.updated_at)
+
+        datime = array.updated_at
+        time.sleep(1)
+        array.append_sampled_dimension(sampling_interval=0.1)
+        self.assertEqual(datime, array.updated_at)
+
+        datime = array.updated_at
+        time.sleep(1)
+        array.append_range_dimension(ticks=[0.1])
+        self.assertEqual(datime, array.updated_at)
+
+        datime = array.updated_at
+        time.sleep(1)
+        df = self.block.create_data_frame(
+            "df", "test.data_array.timestamp.data_frame",
+            col_dict={"idx": int}
+        )
+        array.append_data_frame_dimension(data_frame=df)
+        self.assertEqual(datime, array.updated_at)
+
+        array.delete_dimensions()
+        datime = array.updated_at
+        time.sleep(1)
+        array.append_alias_range_dimension()
+        self.assertEqual(datime, array.updated_at)
+
+        # other properties
+        datime = array.updated_at
+        time.sleep(1)
+        array.polynom_coefficients = [1.1, 2.2]
+        self.assertEqual(datime, array.updated_at)
+
+        datime = array.updated_at
+        time.sleep(1)
+        array.expansion_origin = -1
+        self.assertEqual(datime, array.updated_at)
+
+        datime = array.updated_at
+        time.sleep(1)
+        array.label = "lbl"
+        self.assertEqual(datime, array.updated_at)
+
+        datime = array.updated_at
+        time.sleep(1)
+        array.unit = "Ms"
+        self.assertEqual(datime, array.updated_at)

--- a/nixio/test/test_data_frame.py
+++ b/nixio/test/test_data_frame.py
@@ -3,6 +3,7 @@ import unittest
 import nixio as nix
 from .tmp import TempDir
 import os
+import time
 import numpy as np
 from six import string_types
 try:
@@ -206,3 +207,21 @@ class TestDataFrame(unittest.TestCase):
         df = self.block.create_data_frame("without_name", "test", data=data)
         assert sorted(list(df.column_names)) == sorted(["name", "id", "val"])
         assert sorted(list(df["name"])) == ["a", "b", "c"]
+
+    def test_timestamp_autoupdate(self):
+        self.file.auto_update_timestamps = True
+        df = self.block.create_data_frame("df.time", "test.time",
+                                          col_dict={"idx": int})
+        dftime = df.updated_at
+        time.sleep(1)
+        df.units = "ly"
+        self.assertNotEqual(dftime, df.updated_at)
+
+    def test_timestamp_noautoupdate(self):
+        self.file.auto_update_timestamps = False
+        df = self.block.create_data_frame("df.time", "test.time",
+                                          col_dict={"idx": int})
+        dftime = df.updated_at
+        time.sleep(1)
+        df.units = "ly"
+        self.assertEqual(dftime, df.updated_at)

--- a/nixio/test/test_feature.py
+++ b/nixio/test/test_feature.py
@@ -7,6 +7,7 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 import os
+import time
 import unittest
 import nixio as nix
 from .tmp import TempDir
@@ -84,3 +85,36 @@ class TestFeatures(unittest.TestCase):
 
     def test_create_diff_link_type_style(self):
         self.stimuli_tag.create_feature(self.movie1, nix.LinkType.Tagged)
+
+    def test_timestamp_autoupdate(self):
+        array = self.block.create_data_array("array.time", "signal",
+                                             nix.DataType.Double, (100, ))
+        feature = self.stimuli_tag.create_feature(array, nix.LinkType.Tagged)
+
+        ftime = feature.updated_at
+        time.sleep(1)
+        feature.data = self.block.create_data_array("alt.array", "signal",
+                                                    nix.DataType.Int8, (1,))
+        self.assertNotEqual(ftime, feature.updated_at)
+
+        ftime = feature.updated_at
+        time.sleep(1)
+        feature.link_type = nix.LinkType.Untagged
+        self.assertNotEqual(ftime, feature.updated_at)
+
+    def test_timestamp_noautoupdate(self):
+        self.file.auto_update_timestamps = False
+        array = self.block.create_data_array("array.time", "signal",
+                                             nix.DataType.Double, (100, ))
+        feature = self.stimuli_tag.create_feature(array, nix.LinkType.Tagged)
+
+        ftime = feature.updated_at
+        time.sleep(1)
+        feature.data = self.block.create_data_array("alt.array", "signal",
+                                                    nix.DataType.Int8, (1,))
+        self.assertEqual(ftime, feature.updated_at)
+
+        ftime = feature.updated_at
+        time.sleep(1)
+        feature.link_type = nix.LinkType.Untagged
+        self.assertEqual(ftime, feature.updated_at)

--- a/nixio/test/test_file.py
+++ b/nixio/test/test_file.py
@@ -170,56 +170,54 @@ class TestFile(unittest.TestCase):
     def test_timestamp_autoupdate_definition(self):
         blk = self.file.create_block("block", "timetest")
         blktime = blk.updated_at
+        time.sleep(1)  # wait for time to change
         blk.definition = "updated"
         # no update
-        self.assertEqual(blk.updated_at, blktime)
+        self.assertNotEqual(blk.updated_at, blktime)
 
         rblk = self.file.blocks["block"]  # read through container
+        time.sleep(1)  # wait for time to change
         rblk.definition = "updated again"
-        self.assertEqual(rblk.updated_at, blktime)
+        self.assertNotEqual(rblk.updated_at, blktime)
 
-        # close and recreate file with auto_update_time enabled
-        self.file.close()
-        self.file = nix.File(self.testfilename, nix.FileMode.Overwrite,
-                             auto_update_time=True)
-        blk = self.file.create_block("block", "timetest")
+        # disable timestamp autoupdating
+        self.file.auto_update_timestamps = False
         blktime = blk.updated_at
         time.sleep(1)  # wait for time to change
         blk.definition = "update"
-        self.assertNotEqual(blk.updated_at, blktime)
+        self.assertEqual(blk.updated_at, blktime)
 
         rblk = self.file.blocks["block"]  # read through container
         rblktime = rblk.updated_at
         time.sleep(1)  # wait for time to change
         rblk.definition = "time should change"
-        self.assertNotEqual(rblk.updated_at, rblktime)
+        self.assertEqual(rblk.updated_at, rblktime)
 
     def test_timestamp_autoupdate_type(self):
         blk = self.file.create_block("block", "timetest")
         blktime = blk.updated_at
+        time.sleep(1)  # wait for time to change
         blk.type = "updated"
         # no update
-        self.assertEqual(blk.updated_at, blktime)
+        self.assertNotEqual(blk.updated_at, blktime)
 
         rblk = self.file.blocks["block"]  # read through container
+        time.sleep(1)  # wait for time to change
         rblk.type = "updated again"
-        self.assertEqual(rblk.updated_at, blktime)
+        self.assertNotEqual(rblk.updated_at, blktime)
 
-        # close and recreate file with auto_update_time enabled
-        self.file.close()
-        self.file = nix.File(self.testfilename, nix.FileMode.Overwrite,
-                             auto_update_time=True)
-        blk = self.file.create_block("block", "timetest")
+        # disable timestamp autoupdating
+        self.file.auto_update_timestamps = False
         blktime = blk.updated_at
         time.sleep(1)  # wait for time to change
         blk.type = "update"
-        self.assertNotEqual(blk.updated_at, blktime)
+        self.assertEqual(blk.updated_at, blktime)
 
         rblk = self.file.blocks["block"]  # read through container
         rblktime = rblk.updated_at
         time.sleep(1)  # wait for time to change
         rblk.type = "time should change"
-        self.assertNotEqual(rblk.updated_at, rblktime)
+        self.assertEqual(rblk.updated_at, rblktime)
 
 
 class TestFileVer(unittest.TestCase):

--- a/nixio/test/test_file.py
+++ b/nixio/test/test_file.py
@@ -167,7 +167,8 @@ class TestFile(unittest.TestCase):
         assert self.file.blocks[0] == self.file.blocks[1]  # ID stays the same
         assert self.file.blocks[0].name != self.file.blocks[1].name
 
-    def test_timestamp_autoupdate_definition(self):
+    def test_timestamp_autoupdate(self):
+        # Using Block to test Entity.definition
         blk = self.file.create_block("block", "timetest")
         blktime = blk.updated_at
         time.sleep(1)  # wait for time to change
@@ -179,6 +180,22 @@ class TestFile(unittest.TestCase):
         time.sleep(1)  # wait for time to change
         rblk.definition = "updated again"
         self.assertNotEqual(rblk.updated_at, blktime)
+
+        # Using Block to test Entity.type
+        blktime = blk.updated_at
+        time.sleep(1)  # wait for time to change
+        blk.type = "updated"
+        # no update
+        self.assertNotEqual(blk.updated_at, blktime)
+
+        rblk = self.file.blocks["block"]  # read through container
+        time.sleep(1)  # wait for time to change
+        rblk.type = "updated again"
+        self.assertNotEqual(rblk.updated_at, blktime)
+
+    def test_timestamp_noautoupdate(self):
+        # Using Block to test Entity.definition
+        blk = self.file.create_block("block", "timetest")
 
         # disable timestamp autoupdating
         self.file.auto_update_timestamps = False
@@ -193,21 +210,6 @@ class TestFile(unittest.TestCase):
         rblk.definition = "time should change"
         self.assertEqual(rblk.updated_at, rblktime)
 
-    def test_timestamp_autoupdate_type(self):
-        blk = self.file.create_block("block", "timetest")
-        blktime = blk.updated_at
-        time.sleep(1)  # wait for time to change
-        blk.type = "updated"
-        # no update
-        self.assertNotEqual(blk.updated_at, blktime)
-
-        rblk = self.file.blocks["block"]  # read through container
-        time.sleep(1)  # wait for time to change
-        rblk.type = "updated again"
-        self.assertNotEqual(rblk.updated_at, blktime)
-
-        # disable timestamp autoupdating
-        self.file.auto_update_timestamps = False
         blktime = blk.updated_at
         time.sleep(1)  # wait for time to change
         blk.type = "update"

--- a/nixio/test/test_multi_tag.py
+++ b/nixio/test/test_multi_tag.py
@@ -7,6 +7,7 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 import os
+import time
 import unittest
 import numpy as np
 import nixio as nix
@@ -562,3 +563,42 @@ class TestMultiTags(unittest.TestCase):
             self.feature_tag.feature_data(2, 1)
 
         self.assertRaises(IndexError, out_of_bounds)
+
+    def test_timestamp_autoupdate(self):
+        pos = self.block.create_data_array("positions.time", "test.time",
+                                           nix.DataType.Int16, (0, 0))
+        mtag = self.block.create_multi_tag("mtag.time", "test.time", pos)
+
+        mtagtime = mtag.updated_at
+        time.sleep(1)  # wait for time to change
+        mtag.positions = self.block.create_data_array("pos2.time",
+                                                      "test.time",
+                                                      nix.DataType.Int8, (0,))
+        self.assertNotEqual(mtag.updated_at, mtagtime)
+
+        mtagtime = mtag.updated_at
+        time.sleep(1)  # wait for time to change
+        mtag.extents = self.block.create_data_array("extents.time",
+                                                    "test.time",
+                                                    nix.DataType.Int8, (0,))
+        self.assertNotEqual(mtag.updated_at, mtagtime)
+
+    def test_timestamp_noautoupdate(self):
+        self.file.auto_update_timestamps = False
+        pos = self.block.create_data_array("positions.time", "test.time",
+                                           nix.DataType.Int16, (0, 0))
+        mtag = self.block.create_multi_tag("mtag.time", "test.time", pos)
+
+        mtagtime = mtag.updated_at
+        time.sleep(1)  # wait for time to change
+        mtag.positions = self.block.create_data_array("pos2.time",
+                                                      "test.time",
+                                                      nix.DataType.Int8, (0,))
+        self.assertEqual(mtag.updated_at, mtagtime)
+
+        mtagtime = mtag.updated_at
+        time.sleep(1)  # wait for time to change
+        mtag.extents = self.block.create_data_array("extents.time",
+                                                    "test.time",
+                                                    nix.DataType.Int8, (0,))
+        self.assertEqual(mtag.updated_at, mtagtime)

--- a/nixio/test/test_section.py
+++ b/nixio/test/test_section.py
@@ -7,6 +7,7 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 import os
+import time
 import unittest
 import nixio as nix
 from .tmp import TempDir
@@ -317,3 +318,42 @@ class TestSections(unittest.TestCase):
         assert sec2 == tarsec.sections[1]
         assert sec1.sections[0] == tarsec.sections[1]
         tarfile.close()
+
+    def test_timestamp_autoupdate(self):
+        section = self.file.create_section("section.time", "test.time")
+
+        sectime = section.updated_at
+        time.sleep(1)  # wait for time to change
+        section.reference = "whatever"
+        self.assertNotEqual(sectime, section.updated_at)
+
+        sectime = section.updated_at
+        linksec = self.file.create_section("link.section.time", "test.time")
+        time.sleep(1)  # wait for time to change
+        section.link = linksec
+        self.assertNotEqual(sectime, section.updated_at)
+
+        sectime = section.updated_at
+        time.sleep(1)  # wait for time to change
+        section.repository = "repo"
+        self.assertNotEqual(sectime, section.updated_at)
+
+    def test_timestamp_noautoupdate(self):
+        self.file.auto_update_timestamps = False
+        section = self.file.create_section("section.time", "test.time")
+
+        sectime = section.updated_at
+        time.sleep(1)  # wait for time to change
+        section.reference = "whatever"
+        self.assertEqual(sectime, section.updated_at)
+
+        sectime = section.updated_at
+        time.sleep(1)  # wait for time to change
+        linksec = self.file.create_section("link.section.time", "test.time")
+        section.link = linksec
+        self.assertEqual(sectime, section.updated_at)
+
+        sectime = section.updated_at
+        time.sleep(1)  # wait for time to change
+        section.repository = "repo"
+        self.assertEqual(sectime, section.updated_at)

--- a/nixio/test/test_section.py
+++ b/nixio/test/test_section.py
@@ -231,6 +231,9 @@ class TestSections(unittest.TestCase):
         grp.metadata = child
         self.assertEqual(grp.metadata.parent, self.section)
 
+        # indirect access parent check
+        self.assertEqual(block.groups["group"].metadata.parent, self.section)
+
     def test_inverse_search(self):
         block = self.file.create_block("a block", "block with metadata")
         block.metadata = self.section

--- a/nixio/test/test_tag.py
+++ b/nixio/test/test_tag.py
@@ -7,6 +7,7 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 import os
+import time
 import unittest
 import numpy as np
 import nixio as nix
@@ -297,3 +298,40 @@ class TestTags(unittest.TestCase):
 
         assert (data1.size == 1)
         assert (data2.size == 3)
+
+    def test_timestamp_autoupdate(self):
+        tag = self.block.create_tag("tag.time", "test.time", [-1])
+
+        tagtime = tag.updated_at
+        time.sleep(1)  # wait for time to change
+        tag.position = [-100]
+        self.assertNotEqual(tag.updated_at, tagtime)
+
+        tagtime = tag.updated_at
+        time.sleep(1)  # wait for time to change
+        tag.extent = [30]
+        self.assertNotEqual(tag.updated_at, tagtime)
+
+        tagtime = tag.updated_at
+        time.sleep(1)  # wait for time to change
+        tag.units = "Mm"
+        self.assertNotEqual(tag.updated_at, tagtime)
+
+    def test_timestamp_noautoupdate(self):
+        self.file.auto_update_timestamps = False
+        tag = self.block.create_tag("tag.time", "test.time", [-1])
+
+        tagtime = tag.updated_at
+        time.sleep(1)  # wait for time to change
+        tag.position = [-100]
+        self.assertEqual(tag.updated_at, tagtime)
+
+        tagtime = tag.updated_at
+        time.sleep(1)  # wait for time to change
+        tag.extent = [30]
+        self.assertEqual(tag.updated_at, tagtime)
+
+        tagtime = tag.updated_at
+        time.sleep(1)  # wait for time to change
+        tag.units = "Mm"
+        self.assertEqual(tag.updated_at, tagtime)

--- a/nixio/test/test_validator.py
+++ b/nixio/test/test_validator.py
@@ -245,18 +245,16 @@ class TestValidate (unittest.TestCase):
     def test_incorrect_dim_index(self):
         da = self.file.blocks[1].data_arrays["data-1d"]
         da.delete_dimensions()
-        dimgroup = da._h5group.open_group("dimensions")
         # This wont work if we ever change the internals
-        nix.SetDimension.create_new(dimgroup, "10")
+        nix.SetDimension.create_new(da, "10")
         res = self.file.validate()
         assert VE.IncorrectDimensionIndex.format(1, 10) in res["errors"][da]
 
     def test_invalid_dim_index(self):
         da = self.file.blocks[1].data_arrays["data-1d"]
         da.delete_dimensions()
-        dimgroup = da._h5group.open_group("dimensions")
         # This wont work if we ever change the internals
-        nix.SetDimension.create_new(dimgroup, "-1")
+        nix.SetDimension.create_new(da, "-1")
         res = self.file.validate()
         assert VE.InvalidDimensionIndex.format(1) in res["errors"][da]
 

--- a/nixio/test/test_validator.py
+++ b/nixio/test/test_validator.py
@@ -247,7 +247,7 @@ class TestValidate (unittest.TestCase):
         da.delete_dimensions()
         dimgroup = da._h5group.open_group("dimensions")
         # This wont work if we ever change the internals
-        nix.SetDimension._create_new(dimgroup, "10")
+        nix.SetDimension.create_new(dimgroup, "10")
         res = self.file.validate()
         assert VE.IncorrectDimensionIndex.format(1, 10) in res["errors"][da]
 
@@ -256,7 +256,7 @@ class TestValidate (unittest.TestCase):
         da.delete_dimensions()
         dimgroup = da._h5group.open_group("dimensions")
         # This wont work if we ever change the internals
-        nix.SetDimension._create_new(dimgroup, "-1")
+        nix.SetDimension.create_new(dimgroup, "-1")
         res = self.file.validate()
         assert VE.InvalidDimensionIndex.format(1) in res["errors"][da]
 


### PR DESCRIPTION
Every object that subclasses Entity now holds a reference to the nix.File object that they belong to.  This reference is the same object for all.  The reference is useful for a few reasons but more recently it becomes necessary for being able to read the `auto_update_timestamps` option, which is a session option only (it's not stored in the file) and is only available through the original File object.

Fixes #460

Changes in this PR:
- The timestamp update option, introduced in PR #385 has been renamed to `auto_update_timestamps`.  When enabled, it updates the `updated_at` timestamp for an object when one of its properties are changed.
- The option is now **ENABLED** by default.  The thought behind having an option to disable the timestamp was that fast creation and/or editing of a large number of objects would incur a significant overhead when each operation required editing the object timestamp.  The property was always meant to be updated when an object changes, but the library (or libraries, NIX C++ included) were not consistent in their behaviour across objects and properties.  Now that we've increased the scope of this behaviour, I think the default should still be to keep updating timestamps but allow users to disable the behaviour for performance reasons if they expect it will help.  This should be documented in the file creation/opening docs.
- Added tests for timestamp updating enabled and disabled.  These tests can be a bit slower than others since they require waiting for time to pass to check the time change.

NOTE: The NIX compatibility tests will fail until we fix ASCII reading (see G-Node/nix#817.