### PR TITLE
RangeDimension: Replace ticks with link and vice versa when setting

### DIFF
--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -129,12 +129,14 @@ class DataArray(Entity, DataSet):
         :rtype: RangeDimension
         """
         index = len(self.dimensions) + 1
+
         rdim = RangeDimension.create_new(self, index, ticks)
-        if label:
-            rdim.label = label
-            rdim.unit = unit
+        rdim.label = label
+        rdim.unit = unit
         if self.file.auto_update_timestamps:
             self.force_updated_at()
+        if ticks is not None:
+            rdim.ticks = ticks
         return rdim
 
     def delete_dimensions(self):

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -385,10 +385,10 @@ class SampledDimension(Dimension):
         util.check_attr_type(o, Number)
         self._h5group.set_attr("offset", o)
 
-    def link_data_array(self, data_array, index):
+    def link_data_array(self, *_):
         raise RuntimeError("SampledDimension does not support linking")
 
-    def link_data_frame(self, data_array, index):
+    def link_data_frame(self, *_):
         raise RuntimeError("SampledDimension does not support linking")
 
 
@@ -397,6 +397,18 @@ class RangeDimension(Dimension):
     def __init__(self, data_array, index):
         nixfile = data_array.file
         super(RangeDimension, self).__init__(nixfile, data_array, index)
+
+    def link_data_array(self, data_array, index):
+        if "ticks" in self._h5group:
+            # delete ticks to replace with link
+            self._h5group.delete("ticks")
+        super(RangeDimension, self).link_data_array(data_array, index)
+
+    def link_data_frame(self, data_frame, index):
+        if "ticks" in self._h5group:
+            # delete ticks to replace with link
+            self._h5group.delete("ticks")
+        super(RangeDimension, self).link_data_frame(data_frame, index)
 
     @classmethod
     def create_new(cls, data_array, index, ticks):

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -419,8 +419,8 @@ class RangeDimension(Dimension):
         if np.any(np.diff(ticks) < 0):
             raise ValueError("Ticks are not given in an ascending order.")
         if self.has_link:
-            raise RuntimeError("The ticks of a RangeDimension linked to a "
-                               "data object cannot be modified")
+            # unlick object and set ticks
+            self.remove_link()
         self._h5group.write_data("ticks", ticks)
 
     @property

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -256,7 +256,7 @@ class Dimension(object):
     def remove_link(self):
         if not self.has_link:
             raise RuntimeError("Dimension has no link")
-        self._h5group.delete("link")
+        self._h5group.delete("link", False)
 
     @property
     def has_link(self):
@@ -401,13 +401,13 @@ class RangeDimension(Dimension):
     def link_data_array(self, data_array, index):
         if "ticks" in self._h5group:
             # delete ticks to replace with link
-            self._h5group.delete("ticks")
+            self._h5group.delete("ticks", False)
         super(RangeDimension, self).link_data_array(data_array, index)
 
     def link_data_frame(self, data_frame, index):
         if "ticks" in self._h5group:
             # delete ticks to replace with link
-            self._h5group.delete("ticks")
+            self._h5group.delete("ticks", False)
         super(RangeDimension, self).link_data_frame(data_frame, index)
 
     @classmethod

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -241,7 +241,7 @@ class Dimension(object):
             raise ValueError(invalid_idx_msg)
 
         if self.has_link:
-            self._h5group.delete("link")
+            self.remove_link()
         DimensionLink.create_new(self._file, self, self._h5group,
                                  data_array, "DataArray", index)
 
@@ -249,9 +249,14 @@ class Dimension(object):
         if not 0 <= index < len(data_frame.columns):
             raise OutOfBounds("DataFrame index is out of bounds", index)
         if self.has_link:
-            self._h5group.delete("link")
+            self.remove_link()
         DimensionLink.create_new(self._file, self, self._h5group,
                                  data_frame, "DataFrame", index)
+
+    def remove_link(self):
+        if not self.has_link:
+            raise RuntimeError("Dimension has no link")
+        self._h5group.delete("link")
 
     @property
     def has_link(self):

--- a/nixio/hdf5/h5group.py
+++ b/nixio/hdf5/h5group.py
@@ -202,7 +202,7 @@ class H5Group(object):
                                               idx=pos)
         return self.get_by_name(name)
 
-    def delete(self, id_or_name):
+    def delete(self, id_or_name, delete_if_empty=True):
         """
         Deletes the child HDF5 group that matches the given name or id.
         """
@@ -214,6 +214,12 @@ class H5Group(object):
             del self.group[name]
         except Exception:
             raise ValueError("Error deleting {} ".format(name))
+        # Delete if empty and non-root container
+        groupdepth = len(self.group.name.split("/")) - 1
+        if delete_if_empty and not len(self.group) and groupdepth > 1:
+            del self.parent.group[self.name]
+            # del self.group
+            self.group = None
 
     def delete_all(self, eid):
         """

--- a/nixio/hdf5/h5group.py
+++ b/nixio/hdf5/h5group.py
@@ -214,12 +214,6 @@ class H5Group(object):
             del self.group[name]
         except Exception:
             raise ValueError("Error deleting {} ".format(name))
-        # Delete if empty and non-root container
-        groupdepth = len(self.group.name.split("/")) - 1
-        if not len(self.group) and groupdepth > 1:
-            del self.parent.group[self.name]
-            # del self.group
-            self.group = None
 
     def delete_all(self, eid):
         """

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -464,3 +464,26 @@ class TestLinkDimension(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             # Can't change label: column name
             self.range_dim.label = "a whole new label"
+
+    def test_range_link_tick_replacement(self):
+        tickarray = self.block.create_data_array(
+            "ticks", "array.dimension.ticks",
+            data=np.linspace(0, 100, 15)
+        )
+        assert "link" not in self.range_dim._h5group
+        assert "ticks" not in self.range_dim._h5group
+
+        # add link
+        self.range_dim.link_data_array(tickarray, [-1])
+        assert "link" in self.range_dim._h5group
+        assert "ticks" not in self.range_dim._h5group
+
+        # replace with ticks
+        self.range_dim.ticks = np.cumsum(np.random.random(10))
+        assert "link" not in self.range_dim._h5group
+        assert "ticks" in self.range_dim._h5group
+
+        # replace with link again
+        self.range_dim.link_data_array(tickarray, [-1])
+        assert "link" in self.range_dim._h5group
+        assert "ticks" not in self.range_dim._h5group


### PR DESCRIPTION
When setting the ticks of a RangeDimension that has an object link (DataArray or DataFrame), the object is unlinked.
When linking a data object to a RangeDimension that has ticks, the ticks are removed.

Closes #476.