### PR TITLE
Dimension links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,10 @@ matrix:
       env: pymajor=3 coverage=1
       dist: xenial
       sudo: true
+    - python: "3.7"
+      os: linux
+      env: pymajor=3 nocompat=1
+      dist: xenial
     - language: generic
       os: osx
       env: pymajor=2
@@ -56,25 +60,28 @@ addons:
       - libboost-all-dev
 
 before_install:
-  - nixprefix="/usr/local"
-  - export NIX_INCDIR=${nixprefix}/include/nixio-1.0
-  - export NIX_LIBDIR=${nixprefix}/lib
-  - export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${nixprefix}/lib/pkgconfig
+  # build nix for compat tests
+  - if [[ -z "${nocompat}" ]]; then
+      nixprefix="/usr/local";
+      export NIX_INCDIR=${nixprefix}/include/nixio-1.0;
+      export NIX_LIBDIR=${nixprefix}/lib;
+      export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${nixprefix}/lib/pkgconfig;
+      git clone --branch ${NIX_BRANCH} https://github.com/G-Node/nix /tmp/libnix;
+      pushd /tmp/libnix;
+      mkdir build;
+      pushd build;
+      cmake -DCMAKE_INSTALL_PREFIX=${nixprefix} ..;
+      make;
+      sudo make install;
+      popd;
+      popd;
+    fi
   # For macOS python3
   - export PATH="/usr/local/opt/python@3.8/bin:$PATH"
   - alias pip2='pip'
   - if [[ "${TRAVIS_OS_NAME}" != "osx" ]]; then pip${pymajor} install --upgrade numpy; fi
   - pip${pymajor} install --upgrade h5py pytest pytest-xdist pytest-cov six;
   - if [[ "${pymajor}" == 2 ]]; then pip${pymajor} install enum34; fi
-  - git clone --branch ${NIX_BRANCH} https://github.com/G-Node/nix /tmp/libnix
-  - pushd /tmp/libnix
-  - mkdir build
-  - pushd build
-  - cmake -DCMAKE_INSTALL_PREFIX=${nixprefix} ..
-  - make
-  - sudo make install
-  - popd
-  - popd
   - which pip${pymajor}
   - which python${pymajor}
   - python${pymajor} --version
@@ -83,7 +90,11 @@ install:
   - python${pymajor} setup.py build
 
 script:
-  - pytest --cov=nixio --nix-compat -nauto;
+  - if [[ "${nocompat}" == 1 ]]; then
+      pytest --cov=nixio -nauto;
+    else
+      pytest --cov=nixio --nix-compat -nauto;
+    fi
 
 after_success:
   - if [[ "${coverage}" == 1 ]]; then

--- a/nixio/block.py
+++ b/nixio/block.py
@@ -337,11 +337,10 @@ class Block(Entity):
             else:  # if col_names is None
                 if data is not None and type(data[0]) == np.void:
                     col_dtype = data[0].dtype
-                    for dt in col_dtype.fields.values():
-                        cn = list(col_dtype.fields.keys())
-                        raw_dt = col_dtype.fields.values()
-                        raw_dt = list(raw_dt)
-                        raw_dt_list = [ele[0] for ele in raw_dt]
+                    cn = list(col_dtype.fields.keys())
+                    raw_dt = col_dtype.fields.values()
+                    raw_dt = list(raw_dt)
+                    raw_dt_list = [ele[0] for ele in raw_dt]
                     col_dict = OrderedDict(zip(cn, raw_dt_list))
                     if len(col_dtype.fields.values()) != len(col_dict):
                         raise exceptions.DuplicateColumnName

--- a/nixio/block.py
+++ b/nixio/block.py
@@ -337,7 +337,7 @@ class Block(Entity):
             else:  # if col_names is None
                 if data is not None and type(data[0]) == np.void:
                     col_dtype = data[0].dtype
-                    for i, dt in enumerate(col_dtype.fields.values()):
+                    for dt in col_dtype.fields.values():
                         cn = list(col_dtype.fields.keys())
                         raw_dt = col_dtype.fields.values()
                         raw_dt = list(raw_dt)

--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -118,7 +118,7 @@ class DataArray(Entity, DataSet):
             self.force_updated_at()
         return smpldim
 
-    def append_range_dimension(self, ticks, label=None, unit=None):
+    def append_range_dimension(self, ticks=None, label=None, unit=None):
         """
         Append a new RangeDimension to the list of existing dimension
         descriptors.

--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -20,7 +20,7 @@ from .dimensions import (Dimension, SampledDimension, RangeDimension,
 from . import util
 from .compression import Compression
 
-from .exceptions import InvalidUnit, IncompatibleDimensions
+from .exceptions import IncompatibleDimensions
 from .section import Section
 
 

--- a/nixio/data_frame.py
+++ b/nixio/data_frame.py
@@ -185,7 +185,7 @@ class DataFrame(Entity, DataSet):
             self._write_data(rows, sl=index)
         else:
             cr_list = []
-            for i, cr in enumerate(rows):
+            for cr in rows:
                 cr_list.append(tuple(cr))
             self._write_data(cr_list, sl=index)
 

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -336,6 +336,12 @@ class SampledDimension(Dimension):
         util.check_attr_type(o, Number)
         self._h5group.set_attr("offset", o)
 
+    def link_data_array(self, data_array, index):
+        raise RuntimeError("SampledDimension does not support linking")
+
+    def link_data_frame(self, data_array, index):
+        raise RuntimeError("SampledDimension does not support linking")
+
 
 class RangeDimension(Dimension):
 

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -380,13 +380,10 @@ class RangeDimension(Dimension):
 
     @property
     def ticks(self):
-        g = self._redirgrp
-        if g.has_data("ticks"):
-            ticks = g.get_data("ticks")
-        elif g.has_data("data"):
-            ticks = g.get_data("data")
+        if self.has_link:
+            ticks = self.dimension_link.values
         else:
-            raise AttributeError("Attribute 'ticks' is not set.")
+            ticks = self._h5group.get_data("ticks")
         return tuple(ticks)
 
     @ticks.setter

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -122,7 +122,7 @@ class DimensionLink(object):
             dimindex[dimindex.index(-1)] = slice(None)
             return data[tuple(dimindex)]
         elif self._data_object_type == "DataFrame":
-            return data[self.index]
+            return tuple(row[self.index] for row in data)
         else:
             raise RuntimeError("Invalid DataObjectType attribute found in "
                                "DimensionLink")

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -489,10 +489,15 @@ class SetDimension(Dimension):
 
     @property
     def labels(self):
-        labels = tuple(self._h5group.get_data("labels"))
+        if self.has_link:
+            labels = self.dimension_link.values
+        else:
+            labels = self._h5group.get_data("labels")
+
         if len(labels) and isinstance(labels[0], bytes):
             labels = tuple(label.decode() for label in labels)
-        return labels
+
+        return tuple(labels)
 
     @labels.setter
     def labels(self, labels):

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -200,12 +200,14 @@ class Dimension(object):
                 "Dimension.link_data_array"
             )
 
-        if index.count(-1) != 1:
+        invalid_idx_msg = (
+            "Invalid linked DataArray index: "
+            "One of the values must be -1, indicating the relevant vector. "
+            "Negative indexing is not supported."
+        )
+        if index.count(-1) != 1 or sum(idx < 0 for idx in index) != 1:
             # TODO: Add link to relevant docs
-            raise ValueError(
-                "Invalid linked DataArray index: "
-                "One of the values must be -1, indicating the relevant vector."
-            )
+            raise ValueError(invalid_idx_msg)
 
         if self.has_link:
             self._h5group.delete("link")

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -306,12 +306,12 @@ class SampledDimension(Dimension):
 
     @property
     def label(self):
-        return self._redirgrp.get_attr("label")
+        return self._h5group.get_attr("label")
 
     @label.setter
     def label(self, label):
         util.check_attr_type(label, str)
-        self._redirgrp.set_attr("label", label)
+        self._h5group.set_attr("label", label)
 
     @property
     def sampling_interval(self):
@@ -324,12 +324,12 @@ class SampledDimension(Dimension):
 
     @property
     def unit(self):
-        return self._redirgrp.get_attr("unit")
+        return self._h5group.get_attr("unit")
 
     @unit.setter
     def unit(self, u):
         util.check_attr_type(u, str)
-        self._redirgrp.set_attr("unit", u)
+        self._h5group.set_attr("unit", u)
 
     @property
     def offset(self):

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -79,9 +79,12 @@ class DimensionLink(object):
     def file(self):
         return self._file
 
+    def _linked_group(self):
+        return self._h5group.get_by_pos(0)
+
     @property
     def linked_data(self):
-        grp = self._h5group.get_by_pos(0)
+        grp = self._linked_group()
         return grp.get_data("data")
 
     @property
@@ -133,11 +136,11 @@ class DimensionLink(object):
         Returns the unit from the linked data object (DataArray or DataFrame)
         specified by the LinkDimension's index.
         """
-        data = self.linked_data
+        lobj = self._linked_group()
         if self._data_object_type == "DataArray":
-            return data.get_attr("unit")
+            return lobj.get_attr("unit")
         elif self._data_object_type == "DataFrame":
-            return data.get_attr("units")[self.index]
+            return lobj.get_attr("units")[self.index]
         else:
             raise RuntimeError("Invalid DataObjectType attribute found in "
                                "DimensionLink")
@@ -415,7 +418,9 @@ class RangeDimension(Dimension):
 
     @property
     def unit(self):
-        return self._redirgrp.get_attr("unit")
+        if self.has_link:
+            return self.dimension_link.unit
+        return self._h5group.get_attr("unit")
 
     @unit.setter
     def unit(self, u):

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -188,12 +188,16 @@ class Dimension(object):
                 "One of the values must be -1, indicating the relevant vector."
             )
 
+        if self.has_link:
+            self._h5group.delete("link")
         DimensionLink.create_new(self._file, self, self._h5group,
                                  data_array, "DataArray", index)
 
     def link_data_frame(self, data_frame, index):
         if index >= len(data_frame.columns):
             raise OutOfBounds("DataFrame index is out of bounds", index)
+        if self.has_link:
+            self._h5group.delete("link")
         DimensionLink.create_new(self._file, self, self._h5group,
                                  data_frame, "DataFrame", index)
 

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -120,7 +120,7 @@ class DimensionLink(object):
             dimindex = list(self.index)
             # replace -1 with slice(None)
             dimindex[dimindex.index(-1)] = slice(None)
-            return data[dimindex]
+            return data[tuple(dimindex)]
         elif self._data_object_type == "DataFrame":
             return data[self.index]
         else:

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -220,7 +220,7 @@ class Dimension(object):
         the H5Group representing the dimension.
         """
         if self.has_link:
-            link = self._h5group.open_group("link")
+            link = self._h5group.get_by_name("link")
             return link.get_by_pos(0)
         return self._h5group
 
@@ -231,7 +231,7 @@ class Dimension(object):
         DimensionLink object, otherwise returns None.
         """
         if self.has_link:
-            link = self._h5group.open_group("link")
+            link = self._h5group.get_by_name("link")
             return DimensionLink(self._file, self, link)
         return None
 

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -213,7 +213,7 @@ class Dimension(object):
                                  data_array, "DataArray", index)
 
     def link_data_frame(self, data_frame, index):
-        if index >= len(data_frame.columns):
+        if not 0 <= index < len(data_frame.columns):
             raise OutOfBounds("DataFrame index is out of bounds", index)
         if self.has_link:
             self._h5group.delete("link")

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -280,7 +280,8 @@ class RangeDimension(Dimension):
     def create_new(cls, data_array, index, ticks):
         newdim = cls(data_array, index)
         newdim._set_dimension_type(DimensionType.Range)
-        newdim._h5group.write_data("ticks", ticks, dtype=DataType.Double)
+        if ticks is not None:
+            newdim._h5group.write_data("ticks", ticks, dtype=DataType.Double)
         return newdim
 
     @classmethod

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -146,6 +146,24 @@ class DimensionLink(object):
                                "DimensionLink")
 
     @property
+    def label(self):
+        """
+        Returns the label of the linked data object:
+        For DataArray links, returns the label.
+        For DataFrame links, returns the name of the column specified by the
+        LinkDimension's index.
+        """
+        lobj = self._linked_group()
+        if self._data_object_type == "DataArray":
+            return lobj.get_attr("label")
+        elif self._data_object_type == "DataFrame":
+            col_dts = lobj.group["data"].dtype
+            return col_dts.names[self.index]
+        else:
+            raise RuntimeError("Invalid DataObjectType attribute found in "
+                               "DimensionLink")
+
+    @property
     def _data_object_type(self):
         return self._h5group.get_attr("data_object_type")
 
@@ -409,7 +427,9 @@ class RangeDimension(Dimension):
 
     @property
     def label(self):
-        return self._redirgrp.get_attr("label")
+        if self.has_link:
+            return self.dimension_link.label
+        return self._h5group.get_attr("label")
 
     @label.setter
     def label(self, label):

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -133,9 +133,9 @@ class SampledDimension(Dimension):
         return self._h5group.get_attr("label")
 
     @label.setter
-    def label(self, l):
-        util.check_attr_type(l, str)
-        self._h5group.set_attr("label", l)
+    def label(self, label):
+        util.check_attr_type(label, str)
+        self._h5group.set_attr("label", label)
 
     @property
     def sampling_interval(self):
@@ -229,9 +229,9 @@ class RangeDimension(Dimension):
         return self._redirgrp.get_attr("label")
 
     @label.setter
-    def label(self, l):
-        util.check_attr_type(l, str)
-        self._redirgrp.set_attr("label", l)
+    def label(self, label):
+        util.check_attr_type(label, str)
+        self._redirgrp.set_attr("label", label)
 
     @property
     def unit(self):
@@ -311,7 +311,7 @@ class SetDimension(Dimension):
     def labels(self):
         labels = tuple(self._h5group.get_data("labels"))
         if len(labels) and isinstance(labels[0], bytes):
-            labels = tuple(l.decode() for l in labels)
+            labels = tuple(label.decode() for label in labels)
         return labels
 
     @labels.setter

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -110,6 +110,39 @@ class DimensionLink(object):
                                "DimensionLink")
 
     @property
+    def values(self):
+        """
+        Returns the values (vector or column) from the linked data object
+        (DataArray or DataFrame) specified by the LinkDimension's index.
+        """
+        data = self.linked_data
+        if self._data_object_type == "DataArray":
+            dimindex = list(self.index)
+            # replace -1 with slice(None)
+            dimindex[dimindex.index(-1)] = slice(None)
+            return data[dimindex]
+        elif self._data_object_type == "DataFrame":
+            return data[self.index]
+        else:
+            raise RuntimeError("Invalid DataObjectType attribute found in "
+                               "DimensionLink")
+
+    @property
+    def unit(self):
+        """
+        Returns the unit from the linked data object (DataArray or DataFrame)
+        specified by the LinkDimension's index.
+        """
+        data = self.linked_data
+        if self._data_object_type == "DataArray":
+            return data.get_attr("unit")
+        elif self._data_object_type == "DataFrame":
+            return data.get_attr("units")[self.index]
+        else:
+            raise RuntimeError("Invalid DataObjectType attribute found in "
+                               "DimensionLink")
+
+    @property
     def _data_object_type(self):
         return self._h5group.get_attr("data_object_type")
 

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -46,8 +46,8 @@ def can_read(nixfile):
     filever = nixfile.version
     if len(filever) != 3:
         raise RuntimeError("Invalid version specified in file.")
-    vx, vy, vz = HDF_FF_VERSION
-    fx, fy, fz = filever
+    vx, vy, _ = HDF_FF_VERSION
+    fx, fy, _ = filever
     if vx == fx and vy >= fy:
         return True
     else:

--- a/nixio/section.py
+++ b/nixio/section.py
@@ -469,7 +469,7 @@ class Section(Entity):
             prop.values = data
 
     def __iter__(self):
-        for name, item in self.items():
+        for _, item in self.items():
             yield item
 
     def items(self):

--- a/nixio/test/test_data_array.py
+++ b/nixio/test/test_data_array.py
@@ -311,43 +311,6 @@ class TestDataArray(unittest.TestCase):
 
         self.array.delete_dimensions()
 
-        assert(len(self.array.dimensions) == 0)
-        self.array.append_alias_range_dimension()
-        assert(len(self.array.dimensions) == 1)
-        self.array.delete_dimensions()
-        self.array.append_alias_range_dimension()
-        assert(len(self.array.dimensions) == 1)
-
-        self.assertRaises(ValueError, self.array.append_alias_range_dimension)
-        self.assertRaises(ValueError, self.array.append_alias_range_dimension)
-        string_array = self.block.create_data_array('string_array',
-                                                    'nix.texts',
-                                                    dtype=nix.DataType.String,
-                                                    shape=(10,))
-        self.assertRaises(ValueError,
-                          string_array.append_alias_range_dimension)
-        assert(len(string_array.dimensions) == 0)
-        del self.block.data_arrays['string_array']
-
-        array_2D = self.block.create_data_array(
-            'array_2d', 'nix.2d', dtype=nix.DataType.Double, shape=(10, 10)
-        )
-        self.assertRaises(ValueError, array_2D.append_alias_range_dimension)
-        assert(len(array_2D.dimensions) == 0)
-        del self.block.data_arrays['array_2d']
-
-        # alias range dimension with non-SI unit
-        self.array.delete_dimensions()
-        self.array.unit = "10 * ms"
-        with self.assertRaises(ValueError):
-            self.array.append_alias_range_dimension()
-
-        self.array.delete_dimensions()
-        self.array.unit = None
-        self.array.append_alias_range_dimension()
-        with self.assertRaises(ValueError):
-            self.array.unit = "10 * ms"
-
     def test_data_array_sources(self):
         source1 = self.block.create_source("source1", "channel")
         source2 = self.block.create_source("source2", "electrode")
@@ -497,21 +460,6 @@ class TestDataArray(unittest.TestCase):
         array.append_range_dimension(ticks=[0.1])
         self.assertNotEqual(datime, array.updated_at)
 
-        datime = array.updated_at
-        time.sleep(1)
-        df = self.block.create_data_frame(
-            "df", "test.data_array.timestamp.data_frame",
-            col_dict={"idx": int}
-        )
-        array.append_data_frame_dimension(data_frame=df)
-        self.assertNotEqual(datime, array.updated_at)
-
-        array.delete_dimensions()
-        datime = array.updated_at
-        time.sleep(1)
-        array.append_alias_range_dimension()
-        self.assertNotEqual(datime, array.updated_at)
-
         # other properties
         datime = array.updated_at
         time.sleep(1)
@@ -551,21 +499,6 @@ class TestDataArray(unittest.TestCase):
         datime = array.updated_at
         time.sleep(1)
         array.append_range_dimension(ticks=[0.1])
-        self.assertEqual(datime, array.updated_at)
-
-        datime = array.updated_at
-        time.sleep(1)
-        df = self.block.create_data_frame(
-            "df", "test.data_array.timestamp.data_frame",
-            col_dict={"idx": int}
-        )
-        array.append_data_frame_dimension(data_frame=df)
-        self.assertEqual(datime, array.updated_at)
-
-        array.delete_dimensions()
-        datime = array.updated_at
-        time.sleep(1)
-        array.append_alias_range_dimension()
         self.assertEqual(datime, array.updated_at)
 
         # other properties

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -257,7 +257,7 @@ class TestLinkDimension(unittest.TestCase):
         assert np.all(("Alpha2", "Beta2", "Gamma2") == self.set_dim.labels)
         assert np.all(labelarray2d[1, :] == self.set_dim.labels)
 
-    def test_data_array_self_link_dimension(self):
+    def test_data_array_self_link_range_dimension(self):
         # The new way of making alias range dimension
         da = self.block.create_data_array("alias da", "dimticks",
                                           data=np.random.random(10))
@@ -265,10 +265,19 @@ class TestLinkDimension(unittest.TestCase):
         da.unit = "F"
         rdim = da.append_range_dimension()
         rdim.link_data_array(da, [-1])
-        assert(len(da.dimensions) == 1)
-        assert(da.dimensions[0].label == da.label)
-        assert(da.dimensions[0].unit == da.unit)
-        assert(np.all(da.dimensions[0].ticks == da[:]))
+        assert len(da.dimensions) == 1
+        assert da.dimensions[0].label == da.label
+        assert da.dimensions[0].unit == da.unit
+        assert np.all(da.dimensions[0].ticks == da[:])
+
+    def test_data_array_self_link_set_dimension(self):
+        # The new way of making alias range dimension
+        labelda = self.block.create_data_array("alias da", "dimlabels",
+                                               data=np.random.random(10))
+        rdim = labelda.append_set_dimension()
+        rdim.link_data_array(labelda, [-1])
+        assert len(labelda.dimensions) == 1
+        assert np.all(labelda.dimensions[0].labels == labelda[:])
 
     def test_data_frame_range_link_dimension(self):
         pass

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -135,17 +135,6 @@ class TestDimension(unittest.TestCase):
             self.range_dim.axis(10, 2)
             self.range_dim.axis(100)
 
-    def _test_alias_dimension(self):
-        da = self.block.create_data_array("alias da", "dimticks",
-                                          data=np.random.random(10))
-        da.label = "alias dimension label"
-        da.unit = "F"
-        da.append_alias_range_dimension()
-        assert(len(da.dimensions) == 1)
-        assert(da.dimensions[0].label == da.label)
-        assert(da.dimensions[0].unit == da.unit)
-        assert(np.all(da.dimensions[0].ticks == da[:]))
-
     def test_set_dim_label_resize(self):
         setdim = self.array.append_set_dimension()
         labels = ["A", "B"]

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -240,7 +240,22 @@ class TestLinkDimension(unittest.TestCase):
         assert np.all(tickarray3d.label == self.range_dim.label)
 
     def test_data_array_set_link_dimension(self):
-        pass
+        labelarray = self.block.create_data_array(
+            "labels", "array.dimension.labels",
+            data=["Alpha", "Beta", "Gamma"], dtype=nix.DataType.String
+        )
+        self.set_dim.link_data_array(labelarray, [-1])
+        assert np.all(labelarray[:] == self.set_dim.labels)
+
+        labelarray2d = self.block.create_data_array(
+            "labels2d", "array.dimension.labels",
+            dtype=nix.DataType.String,
+            data=[["Alpha1", "Beta1", "Gamma1"],
+                  ["Alpha2", "Beta2", "Gamma2"]],
+        )
+        self.set_dim.link_data_array(labelarray2d, [1, -1])
+        assert np.all(("Alpha2", "Beta2", "Gamma2") == self.set_dim.labels)
+        assert np.all(labelarray2d[1, :] == self.set_dim.labels)
 
     def test_data_array_self_link_dimension(self):
         # The new way of making alias range dimension

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -211,8 +211,8 @@ class TestLinkDimension(unittest.TestCase):
         tickarray.unit = "mV"
         self.range_dim.link_data_array(tickarray, [-1])
         assert np.all(tickarray[:] == self.range_dim.ticks)
-        assert np.all(tickarray.unit == self.range_dim.unit)
-        assert np.all(tickarray.label == self.range_dim.label)
+        assert tickarray.unit == self.range_dim.unit
+        assert tickarray.label == self.range_dim.label
 
         tickarray3d = self.block.create_data_array(
             "ticks3d", "array.dimension.ticks",
@@ -225,8 +225,8 @@ class TestLinkDimension(unittest.TestCase):
         self.range_dim.link_data_array(tickarray3d, [3, -1, 1])
         assert np.shape(ticks) == np.shape(self.range_dim.ticks)
         assert np.all(ticks == self.range_dim.ticks)
-        assert np.all(tickarray3d.unit == self.range_dim.unit)
-        assert np.all(tickarray3d.label == self.range_dim.label)
+        assert tickarray3d.unit == self.range_dim.unit
+        assert tickarray3d.label == self.range_dim.label
 
     def test_data_array_set_link_dimension(self):
         labelarray = self.block.create_data_array(

--- a/nixio/test/test_multi_tag.py
+++ b/nixio/test/test_multi_tag.py
@@ -432,8 +432,8 @@ class TestMultiTags(unittest.TestCase):
         assert (segdata.shape == (1, 5, 1))
 
         # retrieve all positions for all references
-        for ridx, ref in enumerate(mtag.references):
-            for pidx, p in enumerate(mtag.positions):
+        for ridx, _ in enumerate(mtag.references):
+            for pidx, _ in enumerate(mtag.positions):
                 mtag.tagged_data(pidx, ridx)
 
         wrong_pos = self.block.create_data_array("incorpos", "test",
@@ -462,7 +462,7 @@ class TestMultiTags(unittest.TestCase):
         onedmtag = self.block.create_multi_tag("2dmt", "mtag",
                                                positions=onedpos)
         onedmtag.references.append(oneddata)
-        for pidx, p in enumerate(onedmtag.positions):
+        for pidx, _ in enumerate(onedmtag.positions):
             onedmtag.tagged_data(pidx, 0)
 
     def test_multi_tag_feature_data(self):

--- a/nixio/test/xcompat/compile.py
+++ b/nixio/test/xcompat/compile.py
@@ -41,7 +41,7 @@ def cc(filenames, dest,
         objnames = compiler.compile(filenames, output_dir=dest,
                                     extra_postargs=compile_args)
         for obj in objnames:
-            execname, ext = os.path.splitext(obj)
+            execname, _ = os.path.splitext(obj)
             compiler.link_executable(
                 [obj], execname, output_dir=dest,
                 target_lang="c++",

--- a/nixio/util/units.py
+++ b/nixio/util/units.py
@@ -137,8 +137,8 @@ def scalable(unit_a, unit_b):
     if not (is_si(unit_a) and is_si(unit_b)):
         return False
 
-    a_prefix, a_unit, a_power = split(unit_a)
-    b_prefix, b_unit, b_power = split(unit_b)
+    _, a_unit, a_power = split(unit_a)
+    _, b_unit, b_power = split(unit_b)
     if a_unit != b_unit or a_power != b_power:
         return False
 
@@ -163,8 +163,8 @@ def scaling(origin, destination):
             "nixio.util.scaling"
         )
 
-    org_prefix, org_unit, org_power = split(origin)
-    dest_prefix, dest_unit, dest_power = split(destination)
+    org_prefix, _, org_power = split(origin)
+    dest_prefix, _, dest_power = split(destination)
 
     if org_prefix == dest_prefix and org_power == dest_power:
         return scale

--- a/nixio/validator.py
+++ b/nixio/validator.py
@@ -462,17 +462,6 @@ def check_sampled_dimension(dim, idx):
     return errors, warnings
 
 
-def check_df_dimension(dim, idx):
-    """
-    Validate a DataFrameDimension and return all errors and warnings.
-
-    :returns: A list of 'errors' and a list of 'warnings'
-    """
-    errors = [ValidationError.DataFrameNotMatch.format(idx)]
-    warnings = list()
-    return errors, warnings
-
-
 def check_entity(entity):
     """
     General NIX entity validator


### PR DESCRIPTION
Implements DimensionLink as discussed in G-Node/nix#824 (closes #466).

Some notes and points for discussion:
- The name of the link in the backend (inside the HDF5 file) is simply `link`.  Therefore, a dimension with a linked object has the following path:
`/data/<block name>/data_arrays/<array name>/dimensions/<dim number>/link/<linked object id>`
- The dimension link object holds an attribute that specifies the type of the object it's linking.  The value of the attribute is either "DataArray" or "DataFrame".
- The dimension module has no access to the DataFrame and DataArray classes so it can't return or initialise an object of those types.  We could do it for the DataFrame, but importing DataArray would result in an import cycle.  DataArrays need to be able to create Dimensions, so Dimensions can't create (initialise) DataArrays.
- Do we want to allow setting values or attributes through the dimension link to the underlying data object?  For instance, should the `ticks` or `label` of a RangeDimension that links to a DataArray be modifiable through the RangeDimension object?
    - I haven't added support for this, but depending on the answer, I'll have to either add support for it or raise an exception.
- We don't allow dimensions that link to a DataFrame to have a `None` index, for linking to the entire DataFrame.  We initially supported this in the DataFrameDimension implementation, but now this ability or an analogous one isn't supported.  I think we agreed on this in our discussion, but I wanted to make sure I'm remembering correctly.
- Users are allowed to link a DataArray to a dimension with an index that is out of bounds for the array, as long as the dimensionality is correct.  My thinking here was that the underlying (linked) DataArray can be resized to fit or break the indexing, so the error will be caught on data retrieval or validation.  The dimensionality of a DA can't change, so we check for this during linking.