### PR TITLE
H5Py string handling changes and fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,12 @@ matrix:
       env: pymajor=3
     - python: "3.7"
       os: linux
-      env: pymajor=3 coverage=1
+      env: pymajor=3 compat=1
       dist: xenial
       sudo: true
     - python: "3.7"
       os: linux
-      env: pymajor=3 nocompat=1
+      env: pymajor=3 coverage=1
       dist: xenial
     - language: generic
       os: osx
@@ -50,6 +50,8 @@ matrix:
             - hdf5
             - numpy
           update: true
+  allow_failures:
+    - env:
 
 addons:
   apt:
@@ -61,7 +63,7 @@ addons:
 
 before_install:
   # build nix for compat tests
-  - if [[ -z "${nocompat}" ]]; then
+  - if [[ "${compat}" == 1 ]]; then
       nixprefix="/usr/local";
       export NIX_INCDIR=${nixprefix}/include/nixio-1.0;
       export NIX_LIBDIR=${nixprefix}/lib;
@@ -90,10 +92,10 @@ install:
   - python${pymajor} setup.py build
 
 script:
-  - if [[ "${nocompat}" == 1 ]]; then
-      pytest --cov=nixio -nauto;
-    else
+  - if [[ "${compat}" == 1 ]]; then
       pytest --cov=nixio --nix-compat -nauto;
+    else
+      pytest --cov=nixio -nauto;
     fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ matrix:
             - numpy
           update: true
   allow_failures:
-    - env:
+    - env: pymajor=3 compat=1
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,10 @@ matrix:
       sudo: true
     - python: "3.7"
       os: linux
+      env: pymajor=3
+      dist: xenial
+    - python: "3.8"
+      os: linux
       env: pymajor=3 coverage=1
       dist: xenial
     - language: generic

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,16 +21,6 @@ environment:
       pyver: 2
       bits: 32
 
-    # Python 3.6 32 bit
-    - PYTHON: "C:\\Python36"
-      pyver: 3
-      bits: 32
-
-    # Python 3.7 32 bit
-    - PYTHON: "C:\\Python37"
-      pyver: 3
-      bits: 32
-
     # Python 2.7 64 bit
     - PYTHON: "C:\\Python27-x64"
       pyver: 2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -78,7 +78,8 @@ install:
   #     Invoke-WebRequest -URI $env:nix_exe_url -OutFile "nix.exe"
   # - 7z x nix.exe
   # - cd ..
-  - python -m pip install numpy h5py wheel pytest-xdist
+  - python -m pip install -U pip wheel
+  - python -m pip install numpy h5py pytest-xdist
   - ps: cd "$env:APPVEYOR_BUILD_FOLDER"
   - set DISTUTILS_USE_SDK="1"
   - set MSSdk="1"

--- a/nixio/block.py
+++ b/nixio/block.py
@@ -302,10 +302,10 @@ class Block(Entity):
         if (isinstance(col_dict, dict)
                 and not isinstance(col_dict, OrderedDict)
                 and sys.version_info[0] < 3):
-            raise TypeError("Python 2 users should use name_list "
-                            "or OrderedDict created with LIST and TUPLES "
-                            "to create DataFrames as the order "
-                            "of the columns cannot be maintained in Py2")
+            raise TypeError("Cannot create a DataFrame from a dictionary "
+                            "in Python 2 as the order of keys is not "
+                            "preserved. Please use the OrderedDict class "
+                            "from the collections module instead.")
 
         if data is not None:
             shape = len(data)

--- a/nixio/data_frame.py
+++ b/nixio/data_frame.py
@@ -341,13 +341,17 @@ class DataFrame(Entity, DataSet):
         return u
 
     @units.setter
-    def units(self, u):
-        for i in u:
-            if i is not None:
-                i = util.units.sanitizer(i)
-                util.check_attr_type(i, str)
-        unit = np.array(u, util.vlen_str_dtype)
-        self._h5group.set_attr("units", unit)
+    def units(self, units):
+        units_arr = np.array(units, util.vlen_str_dtype)
+        for idx, unit in enumerate(units_arr):
+            if unit is not None:
+                unit = util.units.sanitizer(unit)
+                util.check_attr_type(unit, str)
+                units_arr[idx] = unit
+            else:
+                # Write None units as empty string
+                units_arr[idx] = ""
+        self._h5group.set_attr("units", units_arr)
         if self.file.auto_update_timestamps:
             self.force_updated_at()
 

--- a/nixio/hdf5/h5dataset.py
+++ b/nixio/hdf5/h5dataset.py
@@ -52,6 +52,10 @@ class H5DataSet(object):
             # h5py throws ValueError for out-of-bounds index
             # Let's change it to IndexError
             raise IndexError(ve)
+        except TypeError as te:
+            # h5py 2.10 in Python2 throws TypeError for out-of-bounds index
+            # Let's change it to IndexError
+            raise IndexError(te)
 
     def set_attr(self, name, value):
         if value is None:

--- a/nixio/test/test_data_array.py
+++ b/nixio/test/test_data_array.py
@@ -171,7 +171,8 @@ class TestDataArray(unittest.TestCase):
         assert(np.array_equal(data, dout))
 
         # indexing support in 2-d arrays
-        self.assertRaises(TypeError, lambda: self.array[[], [1, 2]])
+        with self.assertRaises(IndexError):
+            self.array[[], [1, 2]]
 
         dout = dset[12]
         assert(dout.shape == data[12].shape)

--- a/nixio/test/test_data_frame.py
+++ b/nixio/test/test_data_frame.py
@@ -61,7 +61,7 @@ class TestDataFrame(unittest.TestCase):
         assert df_li.column_names == self.df1.column_names
         assert df_li.dtype == self.df1.dtype
         for i in df_li[:]:
-            self.assertIsInstance(i['id'], string_types)
+            self.assertIsInstance(i['id'], (bytes, string_types))
             self.assertIsInstance(i['sig2'], np.int32)
 
     def test_column_name_collision(self):
@@ -83,9 +83,9 @@ class TestDataFrame(unittest.TestCase):
     def test_write_row(self):
         # test write single row
         row = ["1", 'abc', 3, 4.4556356242341, 5.1111111]
-        self.assertAlmostEqual(list(self.df1[9]), [2, 'j', 20.08, 5.1, 200])
+        assert list(self.df1[9]) == [2, b'j', 20.08, 5.1, 200]
         self.df1.write_rows([row], [9])
-        assert list(self.df1[9]) == [1, 'abc', 3., 4.4556356242341, 5]
+        assert list(self.df1[9]) == [1, b'abc', 3., 4.4556356242341, 5]
         self.assertIsInstance(self.df1[9]['name'],  np.integer)
         self.assertIsInstance(self.df1[9]['sig2'],  np.int32)
         assert self.df1[9]['sig2'] == int(5)
@@ -93,8 +93,8 @@ class TestDataFrame(unittest.TestCase):
         multi_rows = [[1775, '12355', 1777, 1778, 1779],
                       [1785, '12355', 1787, 1788, 1789]]
         self.df1.write_rows(multi_rows, [1, 2])
-        assert list(self.df1[1]) == [1775, '12355', 1777, 1778, 1779]
-        assert list(self.df1[2]) == [1785, '12355', 1787, 1788, 1789]
+        assert list(self.df1[1]) == [1775, b'12355', 1777, 1778, 1779]
+        assert list(self.df1[2]) == [1785, b'12355', 1787, 1788, 1789]
 
     def test_write_column(self):
         # write by name
@@ -109,7 +109,7 @@ class TestDataFrame(unittest.TestCase):
 
     def test_read_row(self):
         # read single row
-        assert list(self.df1.read_rows(0)) == [1, 'a', 20.18, 5.0, 100]
+        assert list(self.df1.read_rows(0)) == [1, b'a', 20.18, 5.0, 100]
         # read multiple
         multi_rows = self.df1.read_rows(np.arange(4, 9))
         np.testing.assert_array_equal(multi_rows, self.df1[4:9])
@@ -117,8 +117,7 @@ class TestDataFrame(unittest.TestCase):
     def test_read_column(self):
         # read single columns by index
         single_col = self.df1.read_columns(index=[1])
-        t = np.array(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'])
-        t = np.array(t, dtype=str)
+        t = np.array(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'], dtype=bytes)
         np.testing.assert_array_equal(single_col, t)
         # read multiple columns by name
         multi_col = self.df1.read_columns(name=['sig1', 'sig2'])
@@ -133,7 +132,7 @@ class TestDataFrame(unittest.TestCase):
         assert scell == 5.2
         # read cell by row_idx + col_name
         crcell = self.df1.read_cell(col_name=['id'], row_idx=9)
-        assert crcell == 'j'
+        assert crcell == b'j'
         # test error raise if only one param given
         self.assertRaises(ValueError, self.df1.read_cell, row_idx=10)
         self.assertRaises(ValueError, self.df1.read_cell, col_name='sig1')
@@ -144,7 +143,7 @@ class TestDataFrame(unittest.TestCase):
         assert self.df1[8]['sig1'] == 105
         # write cell by rowid colname
         self.df1.write_cell('test', col_name='id', row_idx=3)
-        assert self.df1[3]['id'] == 'test'
+        assert self.df1[3]['id'] == b'test'
         # test error raise
         self.assertRaises(ValueError, self.df1.write_cell, 11, col_name='sig1')
 
@@ -167,14 +166,13 @@ class TestDataFrame(unittest.TestCase):
 
     def test_append_rows(self):
         # append single row
-        srow = [1, "test", 3, 4, 5]
+        srow = [1, b"test", 3, 4, 5]
         self.df1.append_rows([srow])
         assert list(self.df1[10]) == srow
         # append multi-rows
-        mrows = [[1, '2', 3, 4, 5], [6, 'testing', 8, 9, 10]]
+        mrows = [[1, "2", 3, 4, 5], [6, "testing", 8, 9, 10]]
         self.df1.append_rows(mrows)
-        assert [list(i) for i in self.df1[-2:]] == \
-               [[1, '2', 3., 4., 5], [6, 'testing', 8., 9., 10]]
+        assert [list(i) for i in self.df1[-2:]] == [[1, b'2', 3., 4., 5], [6, b'testing', 8., 9., 10]]
         # append row with incorrect length
         errrow = [5, 6, 7, 8]
         self.assertRaises(ValueError, self.df1.append_rows, [errrow])

--- a/nixio/test/test_data_frame.py
+++ b/nixio/test/test_data_frame.py
@@ -214,7 +214,7 @@ class TestDataFrame(unittest.TestCase):
                                           col_dict=OrderedDict({"idx": int}))
         dftime = df.updated_at
         time.sleep(1)
-        df.units = "ly"
+        df.units = ("ly",)
         self.assertNotEqual(dftime, df.updated_at)
 
     def test_timestamp_noautoupdate(self):
@@ -223,5 +223,5 @@ class TestDataFrame(unittest.TestCase):
                                           col_dict=OrderedDict({"idx": int}))
         dftime = df.updated_at
         time.sleep(1)
-        df.units = "ly"
+        df.units = ("ly",)
         self.assertEqual(dftime, df.updated_at)

--- a/nixio/util/util.py
+++ b/nixio/util/util.py
@@ -6,7 +6,7 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
-from six import string_types, text_type
+from six import string_types
 import numpy as np
 
 import h5py
@@ -16,7 +16,7 @@ from ..exceptions import exceptions
 from . import names
 
 
-vlen_str_dtype = h5py.special_dtype(vlen=text_type)
+vlen_str_dtype = h5py.string_dtype(encoding='utf-8', length=None)
 
 
 def create_id():


### PR DESCRIPTION
This PR takes care of [recent changes to string handling in H5Py](https://docs.h5py.org/en/stable/strings.html) as well as some older inconsistencies with string handling.

- Use the h5py string_dtype with explicit UTF-8 encoding, instead of a numpy type.
- Write empty string in place of `None` for DataFrame.units: `None` is no longer a valid element of a string array in h5py.
- Change DataFrame tests to check for bytes instead of strings in returned data.

Copying commit message for DataFrame string/bytes element type tests:
String data and attributes in NIXPy are generally returned as strings.  H5Py returns string data from a file as bytes and these are decoded to strings before returning to the user.  Unfortunately, there's no clean way to do the same with compound data types that contain string elements.  Strings in DataFrame data are returned as bytes and tests are adjusted accordingly.