### PR TITLE
Global pylintrc file and code quality fixes

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -21,13 +21,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install h5py
-    - name: Lint with flake8
-      run: |
-        pip install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude="docs,.eggs,build,scripts"
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=80 --statistics --exclude="docs,.eggs,build,scripts"
     - name: Lint with Pylint
       run: |
         pip install pylint

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -28,10 +28,11 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude="docs,.eggs,build,scripts"
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=80 --statistics --exclude="docs,.eggs,build,scripts"
-    - name: Lint with pycodestyle
+    - name: Lint with Pylint
       run: |
-        pip install pycodestyle
-        pycodestyle . --exclude="docs,.eggs,build,scripts"
+        pip install pylint
+        # Make sure it uses the project rcfile
+        pylint --rcfile=.pylintrc nixio
     - name: Test with pytest
       run: |
         pip install pytest

--- a/.pylintrc
+++ b/.pylintrc
@@ -108,9 +108,9 @@ enable=C0102,  # Black listed name "%s"**
        E1002,  # Use of super on an old style class**
        E1003,  # Bad first argument %r given to super()**
        E1004,  # Missing argument to super()**
-       E1101,  # %s %r has no %r member**
+       # E1101,  # %s %r has no %r member**  ## RE-ENABLE AFTER CODE RESTRUCTURING
        E1102,  # %s is not callable**
-       E1103,  # %s %r has no %r member (but some types could not be inferred)**
+       # E1103,  # %s %r has no %r member (but some types could not be inferred)**  ## RE-ENABLE AFTER CODE RESTRUCTURING
        E1111,  # Assigning to function call which doesn't return**
        E1120,  # No value passed for parameter %s in function call**
        E1121,  # Too many positional arguments for function call**

--- a/.pylintrc
+++ b/.pylintrc
@@ -354,7 +354,7 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=120
 
 # Maximum number of lines in a module.
 max-module-lines=1000

--- a/.pylintrc
+++ b/.pylintrc
@@ -285,6 +285,7 @@ good-names=i,
            mt,  # common for MultiTag
            df,  # common for DataFrame
            dt,  # common for time difference/step
+           id,  # entity id attribute
 
 # Good variable names regexes, separated by a comma. If names match any regex,
 # they will always be accepted

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,618 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=
+
+# Specify a score threshold to be exceeded before program exits with error.
+fail-under=10.0
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=0
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=all
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=C0102,  # Black listed name "%s"**
+       C0103,  # Invalid %s name "%s"**
+       C0121,  # Missing required attribute "%s"**
+       C0202,  # Class method %s should have cls as first argument**
+       C0203,  # Metaclass method %s should have mcs as first argument**
+       C0204,  # Metaclass class method %s should have %s as first argument**
+       C0325,  # Unnecessary parens after %r keyword**
+       E0011,  # Unrecognized file option %r**
+       E0012,  # Bad option value %r**
+       E0100,  # __init__ method is a generator**
+       E0101,  # Explicit return in __init__**
+       E0102,  # %s already defined line %s**
+       E0103,  # %r not properly in loop**
+       E0104,  # Return outside function**
+       E0105,  # Yield outside function**
+       E0106,  # Return with argument inside generator**
+       E0107,  # Use of the non-existent %s operator**
+       E0108,  # Duplicate argument name %s in function definition**
+       E0202,  # An attribute affected in %s line %s hide this method**
+       E0203,  # Access to member %r before its definition line %s**
+       E0211,  # Method has no argument**
+       E0213,  # Method should have "self" as first argument**
+       E0221,  # Interface resolved to %s is not a class**
+       E0222,  # Missing method %r from %s interface**
+       E0235,  # __exit__ must accept 3 arguments: type, value, traceback**
+       E0501,  # Old: Non ascii characters found but no encoding specified (PEP 263)**
+       E0502,  # Old: Wrong encoding specified (%s)**
+       E0503,  # Old: Unknown encoding specified (%s)**
+       E0601,  # Using variable %r before assignment**
+       E0602,  # Undefined variable %r**
+       E0603,  # Undefined variable name %r in __all__**
+       E0604,  # Invalid object %r in __all__, must contain only strings**
+       E0611,  # No name %r in module %r**
+       E0701,  # Bad except clauses order (%s)**
+       E0702,  # Raising %s while only classes, instances or string are allowed**
+       E0710,  # Raising a new style class which doesn't inherit from BaseException**
+       E0711,  # NotImplemented raised - should raise NotImplementedError**
+       E0712,  # Catching an exception which doesn\'t inherit from BaseException: %s**
+       E1001,  # Use of __slots__ on an old style class**
+       E1002,  # Use of super on an old style class**
+       E1003,  # Bad first argument %r given to super()**
+       E1004,  # Missing argument to super()**
+       E1101,  # %s %r has no %r member**
+       E1102,  # %s is not callable**
+       E1103,  # %s %r has no %r member (but some types could not be inferred)**
+       E1111,  # Assigning to function call which doesn't return**
+       E1120,  # No value passed for parameter %s in function call**
+       E1121,  # Too many positional arguments for function call**
+       E1122,  # Old: Duplicate keyword argument %r in function call**
+       E1123,  # Passing unexpected keyword argument %r in function call**
+       E1124,  # Parameter %r passed as both positional and keyword argument**
+       E1125,  # Old: Missing mandatory keyword argument %r**
+       E1200,  # Unsupported logging format character %r (%#02x) at index %d**
+       E1201,  # Logging format string ends in middle of conversion specifier**
+       E1205,  # Too many arguments for logging format string**
+       E1206,  # Not enough arguments for logging format string**
+       E1300,  # Unsupported format character %r (%#02x) at index %d**
+       E1301,  # Format string ends in middle of conversion specifier**
+       E1302,  # Mixing named and unnamed conversion specifiers in format string**
+       E1303,  # Expected mapping for format string, not %s**
+       E1304,  # Missing key %r in format string dictionary**
+       E1305,  # Too many arguments for format string**
+       E1306,  # Not enough arguments for format string**
+       E1310,  # Suspicious argument in %s.%s call**
+       W0101,  # Unreachable code**
+       W0102,  # Dangerous default value %s as argument**
+       W0104,  # Statement seems to have no effect**
+       W0105,  # String statement has no effect**
+       W0106,  # Expression "%s" is assigned to nothing**
+       W0108,  # Lambda may not be necessary**
+       W0109,  # Duplicate key %r in dictionary**
+       W0120,  # Else clause on loop without a break statement**
+       W0150,  # %s statement in finally block may swallow exception**
+       W0201,  # Attribute %r defined outside __init__**
+       W0211,  # Static method with %r as first argument**
+       W0221,  # Arguments number differs from %s method**
+       W0222,  # Signature differs from %s method**
+       W0223,  # Method %r is abstract in class %r but is not overridden**
+       W0234,  # iter returns non-iterator**
+       W0301,  # Unnecessary semicolon**
+       W0311,  # Bad indentation. Found %s %s, expected %s**
+       W0312,  # Found indentation with %ss instead of %ss**
+       W0331,  # Use of the <> operator**
+       W0402,  # Uses of a deprecated module %r**
+       W0406,  # Module import itself**
+       W0512,  # Cannot decode using encoding "%s", unexpected byte at position %d**
+       W0601,  # Global variable %r undefined at the module level**
+       W0602,  # Using global for %r but no assigment is done**
+       W0611,  # Unused import %s**
+       W0612,  # Unused variable %r**
+       W0613,  # Unused argument %r**
+       W0614,  # Unused import %s from wildcard import**
+       W0621,  # Redefining name %r from outer scope (line %s)**
+       W0622,  # Redefining built-in %r**
+       W0623,  # Redefining name %r from %s in exception handler**
+       W0631,  # Using possibly undefined loop variable %r**
+       W0632,  # Possible unbalanced tuple unpacking with sequence%s: …**
+       W0633,  # Attempting to unpack a non-sequence%s**
+       W0701,  # Raising a string exception**
+       W0704,  # Except doesn't do anything**
+       W0710,  # Exception doesn't inherit from standard "Exception" class**
+       W0711,  # Exception to catch is the result of a binary "%s" operation**
+       W0712,  # Implicit unpacking of exceptions is not supported in Python 3**
+       W1111,  # Assigning to function call which only returns None**
+       W1300,  # Format string dictionary key should be a string, not %s**
+       W1301,  # Unused key %r in format string dictionary**
+       W1401,  # Anomalous backslash in string: \'%s\'. String constant might be missing an r prefix.**
+       W1402,  # Anomalous Unicode escape in byte string: \'%s\'. String constant might be missing an r or u prefix.**
+       W1501,  # "%s" is not a valid mode for open.**
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'error', 'warning', 'refactor', and 'convention'
+# which contain the number of messages in each category, as well as 'statement'
+# which is the total number of statements analyzed. This score is used by the
+# global evaluation report (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+#notes-rgx=
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it work,
+# install the python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "BaseException, Exception".
+overgeneral-exceptions=BaseException,
+                       Exception

--- a/.pylintrc
+++ b/.pylintrc
@@ -141,8 +141,8 @@ enable=C0102,  # Black listed name "%s"**
        W0150,  # %s statement in finally block may swallow exception**
        W0201,  # Attribute %r defined outside __init__**
        W0211,  # Static method with %r as first argument**
-       W0221,  # Arguments number differs from %s method**
-       W0222,  # Signature differs from %s method**
+       # W0221,  # Arguments number differs from %s method**  ## RE-ENABLE AFTER CODE RESTRUCTURING
+       # W0222,  # Signature differs from %s method**  ## RE-ENABLE AFTER CODE RESTRUCTURING
        W0223,  # Method %r is abstract in class %r but is not overridden**
        W0234,  # iter returns non-iterator**
        W0301,  # Unnecessary semicolon**

--- a/.pylintrc
+++ b/.pylintrc
@@ -281,9 +281,11 @@ good-names=i,
            ex,
            Run,
            _,
+           nf,  # common for nix.File
            da,  # common for DataArray
            mt,  # common for MultiTag
            df,  # common for DataFrame
+           dv,  # common for DataView
            dt,  # common for time difference/step
            id,  # entity id attribute
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -280,7 +280,11 @@ good-names=i,
            k,
            ex,
            Run,
-           _
+           _,
+           da,  # common for DataArray
+           mt,  # common for MultiTag
+           df,  # common for DataFrame
+           dt,  # common for time difference/step
 
 # Good variable names regexes, separated by a comma. If names match any regex,
 # they will always be accepted

--- a/nixio/block.py
+++ b/nixio/block.py
@@ -80,9 +80,8 @@ class Block(Entity):
         if copy_from:
             if not isinstance(copy_from, MultiTag):
                 raise TypeError("Object to be copied is not a MultiTag")
-            id = self._copy_objects(copy_from, "multi_tags",
-                                    keep_copy_id, name)
-            return self.multi_tags[id]
+            objid = self._copy_objects(copy_from, "multi_tags", keep_copy_id, name)
+            return self.multi_tags[objid]
 
         util.check_entity_name_and_type(name, type_)
         multi_tags = self._h5group.open_group("multi_tags")
@@ -105,7 +104,7 @@ class Block(Entity):
                 extcreated = True
             mtag = MultiTag.create_new(self.file, self, multi_tags,
                                        name, type_, positions)
-        except Exception as e:
+        except Exception as exp:
             msg = "MultiTag Creation Failed"
             if poscreated:
                 del self.data_arrays["{}-positions".format(name)]
@@ -116,7 +115,7 @@ class Block(Entity):
             elif poscreated and not extcreated:
                 msg += " due to invalid extents"
             print(msg)
-            raise e
+            raise exp
 
         if extents is not None:
             mtag.extents = extents
@@ -145,8 +144,8 @@ class Block(Entity):
         if copy_from:
             if not isinstance(copy_from, Tag):
                 raise TypeError("Object to be copied is not a Tag")
-            id = self._copy_objects(copy_from, "tags", keep_copy_id, name)
-            return self.tags[id]
+            objid = self._copy_objects(copy_from, "tags", keep_copy_id, name)
+            return self.tags[objid]
 
         util.check_entity_name_and_type(name, type_)
         tags = self._h5group.open_group("tags")
@@ -228,9 +227,9 @@ class Block(Entity):
         if copy_from:
             if not isinstance(copy_from, DataArray):
                 raise TypeError("Object to be copied is not a DataArray")
-            id = self._copy_objects(copy_from, "data_arrays",
+            objid = self._copy_objects(copy_from, "data_arrays",
                                     keep_copy_id, name)
-            return self.data_arrays[id]
+            return self.data_arrays[objid]
 
         if data is None:
             if shape is None:
@@ -294,9 +293,8 @@ class Block(Entity):
         if copy_from:
             if not isinstance(copy_from, DataFrame):
                 raise TypeError("Object to be copied is not a DataFrame")
-            id = self._copy_objects(copy_from, "data_frames",
-                                    keep_copy_id, name)
-            return self.data_frames[id]
+            objid = self._copy_objects(copy_from, "data_frames", keep_copy_id, name)
+            return self.data_frames[objid]
 
         util.check_entity_name_and_type(name, type_)
         if (isinstance(col_dict, dict)
@@ -322,8 +320,8 @@ class Block(Entity):
                     )
                 elif col_dtypes is None and data is not None:
                     col_dtypes = []
-                    for x in data[0]:
-                        col_dtypes.append(type(x))
+                    for val in data[0]:
+                        col_dtypes.append(type(val))
                     col_dict = OrderedDict(
                         (str(nam), dt)
                         for nam, dt in zip(col_names, col_dtypes)
@@ -337,11 +335,11 @@ class Block(Entity):
             else:  # if col_names is None
                 if data is not None and type(data[0]) == np.void:
                     col_dtype = data[0].dtype
-                    cn = list(col_dtype.fields.keys())
+                    col_name = list(col_dtype.fields.keys())
                     raw_dt = col_dtype.fields.values()
                     raw_dt = list(raw_dt)
                     raw_dt_list = [ele[0] for ele in raw_dt]
-                    col_dict = OrderedDict(zip(cn, raw_dt_list))
+                    col_dict = OrderedDict(zip(col_name, raw_dt_list))
                     if len(col_dtype.fields.values()) != len(col_dict):
                         raise exceptions.DuplicateColumnName
 
@@ -425,12 +423,12 @@ class Block(Entity):
             for tag in grp.tags:
                 self._pp(tag, max_length,
                          indent*(start_depth + 2), extra, True)
-                for fe in tag.features:
-                    self._pp(fe, max_length, indent*(start_depth + 3), False)
+                for feat in tag.features:
+                    self._pp(feat, max_length, indent*(start_depth + 3), False)
             for mt in grp.multi_tags:
                 self._pp(mt, max_length, indent*(start_depth + 2), extra, True)
-                for fe in mt.features:
-                    self._pp(fe, max_length, indent*(start_depth + 3), False)
+                for feat in mt.features:
+                    self._pp(feat, max_length, indent*(start_depth + 3), False)
         for da in self.data_arrays:
             self._pp(da, max_length, indent*(start_depth + 1), extra)
             for dim in da.dimensions:
@@ -439,21 +437,21 @@ class Block(Entity):
             self._pp(df, max_length, indent*(start_depth + 1), extra)
         for tag in self.tags:
             self._pp(tag, max_length, indent*(start_depth + 1), extra)
-            for fe in tag.features:
-                self._pp(fe, max_length, indent*(start_depth + 2), False)
+            for feat in tag.features:
+                self._pp(feat, max_length, indent*(start_depth + 2), False)
         for mt in self.multi_tags:
             self._pp(mt, max_length, indent*(start_depth + 1), extra)
-            for fe in mt.features:
-                self._pp(fe, max_length, indent*(start_depth + 2), False)
+            for feat in mt.features:
+                self._pp(feat, max_length, indent*(start_depth + 2), False)
 
     @staticmethod
-    def _pp(obj, ml, indent, ex, grp=False):
+    def _pp(obj, max_len, indent, extra, grp=False):
         spaces = " "*(indent)
         if grp:
             prefix = "*"
         else:
             prefix = ""
-        if ex:
+        if extra:
             stat = ""
             if isinstance(obj, MultiTag):
                 stat = "Position Shape:{} Units: {}".format(
@@ -467,25 +465,25 @@ class Block(Entity):
                                                      obj.column_names)
             elif isinstance(obj, DataArray):
                 stat = "Shape: {} Unit:{}".format(obj.shape, obj.unit)
-            p = "{}{}{}".format(spaces, prefix, obj)
-            n = "{}  {}".format(spaces, stat)
+            objstr = "{}{}{}".format(spaces, prefix, obj)
+            stat = "{}  {}".format(spaces, stat)
         else:
-            p = "{}{}{}".format(spaces, prefix, obj)
-        if len(p) > ml - 4:
-            split_len = int(ml/2)
-            str1 = p[0:split_len]
-            str2 = p[-split_len:]
+            objstr = "{}{}{}".format(spaces, prefix, obj)
+        if len(objstr) > max_len - 4:
+            split_len = int(max_len/2)
+            str1 = objstr[0:split_len]
+            str2 = objstr[-split_len:]
             print("{} ... {}".format(str1, str2))
         else:
-            print(p)
-        if ex:
-            if len(n) > ml - 4:
-                split_len = int(ml/2)
-                nstr1 = n[0:split_len]
-                nstr2 = n[-split_len:]
+            print(objstr)
+        if extra:
+            if len(stat) > max_len - 4:
+                split_len = int(max_len/2)
+                nstr1 = stat[0:split_len]
+                nstr2 = stat[-split_len:]
                 print("{} ... {}".format(nstr1, nstr2))
             else:
-                print(n)
+                print(stat)
 
     def _copy_objects(self, obj, clsname, keep_id=True, name=""):
         src = "{}/{}".format(clsname, obj.name)
@@ -496,11 +494,8 @@ class Block(Entity):
             raise NameError("Name already exist. Possible solution is to "
                             "provide a new name when copying destination "
                             "is the same as the source parent")
-        o = obj._parent._h5group.copy(source=src, dest=self._h5group,
-                                      name=name, cls=clsname,
-                                      keep_id=keep_id)
-
-        return o.attrs["entity_id"]
+        obj_copy = obj._parent._h5group.copy(source=src, dest=self._h5group, name=name, cls=clsname, keep_id=keep_id)
+        return obj_copy.attrs["entity_id"]
 
     @property
     def sources(self):

--- a/nixio/block.py
+++ b/nixio/block.py
@@ -227,8 +227,7 @@ class Block(Entity):
         if copy_from:
             if not isinstance(copy_from, DataArray):
                 raise TypeError("Object to be copied is not a DataArray")
-            objid = self._copy_objects(copy_from, "data_arrays",
-                                    keep_copy_id, name)
+            objid = self._copy_objects(copy_from, "data_arrays", keep_copy_id, name)
             return self.data_arrays[objid]
 
         if data is None:

--- a/nixio/cmd/explore.py
+++ b/nixio/cmd/explore.py
@@ -25,74 +25,69 @@ import sys
 
 try:
     import nixworks as nw
-    nw_present = True
+    NIX_WORKS = True
 except ImportError:
-    nw_present = False
+    NIX_WORKS = False
 
-tool_description = """
-nixio explore functionality is split into sub-commands for file, metadata, and
-data exploration. For help on the commands type e.g.: 'nixio explore file
---help'.
+TOOL_DESCRIPTION = """
+nixio explore functionality is split into sub-commands for file, metadata, and data exploration. For help on the
+commands type e.g.: 'nixio explore file --help'.
 """
 
-mdata_pattern_help = """
-Pattern(s) with which to look for sections and properties. The pattern can be
-either 1) type_or_name: First looks for a section matching in type or name or
-a property with matching name. 2) type_or_name/prop_name: first looks for a
-matching section and within those for matching properties. Patterns are
-applied case-insensitive and can be partial matches. You can provide multiple
-patterns by calling the command like: `nixio explore metadata -p "subject" -p
-"species" file1.nix file2.nix`
+METADATA_PATTERN_HELP = """
+Pattern(s) with which to look for sections and properties. The pattern can be either 1) type_or_name: First looks for a
+section matching in type or name or a property with matching name. 2) type_or_name/prop_name: first looks for a matching
+section and within those for matching properties. Patterns are applied case-insensitive and can be partial matches. You
+can provide multiple patterns by calling the command like: `nixio explore metadata -p "subject" -p "species" file1.nix
+file2.nix`
 """
 
-data_parser_help = """
+DATA_PARSER_HELP = """
 Display information about data entities such as DataArrays, Tags, or MultiTags.
 """
 
-data_pattern_help = """
+DATA_PATTERN_HELP = """
 A string pattern that is parsed to find the data entity.
 """
 
-dump_parser_help = """
-Dump data to file or stdout. This command can process up to 3D data. The data
-dump contains dimension information as well as the stored data. To write the
-data to text file use e.g. 'nixio explore dump path_to_nix_file -p "name or
-type of data entity" > data.dump' or provide the "--outfile" argument.
+DUMP_PARSER_HELP = """
+Dump data to file or stdout. This command can process up to 3D data. The data dump contains dimension information as
+well as the stored data. To write the data to text file use e.g. 'nixio explore dump path_to_nix_file -p "name or type
+of data entity" > data.dump' or provide the "--outfile" argument.
 """
 
-dump_pattern_help = data_pattern_help
+DUMP_PATTERN_HELP = DATA_PATTERN_HELP
 
-dump_outfile_help = """
-Name of a file into which the data should be dumped. If not given data will be
-dumped to stdout.
+DUMP_OUTFILE_HELP = """
+Name of a file into which the data should be dumped. If not given data will be dumped to stdout.
 """
 
-plot_parser_help = """
-Create basic plots of the stored data. This command is only available if
-nixworks is installed.
+PLOT_PARSER_HELP = """
+Create basic plots of the stored data. This command is only available if nixworks is installed.
 """
 
 
 def progress(count, total, status='', bar_len=60):
     """
-    Modified after https://gist.github.com/vladignatyev/06860ec2040cb497f0f3
-    by Vladimir Ignatev published under MIT License
+    Modified after https://gist.github.com/vladignatyev/06860ec2040cb497f0f3 by Vladimir Ignatev published under MIT
+    License
     """
     percents = count / total
     filled_len = int(percents * bar_len)
-    bar = '=' * filled_len + '-' * (bar_len - filled_len)
+    prog_bar = '=' * filled_len + '-' * (bar_len - filled_len)
 
-    sys.stderr.write('[%s] %.2f%s ...%s\r' % (bar, percents * 100, '%', status))
+    sys.stderr.write('[%s] %.2f%s ...%s\r' % (prog_bar, percents * 100, '%', status))
     sys.stderr.flush()
 
 
 def open_nix_file(filename):
-    f = None
+    nf = None
     try:
-        f = nix.File.open(filename, nix.FileMode.ReadOnly)
-    except Exception as e:
-        print("ERROR: '{}' is not a valid NIX file!\n\t error message was: '{}'".format(filename, e))
-    return f
+        nf = nix.File.open(filename, nix.FileMode.ReadOnly)
+    except Exception as exc:
+        print("ERROR: '{}' is not a valid NIX file!\n\t error message was: '{}'".format(filename,
+                                                                                        exc))
+    return nf
 
 
 def assemble_files(arguments):
@@ -108,12 +103,12 @@ def assemble_files(arguments):
             candidates = sorted(glob.glob(filename))
             if len(candidates) == 0:
                 print("Error: invalid file or directory! No matches found. '{}'".format(filename))
-            for c in candidates:
-                if os.path.isdir(c):
-                    c = os.sep.join((c, "*." + arguments.suffix))
-                    all_files.extend(sorted(glob.glob(c)))
-                elif os.path.isfile(c):
-                    all_files.append(c)
+            for candidate in candidates:
+                if os.path.isdir(candidate):
+                    candidate = os.sep.join((candidate, "*." + arguments.suffix))
+                    all_files.extend(sorted(glob.glob(candidate)))
+                elif os.path.isfile(candidate):
+                    all_files.append(candidate)
 
     return all_files
 
@@ -121,12 +116,12 @@ def assemble_files(arguments):
 def disp_file_structure(nix_file, verbosity):
     def block_content(nix_file, verbosity):
         def array_content(block, verbosity):
-            def dimension_description(data_array, verbosity):
+            def dimension_description(data_array, _):
                 content = ", dimensions: ["
-                dd = [d.label if d.dimension_type == nix.DimensionType.Sample or
-                      d.dimension_type == nix.DimensionType.Range else d.dimension_type
-                      for d in data_array.dimensions]
-                content += ",".join(dd)
+                dim_desc = [d.label if d.dimension_type == nix.DimensionType.Sample or
+                            d.dimension_type == nix.DimensionType.Range else d.dimension_type
+                            for d in data_array.dimensions]
+                content += ",".join(dim_desc)
                 content += "]"
                 return content
 
@@ -136,15 +131,15 @@ def disp_file_structure(nix_file, verbosity):
                 return content
 
             content = "      Data Arrays:\n" if len(block.data_arrays) > 0 else ""
-            for a in b.data_arrays:
-                array_struct = array_structure(a, verbosity) if verbosity > 2 else ""
-                content += "      %s [%s] --- id: %s    %s\n" % (a.name, a.type, a.id, array_struct)
+            for da in block.data_arrays:
+                array_struct = array_structure(da, verbosity) if verbosity > 2 else ""
+                content += "      %s [%s] --- id: %s    %s\n" % (da.name, da.type, da.id, array_struct)
             return content
 
-        def group_content(block, verbosity):
+        def group_content(block, _):
             content = "      Groups:\n" if len(block.groups) > 0 else ""
-            for g in block.groups:
-                content += "      %s [%s] -- id: %s\n" % (g.name, g.type, g.id)
+            for grp in block.groups:
+                content += "      %s [%s] -- id: %s\n" % (grp.name, grp.type, grp.id)
             return content
 
         def tag_content(block, verbosity):
@@ -153,16 +148,16 @@ def disp_file_structure(nix_file, verbosity):
                     return ""
 
                 content = "      start: %s, extent: %s" % (tag.position, tag.extent)
-                for r in tag.references:
-                    content += "\n       refers to -> %s" % r.name
-                for ft in tag.features:
-                    content += "\n       feature in -> %s" % ft.data.name
+                for ref in tag.references:
+                    content += "\n       refers to -> %s" % ref.name
+                for feat in tag.features:
+                    content += "\n       feature in -> %s" % feat.data.name
                 content += "\n"
                 return content
 
             content = "      Tags:\n"
-            for t in block.tags:
-                content += "      %s [%s] --- id: %s\n %s" % (t.name, t.type, t.id, tag_details(t, verbosity))
+            for tag in block.tags:
+                content += "      %s [%s] --- id: %s\n %s" % (tag.name, tag.type, tag.id, tag_details(tag, verbosity))
             return content
 
         def mtag_content(block, verbosity):
@@ -171,53 +166,59 @@ def disp_file_structure(nix_file, verbosity):
                     return ""
 
                 content = "      start: %s, extent: %s" % (tag.position[:], tag.extent[:])
-                for r in tag.references:
-                    content += "\n       segment refers to -> %s" % r.name
-                for ft in tag.features:
-                    content += "\n       segment feature(s) in -> %s" % ft.data.name
+                for ref in tag.references:
+                    content += "\n       segment refers to -> %s" % ref.name
+                for feat in tag.features:
+                    content += "\n       segment feature(s) in -> %s" % feat.data.name
                 content += "\n"
                 return content
 
             content = "      Multi-Tags:\n"
-            for t in block.tags:
-                content += "      %s [%s] --- id: %s\n %s" % (t.name, t.type, t.id, tag_details(t, verbosity))
+            for tag in block.tags:
+                content += "      %s [%s] --- id: %s\n %s" % (tag.name, tag.type, tag.id,
+                                                              tag_details(tag, verbosity))
             return content
 
-        def frame_content(block, verbosity):
+        def frame_content(block, _):
             content = "      Data frames:\n" if len(block.data_frames) > 0 else ""
             for df in block.data_frames:
                 content += "      %s [%s] -- id: %s\n" % (df.name, df.type, df.id)
             return content
 
-        def source_content(block, verbosity):
+        def source_content(block, _):
             content = "      Sources:\n" if len(block.groups) > 0 else ""
-            for s in block.sources:
-                content += "      %s [%s] -- id: %s\n" % (s.name, s.type, s.id)
+            for src in block.sources:
+                content += "      %s [%s] -- id: %s\n" % (src.name, src.type, src.id)
             return content
 
         content = ""
         if verbosity < 1:
             content += "  %i block(s)" % len(nix_file.blocks)
         else:
-            for b in nix_file.blocks:
-                arrays = array_content(b, verbosity) if verbosity > 1 else "      %i data arrays\n" % len(b.data_arrays)
-                if getattr(b, "data_frames", None) is not None:
-                    frames = frame_content(b, verbosity) if verbosity > 1 else "      %i data frames\n" % len(b.data_frames)
+            for blk in nix_file.blocks:
+                arrays = array_content(blk, verbosity) if verbosity > 1 \
+                    else "      %i data arrays\n" % len(blk.data_arrays)
+                if getattr(blk, "data_frames", None) is not None:
+                    frames = frame_content(blk, verbosity) if verbosity > 1 \
+                        else "      %i data frames\n" % len(blk.data_frames)
                 else:
                     frames = ""
-                groups = group_content(b, verbosity) if verbosity > 1 else "      %i groups\n" % len(b.groups)
-                tags = tag_content(b, verbosity) if verbosity > 1 else "      %i tags\n" % len(b.tags)
-                mtags = mtag_content(b, verbosity) if verbosity > 1 else "      %i multi-tags\n" % len(b.multi_tags)
-                srcs = source_content(b, verbosity) if verbosity > 1 else "      %i sources\n" % len(b.sources)
-                content += "    %s [%s] --- id: %s\n%s%s%s%s%s%s\n" % (b.name, b.type, b.id, arrays,
-                                                                       frames, groups, tags, mtags,
-                                                                       srcs)
+                groups = group_content(blk, verbosity) if verbosity > 1 \
+                    else "      %i groups\n" % len(blk.groups)
+                tags = tag_content(blk, verbosity) if verbosity > 1 \
+                    else "      %i tags\n" % len(blk.tags)
+                mtags = mtag_content(blk, verbosity) if verbosity > 1 \
+                    else "      %i multi-tags\n" % len(blk.multi_tags)
+                srcs = source_content(blk, verbosity) if verbosity > 1 \
+                    else "      %i sources\n" % len(blk.sources)
+                content += "    %s [%s] --- id: %s\n%s%s%s%s%s%s\n" % (blk.name, blk.type, blk.id, arrays, frames,
+                                                                       groups, tags, mtags, srcs)
         return content
 
     def section_content(nix_file, verbosity):
-        def subsections(section, verbosity):
+        def subsections(section, _):
             content = ""
-            sections = s.find_sections()
+            sections = section.find_sections()
             prop_count = sum([len(sec) for sec in sections])
             content += "\n     %i sub-section(s), %i properties\n" % (len(sections), prop_count)
             return content
@@ -226,9 +227,9 @@ def disp_file_structure(nix_file, verbosity):
         if verbosity < 1:
             content += "  %i section(s)" % len(nix_file.find_sections())
         else:
-            for s in nix_file.sections:
-                subs_props = subsections(s, verbosity)
-                content += "    %s [%s] --- id: %s%s" % (s.name, s.type, s.id, subs_props)
+            for section in nix_file.sections:
+                subs_props = subsections(section, verbosity)
+                content += "    %s [%s] --- id: %s%s" % (section.name, section.type, section.id, subs_props)
         return content
 
     def file_content(nix_file, verbosity):
@@ -246,94 +247,95 @@ def disp_file_structure(nix_file, verbosity):
 
 
 def disp_file_info(filename, arguments):
-    f = open_nix_file(filename)
-    if f is None:
+    nf = open_nix_file(filename)
+    if nf is None:
         pass
 
     print(" File: %s" % (filename.split(os.sep)[-1]))
-    print("  format: %s \n  version: %s " % (f.format, f.version))
+    print("  format: %s \n  version: %s " % (nf.format, nf.version))
     print("  created at: %s \n  last updated: %s" %
-          (str(dt.datetime.fromtimestamp(f.created_at)),
-           str(dt.datetime.fromtimestamp(f.updated_at))))
+          (str(dt.datetime.fromtimestamp(nf.created_at)),
+           str(dt.datetime.fromtimestamp(nf.updated_at))))
     print("  size on disk: %.2f MB" % (os.path.getsize(filename) / 10**6))
     print("  location: %s" % os.path.split(filename)[0])
-    disp_file_structure(f, arguments.verbosity)
-    f.close()
+    disp_file_structure(nf, arguments.verbosity)
+    nf.close()
 
 
 def find_section(nix_file, pattern, case_sensitive=False, full_match=False):
-    def type_lambda(t, full_match):
+    def type_lambda(typ, full_match):
         if full_match:
-            return lambda s: t.lower() == s.type.lower()
+            return lambda s: typ.lower() == s.type.lower()
         else:
-            return lambda s: t.lower() in s.type.lower()
+            return lambda s: typ.lower() in s.type.lower()
 
-    def name_lambda(n, full_match):
+    def name_lambda(name, full_match):
         if full_match:
-            return lambda s: n.lower() == s.name.lower()
+            return lambda s: name.lower() == s.name.lower()
         else:
-            return lambda s: n.lower() in s.name.lower()
+            return lambda s: name.lower() in s.name.lower()
 
-    def name_lambda_cs(n, full_match):
+    def name_lambda_cs(name, full_match):
         if full_match:
-            return lambda s: n == s.name
+            return lambda s: name == s.name
         else:
-            return lambda s: n in s.name
+            return lambda s: name in s.name
 
     secs = nix_file.find_sections(type_lambda(pattern, full_match))
     if len(secs) == 0:
-        secs = nix_file.find_sections(name_lambda_cs(pattern, full_match) if case_sensitive else name_lambda(pattern, full_match))
+        secs = nix_file.find_sections(name_lambda_cs(pattern, full_match) if case_sensitive
+                                      else name_lambda(pattern, full_match))
     return secs
 
 
 def find_props(nix_file, pattern, case_sensitive=False, full_match=False):
-    n = pattern if case_sensitive else pattern.lower()
+    name = pattern if case_sensitive else pattern.lower()
     props = {}
-    for s in nix_file.find_sections(lambda s: True):
-        for p in s.props:
-            pname = p.name if case_sensitive else p.name.lower()
-            if n == pname if full_match else n in pname:
-                if s not in props.keys():
-                    props[s] = []
-                props[s].append(p)
+    for sec in nix_file.find_sections(lambda s: True):
+        for prop in sec.props:
+            pname = prop.name if case_sensitive else prop.name.lower()
+            if name == pname if full_match else name in pname:
+                if sec not in props.keys():
+                    props[sec] = []
+                props[sec].append(prop)
     return props
 
 
 def disp_metadata(filename, arguments):
     case_sensitive = arguments.case_sensitive
     full_match = arguments.full_match
-    f = open_nix_file(filename)
-    if f is None:
-        pass
+    nf = open_nix_file(filename)
+    if nf is None:
+        return
     print("%s: " % (filename.split(os.sep)[-1]), end="\n")
     if arguments.pattern is None or len(arguments.pattern) == 0:
-        for sec in f.sections:
+        for sec in nf.sections:
             sec.pprint(max_depth=arguments.depth)
     else:
-        for p in arguments.pattern:
-            if "/" in p:
-                parts = p.split("/")
-                secs = find_section(f, parts[0], case_sensitive)
-                for s in secs:
-                    for prop in s.props:
+        for patt in arguments.pattern:
+            if "/" in patt:
+                parts = patt.split("/")
+                sections = find_section(nf, parts[0], case_sensitive)
+                for sec in sections:
+                    for prop in sec.props:
                         part = parts[1] if case_sensitive else parts[1].lower()
                         pname = prop.name if case_sensitive else prop.name.lower()
                         if part == pname if full_match else part in pname:
-                            print("[section: %s, type: %s, id: %s] >> " % (s.name, s.type, s.id), end="")
+                            print("[section: %s, type: %s, id: %s] >> " % (sec.name, sec.type, sec.id), end="")
                             prop.pprint()
             else:
-                secs = find_section(f, p, case_sensitive)
-                if len(secs) == 0:
-                    props = find_props(f, p, case_sensitive)
+                sections = find_section(nf, patt, case_sensitive)
+                if len(sections) == 0:
+                    props = find_props(nf, patt, case_sensitive)
                     for sec in props.keys():
                         for prop in props[sec]:
                             print("[section: %s, type: %s, id: %s] >> " % (sec.name, sec.type, sec.id), end="")
                             prop.pprint()
                 else:
-                    for s in secs:
-                        s.pprint(max_depth=arguments.depth)
+                    for sec in sections:
+                        sec.pprint(max_depth=arguments.depth)
 
-    f.close()
+    nf.close()
     print("\n\n")
 
 
@@ -380,18 +382,23 @@ def get_ticks(dimension, extent):
 
 
 def get_dim_label_and_unit(dimension):
-    dim_label = getattr(dimension, "label") if hasattr(dimension, "label") and getattr(dimension, "label") else ""
-    dim_unit = getattr(dimension, "unit") if hasattr(dimension, "unit") and getattr(dimension, "unit") else ""
+    dim_label = getattr(dimension, "label") if hasattr(dimension, "label") \
+        and getattr(dimension, "label") else ""
+    dim_unit = getattr(dimension, "unit") if hasattr(dimension, "unit") \
+        and getattr(dimension, "unit") else ""
     return dim_label, dim_unit
 
 
-def dump_oned(data, dimension, label, unit, outfile, format="%.6f", end="\n\n", forgiving=True, show_progress=False):
+def dump_oned(data, dimension, label, unit, outfile, fmt="%.6f", end="\n\n",
+              forgiving=True, show_progress=False):
     if len(data.shape) > 1:
-        raise ValueError("data dimensionality is too deep, expected 1D data, got %iD" % len(data.shape))
+        raise ValueError("data dimensionality is too deep, "
+                         "expected 1D data, got %iD" % len(data.shape))
     ticks = get_ticks(dimension, data.shape[0])
     if len(ticks) != len(data):
         if not forgiving:
-            print("Cannot dump data, could not read the dimension values on dimension %i (type: %s)!" % (dimension.index, dimension.dimension_type))
+            print("Cannot dump data, could not read the dimension values on dimension "
+                  "%i (type: %s)!" % (dimension.index, dimension.dimension_type))
             return
         else:
             ticks = np.arange(len(data))
@@ -399,42 +406,46 @@ def dump_oned(data, dimension, label, unit, outfile, format="%.6f", end="\n\n", 
     if isinstance(ticks[-1], str):
         max_tick_len = max([len(ticks[-1]), len(dim_label)])
     else:
-        max_tick_len = max([len(format % ticks[-1]), len(dim_label)])
+        max_tick_len = max([len(fmt % ticks[-1]), len(dim_label)])
 
     numeric_dim_ticks = isinstance(ticks[0], (int, float))
     numeric_data = isinstance(data[0], (int, float))
-    data_conv_func = (lambda x: format % x) if numeric_data else str
-    dim_ticks_conv_func = (lambda x: format % x) if numeric_dim_ticks else str
+    data_conv_func = (lambda x: fmt % x) if numeric_data else str
+    dim_ticks_conv_func = (lambda x: fmt % x) if numeric_dim_ticks else str
 
     if dimension.dimension_type == nix.DimensionType.Range and dimension.has_link:
         print("# %s" % dim_label, file=outfile)
         print("# %s" % dim_unit, file=outfile)
-        for i, t in enumerate(ticks):
-            print(data_conv_func(t), file=outfile)
-            if show_progress and i % 1000 == 0:
-                progress(i, data.shape[0], status='')
+        for idx, tick in enumerate(ticks):
+            print(data_conv_func(tick), file=outfile)
+            if show_progress and idx % 1000 == 0:
+                progress(idx, data.shape[0], status='')
     else:
         padding = " " * (max_tick_len - len(dim_label) if dim_label else 0)
         print("# %s%s%s" % (dim_label, padding, label), file=outfile)
         padding = " " * (max_tick_len - len(dim_unit) if dim_unit else 0)
         print("# %s%s%s" % (dim_unit, padding, unit), file=outfile)
 
-        for i in range(data.shape[0]):
-            if show_progress and i % 1000 == 0:
-                progress(i, data.shape[0], status='')
-            print(dim_ticks_conv_func(ticks[i]) + "   " + data_conv_func(data[i]), file=outfile)
+        for idx in range(data.shape[0]):
+            if show_progress and idx % 1000 == 0:
+                progress(idx, data.shape[0], status='')
+            print(dim_ticks_conv_func(ticks[idx]) + "   " + data_conv_func(data[idx]),
+                  file=outfile)
     if show_progress:
         progress(data.shape[0], data.shape[0], "Done")
     print(end, file=outfile)
 
 
-def dump_twod(data, dimensions, label, unit, outfile, format="%.6f", end="\n\n", show_progress=False):
+def dump_twod(data, dimensions, label, unit, outfile, fmt="%.6f", end="\n\n",
+              show_progress=False):
     if len(data.shape) != 2 or len(dimensions) != 2:
-        raise ValueError("data must be 2 dimensional and exactly two dimensions must be passed inorder to dump the content properly.")
+        raise ValueError("data must be 2 dimensional and exactly two dimensions must be passed "
+                         "in order to dump the content properly.")
     first_dim_ticks = get_ticks(dimensions[0], data.shape[0])
     second_dim_ticks = get_ticks(dimensions[1], data.shape[1])
     if len(first_dim_ticks) != data.shape[0] or len(second_dim_ticks) != data.shape[1]:
-        raise ValueError("dimension ticks for first or second dimension do not match the data shape.")
+        raise ValueError("dimension ticks for first or second dimension "
+                         "do not match the data shape.")
 
     first_dim_label, first_dim_unit = get_dim_label_and_unit(dimensions[0])
     second_dim_label, second_dim_unit = get_dim_label_and_unit(dimensions[1])
@@ -442,9 +453,9 @@ def dump_twod(data, dimensions, label, unit, outfile, format="%.6f", end="\n\n",
     numeric_1st_dim_ticks = isinstance(first_dim_ticks[0], (int, float))
     numeric_2nd_dim_ticks = isinstance(second_dim_ticks[0], (int, float))
     numeric_data = isinstance(data[0, 0], (int, float))
-    data_conv_func = (lambda x: format % x) if numeric_data else str
-    dim_ticks_conv_func1 = (lambda x: format % x) if numeric_1st_dim_ticks else str
-    dim_ticks_conv_func2 = (lambda x: format % x) if numeric_2nd_dim_ticks else str
+    data_conv_func = (lambda x: fmt % x) if numeric_data else str
+    dim_ticks_conv_func1 = (lambda x: fmt % x) if numeric_1st_dim_ticks else str
+    dim_ticks_conv_func2 = (lambda x: fmt % x) if numeric_2nd_dim_ticks else str
 
     max_tick_len = max([len(dim_ticks_conv_func1(first_dim_ticks[-1])), len(first_dim_label)])
     print("# data label: %s" % label, file=outfile)
@@ -454,10 +465,12 @@ def dump_twod(data, dimensions, label, unit, outfile, format="%.6f", end="\n\n",
     padding = " " * (max_tick_len - (len(first_dim_unit) if first_dim_unit else 0))
     print("# %s%s%s" % (first_dim_unit, padding, second_dim_unit), file=outfile)
     # first line contains 2nd dim ticks
-    print(" " * max_tick_len + "   " + (" " * max_tick_len + "  ").join(map(dim_ticks_conv_func2, second_dim_ticks)), file=outfile)
+    print(" " * max_tick_len + "   " + (" " * max_tick_len + "  ").join(map(dim_ticks_conv_func2, second_dim_ticks)),
+          file=outfile)
     # now dump the rest
     for i in range(len(first_dim_ticks)):
-        print(dim_ticks_conv_func1(first_dim_ticks[i]) + "    " + "   ".join(map(data_conv_func, data[i, :])), file=outfile)
+        print(dim_ticks_conv_func1(first_dim_ticks[i]) + "    " + "   ".join(map(data_conv_func, data[i, :])),
+              file=outfile)
         if show_progress and i % 500 == 0:
             progress(i, data.shape[0], status='')
     if show_progress:
@@ -465,32 +478,40 @@ def dump_twod(data, dimensions, label, unit, outfile, format="%.6f", end="\n\n",
     print(end, file=outfile)
 
 
-def dump_threed(data, dimensions, label, unit, outfile, format="%.6f", end="\n\n", show_progress=False):
+def dump_threed(data, dimensions, label, unit, outfile, fmt="%.6f", end="\n\n",
+                show_progress=False):
     if len(data.shape) != 3 or len(dimensions) != 3:
-        raise ValueError("data must be 3 dimensional and exactly three dimensions must be passed inorder to dump the content properly.")
+        raise ValueError("data must be 3 dimensional and exactly three dimensions must be passed in order to dump "
+                         "the content properly.")
     ticks = get_ticks(dimensions[2], data.shape[2])
     dim_label, dim_unit = get_dim_label_and_unit(dimensions[2])
 
     for i in range(data.shape[2]):
-        print("# data[:, :, %i]: %s" % (i, dim_label + "%s%s" % (ticks[i], dim_unit) if dim_unit else ""), file=outfile)
-        dump_twod(data[:, :, i], [dimensions[0], dimensions[1]], label, unit, outfile, format, end="\n", show_progress=show_progress)
+        print("# data[:, :, %i]: %s" % (i, dim_label + "%s%s" % (ticks[i], dim_unit)
+                                        if dim_unit else ""), file=outfile)
+        dump_twod(data[:, :, i], [dimensions[0], dimensions[1]], label, unit, outfile, fmt,
+                  end="\n", show_progress=show_progress)
 
     print(end, file=outfile)
 
 
 def dump_data_array(array, filename, outfile, show_progress=False):
-    print("# File: %s\n# entity: %s\n# type: %s\n# id: %s" % (filename, array.name, array.type, array.id), file=outfile)
-    print("# created at: %s\n# last edited at: %s\n" %
-          (str(dt.datetime.fromtimestamp(array.created_at)),
-           str(dt.datetime.fromtimestamp(array.updated_at))), file=outfile)
+    print("# File: %s\n# entity: %s\n# type: %s\n# id: %s" % (filename, array.name, array.type, array.id),
+          file=outfile)
+    print("# created at: %s\n# last edited at: %s\n" % (str(dt.datetime.fromtimestamp(array.created_at)),
+                                                        str(dt.datetime.fromtimestamp(array.updated_at))),
+          file=outfile)
     dims = len(array.shape)
     data = array[:]
     if dims == 1:
-        dump_oned(data, array.dimensions[0], array.label, array.unit, outfile, show_progress=show_progress)
+        dump_oned(data, array.dimensions[0], array.label, array.unit, outfile,
+                  show_progress=show_progress)
     elif dims == 2:
-        dump_twod(data, array.dimensions, array.label, array.unit, outfile, show_progress=show_progress)
+        dump_twod(data, array.dimensions, array.label, array.unit, outfile,
+                  show_progress=show_progress)
     elif dims == 3:
-        dump_threed(data, array.dimensions, array.label, array.unit, outfile, show_progress=show_progress)
+        dump_threed(data, array.dimensions, array.label, array.unit, outfile,
+                    show_progress=show_progress)
     else:
         print("Sorry, cannot dump data with more than 3 dimensions!")
 
@@ -498,10 +519,10 @@ def dump_data_array(array, filename, outfile, show_progress=False):
 def data_dump(filename, arguments, outfile, show_progress=False):
     nix_file = open_nix_file(filename)
     entities = find_data_entity(nix_file, arguments)
-    for e in entities:
-        if isinstance(e, nix.DataArray):
-            sys.stderr.write("Dumping %s to %s...\n" % (e.name, arguments.outfile))
-            dump_data_array(e, filename, outfile, show_progress)
+    for ent in entities:
+        if isinstance(ent, nix.DataArray):
+            sys.stderr.write("Dumping %s to %s...\n" % (ent.name, arguments.outfile))
+            dump_data_array(ent, filename, outfile, show_progress)
             sys.stderr.write("\n")
     nix_file.close()
 
@@ -509,14 +530,14 @@ def data_dump(filename, arguments, outfile, show_progress=False):
 def data_plotter(filename, arguments):
     nix_file = open_nix_file(filename)
     entities = find_data_entity(nix_file, arguments)
-    for e in entities:
-        if isinstance(e, nix.DataArray):
-            plotter = nw.plotter.suggested_plotter(e)
+    for ent in entities:
+        if isinstance(ent, nix.DataArray):
+            plotter = nw.plotter.suggested_plotter(ent)
             if plotter:
                 plotter.plot()
                 plotter.show()
             else:
-                print("Could not find a suitable plotter for the DataArray: %s" % str(e))
+                print("Could not find a suitable plotter for the DataArray: %s" % str(ent))
         else:
             print("Sorry, so far I can only try to plot DataArrays.")
 
@@ -527,12 +548,11 @@ def disp_data(filename, arguments):
     nix_file = open_nix_file(filename)
     entities = find_data_entity(nix_file, arguments)
     print("# File: %s" % filename)
-    for e in entities:
-        print("# entity: %s\n# type: %s\n# id: %s" % (e.name, e.type, e.id))
-        print("# created at: %s\n# last edited at: %s\n" %
-              (str(dt.datetime.fromtimestamp(e.created_at)),
-               str(dt.datetime.fromtimestamp(e.updated_at))))
-        print(e)
+    for ent in entities:
+        print("# entity: %s\n# type: %s\n# id: %s" % (ent.name, ent.type, ent.id))
+        print("# created at: %s\n# last edited at: %s\n" % (str(dt.datetime.fromtimestamp(ent.created_at)),
+                                                            str(dt.datetime.fromtimestamp(ent.updated_at))))
+        print(ent)
         print("\n")
     nix_file.close()
 
@@ -558,16 +578,16 @@ def dump_worker(arguments):
             if response.lower() != "y":
                 print("... data dump aborted.")
                 return
-        f = open(arguments.outfile, 'w')
+        out_file = open(arguments.outfile, 'w')
         to_file = True
     else:
-        f = sys.stdout
+        out_file = sys.stdout
         to_file = False
     show_progress = to_file
-    for nf in files:
-        func(nf, arguments, f, show_progress)
+    for out_file in files:
+        func(out_file, arguments, out_file, show_progress)
     if to_file:
-        f.close()
+        out_file.close()
 
 
 def plot_worker(arguments):
@@ -581,22 +601,25 @@ def add_default_file_args(parent_parser):
     parent_parser.add_argument("file", type=str, nargs="+",
                                help="Path to file (at least one)")
     parent_parser.add_argument("-s", "--suffix", type=str, default="nix", nargs="?",
-                               help="The file suffix used for nix data files (default: %(default)s).")
+                               help=("The file suffix used for nix data files (default: %(default)s)."))
 
 
 def add_default_args(parent_parser):
-    parent_parser.add_argument("-c", "--case_sensitive", action="store_true", help="matching of"
-                               + " entitiy names and types is case sensitive, by default the case is ignored")
-    parent_parser.add_argument("-fm", "--full_match", action="store_true", help="names and types must"
-                               + " be full matches, by default a partial match is sufficient")
+    parent_parser.add_argument("-c", "--case_sensitive", action="store_true",
+                               help=("matching of entitiy names and types is case sensitive, "
+                                     "by default the case is ignored"))
+    parent_parser.add_argument("-fm", "--full_match", action="store_true",
+                               help=("names and types must be full matches, by default a partial match is sufficient"))
 
 
 def create_metadata_parser(parent_parser):
-    meta_parser = parent_parser.add_parser("metadata", help="Filter and display metadata", aliases=["mdata"],
-                                           description="Search for metadata items or display metadata (sub)trees.")
-    meta_parser.add_argument("-p", "--pattern", type=str, action="append", help=mdata_pattern_help)
+    meta_parser = parent_parser.add_parser("metadata", help="Filter and display metadata",
+                                           aliases=["mdata"],
+                                           description=("Search for metadata items or display metadata (sub)trees."))
+    meta_parser.add_argument("-p", "--pattern", type=str, action="append",
+                             help=METADATA_PATTERN_HELP)
     meta_parser.add_argument("-d", "--depth", type=int, default=-1,
-                             help="maximum depth of metadata tree output, default is %(default)s, full depth")
+                             help=("maximum depth of metadata tree output, default is %(default)s, full depth"))
     add_default_args(meta_parser)
     add_default_file_args(meta_parser)
     meta_parser.set_defaults(func=mdata_worker)
@@ -605,30 +628,30 @@ def create_metadata_parser(parent_parser):
 
 
 def create_data_parser(parent_parser):
-    data_parser = parent_parser.add_parser("data", help="Search and display information about data entities",
-                                           description=data_parser_help)
-    data_parser.add_argument("-p", "--pattern", default="", type=str, help=data_pattern_help)
+    data_parser = parent_parser.add_parser("data",
+                                           help=("Search and display information about data entities"),
+                                           description=DATA_PARSER_HELP)
+    data_parser.add_argument("-p", "--pattern", default="", type=str, help=DATA_PATTERN_HELP)
     add_default_args(data_parser)
     add_default_file_args(data_parser)
     data_parser.set_defaults(func=data_worker)
 
 
 def create_dump_parser(parent_parser):
-    dump_parser = parent_parser.add_parser("dump", help="Dump stored data to stdout",
-                                           description=dump_parser_help)
-    dump_parser.add_argument("-p", "--pattern", default="", type=str, help=dump_pattern_help)
-    dump_parser.add_argument("-o", "--outfile", default="", type=str, help=dump_outfile_help)
+    dump_parser = parent_parser.add_parser("dump", help="Dump stored data to stdout", description=DUMP_PARSER_HELP)
+    dump_parser.add_argument("-p", "--pattern", default="", type=str, help=DUMP_PATTERN_HELP)
+    dump_parser.add_argument("-o", "--outfile", default="", type=str, help=DUMP_OUTFILE_HELP)
     add_default_args(dump_parser)
     add_default_file_args(dump_parser)
     dump_parser.set_defaults(func=dump_worker)
 
 
 def create_plot_parser(parent_parser):
-    if not nw_present:
+    if not NIX_WORKS:
         return
     plot_parser = parent_parser.add_parser("plot", help="Create basic plots of stored data.",
-                                           description=plot_parser_help)
-    plot_parser.add_argument("-p", "--pattern", type=str, help=data_pattern_help)
+                                           description=PLOT_PARSER_HELP)
+    plot_parser.add_argument("-p", "--pattern", type=str, help=DATA_PATTERN_HELP)
     add_default_args(plot_parser)
     add_default_file_args(plot_parser)
     plot_parser.set_defaults(func=plot_worker)
@@ -636,10 +659,10 @@ def create_plot_parser(parent_parser):
 
 def create_file_parser(parent_parser):
     file_parser = parent_parser.add_parser("file", help="Display basic file info",
-                                           description="Quick display of file information such as " +
-                                           "creation date, file size and structure etc.")
+                                           description=("Quick display of file information such as creation date, "
+                                                        "file size and structure etc."))
     file_parser.add_argument("-v", "--verbosity", action="count",
-                             help="increase output verbosity, use -v, -vv, -vvv for more verbose output")
+                             help=("increase output verbosity, use -v, -vv, -vvv for more verbose output"))
     add_default_file_args(file_parser)
     file_parser.set_defaults(func=file_worker)
 
@@ -647,7 +670,7 @@ def create_file_parser(parent_parser):
 def create_subcmd_parsers(parser):
     subparsers = parser.add_subparsers(title="commands",
                                        help="Sub commands for working on data and metadata",
-                                       description=tool_description, dest="explore_cmd")
+                                       description=TOOL_DESCRIPTION, dest="explore_cmd")
     create_file_parser(subparsers)
     create_data_parser(subparsers)
     create_dump_parser(subparsers)

--- a/nixio/cmd/upgrade.py
+++ b/nixio/cmd/upgrade.py
@@ -46,7 +46,7 @@ def update_property_values(fname):
     with h5py.File(fname, mode="r") as hfile:
         sections = hfile["metadata"]
 
-        def find_props(name, group):
+        def find_props(_, group):
             if isinstance(group, h5py.Dataset) and len(group.dtype):
                 # structured/compound dtypes have non-zero length
                 props.append(group.name)

--- a/nixio/cmd/validate.py
+++ b/nixio/cmd/validate.py
@@ -9,7 +9,7 @@ def format_obj(obj):
     return "{} '{}' (ID: {})".format(type(obj).__name__, obj.name, obj.id)
 
 
-def print_header(text, h=1):
+def print_header(text):
     print("  {}".format(text))
     print("  " + "-"*len(text))
 

--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -216,9 +216,9 @@ class DataArray(Entity, DataSet):
         return self._h5group.get_attr("expansion_origin")
 
     @expansion_origin.setter
-    def expansion_origin(self, eo):
-        util.check_attr_type(eo, Number)
-        self._h5group.set_attr("expansion_origin", eo)
+    def expansion_origin(self, origin):
+        util.check_attr_type(origin, Number)
+        self._h5group.set_attr("expansion_origin", origin)
         if self.file.auto_update_timestamps:
             self.force_updated_at()
 
@@ -234,9 +234,9 @@ class DataArray(Entity, DataSet):
         return self._h5group.get_attr("label")
 
     @label.setter
-    def label(self, l):
-        util.check_attr_type(l, str)
-        self._h5group.set_attr("label", l)
+    def label(self, label):
+        util.check_attr_type(label, str)
+        self._h5group.set_attr("label", label)
         if self.file.auto_update_timestamps:
             self.force_updated_at()
 
@@ -251,13 +251,13 @@ class DataArray(Entity, DataSet):
         return self._h5group.get_attr("unit")
 
     @unit.setter
-    def unit(self, u):
-        if u:
-            u = util.units.sanitizer(u)
-        if u == "":
-            u = None
-        util.check_attr_type(u, str)
-        self._h5group.set_attr("unit", u)
+    def unit(self, unit):
+        if unit:
+            unit = util.units.sanitizer(unit)
+        if unit == "":
+            unit = None
+        util.check_attr_type(unit, str)
+        self._h5group.set_attr("unit", unit)
         if self.file.auto_update_timestamps:
             self.force_updated_at()
 
@@ -280,8 +280,8 @@ class DataArray(Entity, DataSet):
                 "DataArray.get_slice"
             )
         if mode == DataSliceMode.Index:
-            sl = tuple(slice(p, p+e) for p, e in zip(positions, extents))
-            return DataView(self, sl)
+            slices = tuple(slice(p, p+e) for p, e in zip(positions, extents))
+            return DataView(self, slices)
         elif mode == DataSliceMode.Data:
             return self._get_slice_bydim(positions, extents)
         else:
@@ -299,8 +299,8 @@ class DataArray(Entity, DataSet):
             elif dim.dimension_type == DimensionType.Set:
                 dpos.append(int(pos))
                 dext.append(int(ext))
-        sl = tuple(slice(p, p+e) for p, e in zip(dpos, dext))
-        return DataView(self, sl)
+        slices = tuple(slice(p, p+e) for p, e in zip(dpos, dext))
+        return DataView(self, slices)
 
     @property
     def data(self):

--- a/nixio/data_set.py
+++ b/nixio/data_set.py
@@ -115,16 +115,16 @@ class DataSet(object):
         enlarge = tuple(self.shape[i] + (0 if i != axis else x)
                         for i, x in enumerate(data.shape))
         self.data_extent = enlarge
-        sl = tuple(slice(o, c+o) for o, c in zip(offset, count))
-        self._write_data(data, sl)
+        slc = tuple(slice(o, c+o) for o, c in zip(offset, count))
+        self._write_data(data, slc)
 
-    def _write_data(self, data, sl=None):
+    def _write_data(self, data, slc=None):
         dataset = self._h5group.get_dataset("data")
-        dataset.write_data(data,  sl)
+        dataset.write_data(data,  slc)
 
-    def _read_data(self, sl=None):
+    def _read_data(self, slc=None):
         dataset = self._h5group.get_dataset("data")
-        data = dataset.read_data(sl)
+        data = dataset.read_data(slc)
         if data.dtype == util.vlen_str_dtype:
             data = np.array([ensure_str(d) for d in data],
                             dtype=util.vlen_str_dtype)

--- a/nixio/dimension_type.py
+++ b/nixio/dimension_type.py
@@ -15,4 +15,3 @@ class DimensionType(Enum):
     Sample = "sample"
     Range = "range"
     Set = "set"
-    DataFrame = "data_frame"

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -372,18 +372,18 @@ class SampledDimension(Dimension):
         return self._h5group.get_attr("unit")
 
     @unit.setter
-    def unit(self, u):
-        util.check_attr_type(u, str)
-        self._h5group.set_attr("unit", u)
+    def unit(self, unit):
+        util.check_attr_type(unit, str)
+        self._h5group.set_attr("unit", unit)
 
     @property
     def offset(self):
         return self._h5group.get_attr("offset")
 
     @offset.setter
-    def offset(self, o):
-        util.check_attr_type(o, Number)
-        self._h5group.set_attr("offset", o)
+    def offset(self, offset):
+        util.check_attr_type(offset, Number)
+        self._h5group.set_attr("offset", offset)
 
     def link_data_array(self, *_):
         raise RuntimeError("SampledDimension does not support linking")
@@ -456,12 +456,12 @@ class RangeDimension(Dimension):
         return self._h5group.get_attr("unit")
 
     @unit.setter
-    def unit(self, u):
-        util.check_attr_type(u, str)
+    def unit(self, unit):
+        util.check_attr_type(unit, str)
         if self.has_link:
-            self.dimension_link.unit = u
+            self.dimension_link.unit = unit
         else:
-            self._h5group.set_attr("unit", u)
+            self._h5group.set_attr("unit", unit)
 
     def index_of(self, position):
         """

--- a/nixio/entity.py
+++ b/nixio/entity.py
@@ -66,19 +66,19 @@ class Entity(object):
         """
         return self._file
 
-    def force_created_at(self, t=None):
+    def force_created_at(self, time=None):
         """
         Sets the creation time `created_at` to the given time
         (default: current time).
 
-        :param t: The time to set.
-        :type t: int
+        :param time: The time to set.
+        :type time: int
         """
-        if t is None:
-            t = util.now_int()
+        if time is None:
+            time = util.now_int()
         else:
-            util.check_attr_type(t, int)
-        self._h5group.set_attr("created_at", util.time_to_str(t))
+            util.check_attr_type(time, int)
+        self._h5group.set_attr("created_at", util.time_to_str(time))
 
     @property
     def updated_at(self):
@@ -91,19 +91,19 @@ class Entity(object):
         """
         return util.str_to_time(self._h5group.get_attr("updated_at"))
 
-    def force_updated_at(self, t=None):
+    def force_updated_at(self, time=None):
         """
         Sets the update time `updated_at` to the given time.
         (default: current time)
 
-        :param t: The time to set.
-        :type t: int
+        :param time: The time to set.
+        :type time: int
         """
-        if t is None:
-            t = util.now_int()
+        if time is None:
+            time = util.now_int()
         else:
-            util.check_attr_type(t, int)
-        self._h5group.set_attr("updated_at", util.time_to_str(t))
+            util.check_attr_type(time, int)
+        self._h5group.set_attr("updated_at", util.time_to_str(time))
 
     @property
     def definition(self):
@@ -117,9 +117,9 @@ class Entity(object):
         return self._h5group.get_attr("definition")
 
     @definition.setter
-    def definition(self, d):
-        util.check_attr_type(d, str)
-        self._h5group.set_attr("definition", d)
+    def definition(self, definition):
+        util.check_attr_type(definition, str)
+        self._h5group.set_attr("definition", definition)
         if self.file.auto_update_timestamps:
             self.force_updated_at()
 
@@ -146,11 +146,11 @@ class Entity(object):
         return self._h5group.get_attr("type")
 
     @type.setter
-    def type(self, t):
-        if t is None:
+    def type(self, typ):
+        if typ is None:
             raise AttributeError("type can't be None")
-        util.check_attr_type(t, str)
-        self._h5group.set_attr("type", t)
+        util.check_attr_type(typ, str)
+        self._h5group.set_attr("type", typ)
         if self.file.auto_update_timestamps:
             self.force_updated_at()
 

--- a/nixio/exceptions/__init__.py
+++ b/nixio/exceptions/__init__.py
@@ -7,5 +7,5 @@ __all__ = (
     "DuplicateName", "UninitializedEntity", "InvalidUnit",
     "InvalidAttrType", "InvalidEntity", "OutOfBounds",
     "IncompatibleDimensions", "InvalidFile",
-    "DuplicateColumnName", "UnsuportedLinkType"
+    "DuplicateColumnName", "UnsupportedLinkType"
 )

--- a/nixio/feature.py
+++ b/nixio/feature.py
@@ -52,14 +52,14 @@ class Feature(object):
         return LinkType(self._h5group.get_attr("link_type"))
 
     @link_type.setter
-    def link_type(self, lt):
-        if isinstance(lt, string_types):
-            lt = lt.lower()
-        lt = LinkType(lt)
-        self._h5group.set_attr("link_type", lt.value)
+    def link_type(self, link_type):
+        if isinstance(link_type, string_types):
+            link_type = link_type.lower()
+        link_type = LinkType(link_type)
+        self._h5group.set_attr("link_type", link_type.value)
         if self.file.auto_update_timestamps:
-            t = util.now_int()
-            self._h5group.set_attr("updated_at", util.time_to_str(t))
+            time = util.now_int()
+            self._h5group.set_attr("updated_at", util.time_to_str(time))
 
     @property
     def data(self):
@@ -100,8 +100,8 @@ class Feature(object):
             del self._h5group["data"]
         self._h5group.create_link(dataobj, "data")
         if self.file.auto_update_timestamps:
-            t = util.now_int()
-            self._h5group.set_attr("updated_at", util.time_to_str(t))
+            time = util.now_int()
+            self._h5group.set_attr("updated_at", util.time_to_str(time))
 
     @property
     def created_at(self):

--- a/nixio/hdf5/h5dataset.py
+++ b/nixio/hdf5/h5dataset.py
@@ -37,25 +37,25 @@ class H5DataSet(object):
         name = h5obj.name.split("/")[-1]
         return cls(parent, name)
 
-    def write_data(self, data, sl=None):
-        if sl is None:
+    def write_data(self, data, slc=None):
+        if slc is None:
             self.dataset[:] = data
         else:
-            self.dataset[sl] = data
+            self.dataset[slc] = data
 
-    def read_data(self, sl=None):
-        if sl is None:
+    def read_data(self, slc=None):
+        if slc is None:
             return self.dataset[:]
         try:
-            return self.dataset[sl]
-        except ValueError as ve:
+            return self.dataset[slc]
+        except ValueError as ve_exc:
             # h5py throws ValueError for out-of-bounds index
             # Let's change it to IndexError
-            raise IndexError(ve)
-        except TypeError as te:
+            raise IndexError(ve_exc)
+        except TypeError as te_exc:
             # h5py 2.10 in Python2 throws TypeError for out-of-bounds index
             # Let's change it to IndexError
-            raise IndexError(te)
+            raise IndexError(te_exc)
 
     def set_attr(self, name, value):
         if value is None:

--- a/nixio/hdf5/h5group.py
+++ b/nixio/hdf5/h5group.py
@@ -234,13 +234,13 @@ class H5Group(object):
         # iteration issues since it's deleted before descending into the
         # children of the current group
 
-        def delete_by_id(name, obj):
+        def delete_by_id(_, obj):
             if not isinstance(obj, h5py.Group):
                 return
             grp = self.create_from_h5obj(obj)
-            for ch in grp:
-                if ch.get_attr("entity_id") in eid:
-                    del grp[ch.name]
+            for child in grp:
+                if child.get_attr("entity_id") in eid:
+                    del grp[child.name]
 
         self._group.visititems(delete_by_id)
 
@@ -282,17 +282,17 @@ class H5Group(object):
         dest_grp = dest.group[cls]
         grp.copy(source=source, dest=dest_grp, name=name, shallow=shallow)
 
-        g = dest_grp[name]
-        g.attrs["name"] = name
+        grp = dest_grp[name]
+        grp.attrs["name"] = name
         if not keep_id:
             def change_id(_, igrp):
                 if "entity_id" in igrp.attrs:
                     id_ = util.create_id()
                     igrp.attrs.modify("entity_id", np.string_(id_))
             id_ = util.create_id()
-            g.attrs.modify("entity_id", np.string_(id_))
-            g.visititems(change_id)
-        return g
+            grp.attrs.modify("entity_id", np.string_(id_))
+            grp.visititems(change_id)
+        return grp
 
     @property
     def parent(self):

--- a/nixio/multi_tag.py
+++ b/nixio/multi_tag.py
@@ -187,9 +187,9 @@ class MultiTag(BaseTag):
             feat = self.features[featidx]
         except KeyError:
             feat = None
-            for f in self.features:
-                if f.data.name == featidx or f.data.id == featidx:
-                    feat = f
+            for feature in self.features:
+                if feature.data.name == featidx or feature.data.id == featidx:
+                    feat = feature
                     break
             if feat is None:
                 raise

--- a/nixio/property.py
+++ b/nixio/property.py
@@ -151,8 +151,8 @@ class Property(Entity):
         filever = tuple(dataset._parent.file.attrs["version"])
         if filever < (1, 1, 1):
             val = self._h5dataset.dataset[:]
-            v = val[0]["uncertainty"]
-            return v
+            uncertainty = val[0]["uncertainty"]
+            return uncertainty
         return self._h5dataset.get_attr("uncertainty")
 
     @uncertainty.setter
@@ -167,8 +167,8 @@ class Property(Entity):
         filever = tuple(dataset._parent.file.attrs["version"])
         if filever < (1, 1, 1):
             val = self._h5dataset.dataset[:]
-            v = val[0]["reference"]
-            return v
+            reference = val[0]["reference"]
+            return reference
         return self._h5dataset.get_attr("reference")
 
     @reference.setter
@@ -238,8 +238,8 @@ class Property(Entity):
         dataset = self._h5dataset
         filever = tuple(dataset._parent.file.attrs["version"])
         if filever < (1, 1, 1):
-            v = self._read_old_values()
-            return v
+            values = self._read_old_values()
+            return values
         if not sum(dataset.shape):
             return tuple()
 
@@ -262,13 +262,11 @@ class Property(Entity):
         :param vals: a single value or list of values.
         """
         # Make sure boolean value 'False' gets through as well...
-        if vals is None or (isinstance(vals, (Sequence, Iterable)) and
-                            not len(vals)):
+        if vals is None or (isinstance(vals, (Sequence, Iterable)) and not len(vals)):
             self.delete_values()
             return
 
-        if not isinstance(vals, (Sequence, Iterable)) \
-                or isinstance(vals, string_types):
+        if not isinstance(vals, (Sequence, Iterable)) or isinstance(vals, string_types):
             vals = [vals]
 
         # Make sure all values are of the same data type
@@ -287,15 +285,14 @@ class Property(Entity):
         vtype = self._check_new_value_types(data)
 
         arr = np.array(data, dtype=vtype).flatten('C')
-        ds = self._h5dataset
+        dataset = self._h5dataset
         src_len = len(self.values)
         dlen = len(arr)
-        ds.shape = (src_len+dlen,)
-        ds.write_data(arr, sl=np.s_[src_len: src_len+dlen])
+        dataset.shape = (src_len+dlen,)
+        dataset.write_data(arr, slc=np.s_[src_len: src_len+dlen])
 
     def _check_new_value_types(self, data):
-        if (isinstance(data, (Sequence, Iterable)) and
-                not isinstance(data, string_types)):
+        if isinstance(data, (Sequence, Iterable)) and not isinstance(data, string_types):
             single_val = data[0]
         else:
             single_val = data

--- a/nixio/tag.py
+++ b/nixio/tag.py
@@ -36,12 +36,12 @@ class FeatureContainer(Container):
     def __getitem__(self, item):
         try:
             return Container.__getitem__(self, item)
-        except KeyError as ke:
+        except KeyError as exc:
             # item might be the ID of the referenced data; try it as well
             for feat in self:
                 if feat.data.id == item or feat.data.name == item:
                     return feat
-            raise ke
+            raise exc
 
     def __contains__(self, item):
         if isinstance(item, Feature):
@@ -84,10 +84,10 @@ class BaseTag(Entity):
                 del self._h5group["units"]
         else:
             sanitized = []
-            for u in units:
-                util.check_attr_type(u, str)
-                u = util.units.sanitizer(u)
-                sanitized.append(u)
+            for unit in units:
+                util.check_attr_type(unit, str)
+                unit = util.units.sanitizer(unit)
+                sanitized.append(unit)
 
             dtype = DataType.String
             self._h5group.write_data("units", sanitized, dtype)
@@ -167,7 +167,6 @@ class BaseTag(Entity):
             index = dim.index_of(pos * scaling)
 
         return int(index)
-
 
     @property
     def features(self):
@@ -315,9 +314,9 @@ class Tag(BaseTag):
             feat = self.features[featidx]
         except KeyError:
             feat = None
-            for f in self.features:
-                if f.data.name == featidx or f.data.id == featidx:
-                    feat = f
+            for feature in self.features:
+                if feature.data.name == featidx or feature.data.id == featidx:
+                    feat = feature
                     break
             if feat is None:
                 raise

--- a/nixio/test/test_block.py
+++ b/nixio/test/test_block.py
@@ -162,11 +162,8 @@ class TestBlock(unittest.TestCase):
 
         assert len(self.block.find_sources()) == 8
         assert len(self.block.find_sources(limit=1)) == 2
-        assert(len(self.block.find_sources(filtr=lambda x: "level2-p1-s" in
-                                                           x.name)) == 2)
-        assert(len(self.block.find_sources(filtr=lambda x: "level2-p1-s" in
-                                                           x.name,
-                                           limit=1)) == 0)
+        assert len(self.block.find_sources(filtr=lambda x: "level2-p1-s" in x.name)) == 2
+        assert len(self.block.find_sources(filtr=lambda x: "level2-p1-s" in x.name, limit=1)) == 0
 
     def test_block_groups(self):
         assert len(self.block.groups) == 0

--- a/nixio/test/test_block.py
+++ b/nixio/test/test_block.py
@@ -28,67 +28,67 @@ class TestBlock(unittest.TestCase):
         self.tmpdir.cleanup()
 
     def test_block_eq(self):
-        assert(self.block == self.block)
-        assert(not self.block == self.other)
-        assert(self.block is not None)
+        assert self.block == self.block
+        assert not self.block == self.other
+        assert self.block is not None
 
     def test_block_id(self):
-        assert(self.block.id is not None)
+        assert self.block.id is not None
 
     def test_block_name(self):
-        assert(self.block.name is not None)
+        assert self.block.name is not None
 
     def test_block_type(self):
         def set_none():
             self.block.type = None
 
-        assert(self.block.type is not None)
+        assert self.block.type is not None
         self.assertRaises(Exception, set_none)
 
         self.block.type = "foo type"
-        assert(self.block.type == "foo type")
+        assert self.block.type == "foo type"
 
     def test_block_definition(self):
-        assert(self.block.definition is None)
+        assert self.block.definition is None
 
         self.block.definition = "definition"
-        assert(self.block.definition == "definition")
+        assert self.block.definition == "definition"
 
         self.block.definition = None
-        assert(self.block.definition is None)
+        assert self.block.definition is None
 
     def test_block_timestamps(self):
         created_at = self.block.created_at
-        assert(created_at > 0)
+        assert created_at > 0
 
         updated_at = self.block.updated_at
-        assert(updated_at > 0)
+        assert updated_at > 0
 
         self.block.force_created_at(1403530068)
-        assert(self.block.created_at == 1403530068)
+        assert self.block.created_at == 1403530068
 
     def test_block_data_arrays(self):
-        assert(len(self.block.data_arrays) == 0)
+        assert len(self.block.data_arrays) == 0
 
         data_array = self.block.create_data_array("test data_array",
                                                   "recordingsession",
                                                   nix.DataType.Int32, (0, ))
 
-        assert(len(self.block.data_arrays) == 1)
+        assert len(self.block.data_arrays) == 1
 
         # TODO implement __eq__ for DataArray
-        assert(data_array.id in self.block.data_arrays)
-        assert("notexist" not in self.block.data_arrays)
+        assert data_array.id in self.block.data_arrays
+        assert "notexist" not in self.block.data_arrays
 
-        assert(data_array.id == self.block.data_arrays[0].id)
-        assert(data_array.id == self.block.data_arrays[-1].id)
+        assert data_array.id == self.block.data_arrays[0].id
+        assert data_array.id == self.block.data_arrays[-1].id
 
         del self.block.data_arrays[0]
 
-        assert(len(self.block.data_arrays) == 0)
+        assert len(self.block.data_arrays) == 0
 
     def test_block_multi_tags(self):
-        assert(len(self.block.multi_tags) == 0)
+        assert len(self.block.multi_tags) == 0
 
         data_array = self.block.create_data_array("test array",
                                                   "recording",
@@ -96,55 +96,55 @@ class TestBlock(unittest.TestCase):
         multi_tag = self.block.create_multi_tag("test multi_tag",
                                                 "recordingsession", data_array)
 
-        assert(len(self.block.multi_tags) == 1)
+        assert len(self.block.multi_tags) == 1
 
         # TODO implement __eq__ for MultiTag
-        # assert(multi_tag in self.block.multi_tags)
-        assert(multi_tag.id in self.block.multi_tags)
-        assert("notexist" not in self.block.multi_tags)
+        # assert multi_tag in self.block.multi_tags
+        assert multi_tag.id in self.block.multi_tags
+        assert "notexist" not in self.block.multi_tags
 
-        assert(multi_tag.id == self.block.multi_tags[0].id)
-        assert(multi_tag.id == self.block.multi_tags[-1].id)
+        assert multi_tag.id == self.block.multi_tags[0].id
+        assert multi_tag.id == self.block.multi_tags[-1].id
 
         del self.block.multi_tags[0]
 
-        assert(len(self.block.multi_tags) == 0)
+        assert len(self.block.multi_tags) == 0
 
     def test_block_tags(self):
-        assert(len(self.block.tags) == 0)
+        assert len(self.block.tags) == 0
 
         tag = self.block.create_tag("test tag", "recordingsession", [0])
 
-        assert(len(self.block.tags) == 1)
+        assert len(self.block.tags) == 1
 
-        assert(tag in self.block.tags)
-        assert(tag.id in self.block.tags)
-        assert("notexist" not in self.block.tags)
+        assert tag in self.block.tags
+        assert tag.id in self.block.tags
+        assert "notexist" not in self.block.tags
 
-        assert(tag.id == self.block.tags[0].id)
-        assert(tag.id == self.block.tags[-1].id)
+        assert tag.id == self.block.tags[0].id
+        assert tag.id == self.block.tags[-1].id
 
         del self.block.tags[0]
 
-        assert(len(self.block.tags) == 0)
+        assert len(self.block.tags) == 0
 
     def test_block_sources(self):
-        assert(len(self.block.sources) == 0)
+        assert len(self.block.sources) == 0
 
         source = self.block.create_source("test source", "electrode")
 
-        assert(len(self.block.sources) == 1)
+        assert len(self.block.sources) == 1
 
-        assert(source in self.block.sources)
-        assert(source.id in self.block.sources)
-        assert("notexist" not in self.block.sources)
+        assert source in self.block.sources
+        assert source.id in self.block.sources
+        assert "notexist" not in self.block.sources
 
-        assert(source.id == self.block.sources[0].id)
-        assert(source.id == self.block.sources[-1].id)
+        assert source.id == self.block.sources[0].id
+        assert source.id == self.block.sources[-1].id
 
         del self.block.sources[0]
 
-        assert(len(self.block.sources) == 0)
+        assert len(self.block.sources) == 0
 
     def test_block_find_sources(self):
         for i in range(2):
@@ -160,8 +160,8 @@ class TestBlock(unittest.TestCase):
                 "level3-p1-s" + str(i), "dummy"
             )
 
-        assert(len(self.block.find_sources()) == 8)
-        assert(len(self.block.find_sources(limit=1)) == 2)
+        assert len(self.block.find_sources()) == 8
+        assert len(self.block.find_sources(limit=1)) == 2
         assert(len(self.block.find_sources(filtr=lambda x: "level2-p1-s" in
                                                            x.name)) == 2)
         assert(len(self.block.find_sources(filtr=lambda x: "level2-p1-s" in
@@ -169,22 +169,22 @@ class TestBlock(unittest.TestCase):
                                            limit=1)) == 0)
 
     def test_block_groups(self):
-        assert(len(self.block.groups) == 0)
+        assert len(self.block.groups) == 0
 
         group = self.block.create_group("test group", "RecordingChannelGroup")
 
-        assert(len(self.block.groups) == 1)
+        assert len(self.block.groups) == 1
 
-        assert(group in self.block.groups)
-        assert(group.id in self.block.groups)
-        assert("notexist" not in self.block.groups)
+        assert group in self.block.groups
+        assert group.id in self.block.groups
+        assert "notexist" not in self.block.groups
 
-        assert(group.id == self.block.groups[0].id)
-        assert(group.id == self.block.groups[-1].id)
+        assert group.id == self.block.groups[0].id
+        assert group.id == self.block.groups[-1].id
 
         del self.block.groups[0]
 
-        assert(len(self.block.groups) == 0)
+        assert len(self.block.groups) == 0
 
     def test_copy_on_block(self):
         tar_filename = os.path.join(self.tmpdir.path, "copytarget.nix")

--- a/nixio/test/test_container.py
+++ b/nixio/test/test_container.py
@@ -75,9 +75,8 @@ class TestContainer(unittest.TestCase):
 
     def test_file_references(self):
         # add some sources
-        self.source = self.block.create_source("test source", "containertest")
-        self.child_source = self.source.create_source("test source 2",
-                                                      "containertest")
+        source = self.block.create_source("test source", "containertest")
+        child_source = source.create_source("test source 2", "containertest")
         # using assertIs since the reference should be the same instance as
         # the original
 
@@ -88,8 +87,8 @@ class TestContainer(unittest.TestCase):
         self.assertIs(self.tag.file, self.file)
         self.assertIs(self.multi_tag.file, self.file)
         self.assertIs(self.positions.file, self.file)
-        self.assertIs(self.source.file, self.file)
-        self.assertIs(self.child_source.file, self.file)
+        self.assertIs(source.file, self.file)
+        self.assertIs(child_source.file, self.file)
 
         # instantiated through container getters
         blk = self.file.blocks[0]
@@ -108,9 +107,8 @@ class TestContainer(unittest.TestCase):
 
     def test_parent_references(self):
         # add some sources
-        self.source = self.block.create_source("test source", "containertest")
-        self.child_source = self.source.create_source("test source 2",
-                                                      "containertest")
+        source = self.block.create_source("test source", "containertest")
+        child_source = source.create_source("test source 2", "containertest")
 
         self.assertEqual(self.block._parent, self.file)
         self.assertEqual(self.group._parent, self.block)
@@ -118,8 +116,8 @@ class TestContainer(unittest.TestCase):
         self.assertEqual(self.tag._parent, self.block)
         self.assertEqual(self.multi_tag._parent, self.block)
         self.assertEqual(self.positions._parent, self.block)
-        self.assertEqual(self.source._parent, self.block)
-        self.assertEqual(self.child_source._parent, self.source)
+        self.assertEqual(source._parent, self.block)
+        self.assertEqual(child_source._parent, source)
 
     def test_link_parent_references(self):
         self.assertEqual(self.group.data_arrays[0]._parent, self.block)
@@ -148,13 +146,13 @@ class TestContainer(unittest.TestCase):
 
         # check counts
         self.assertEqual(len(nf.blocks), 2)
-        for bl in nf.blocks:
-            self.assertEqual(len(bl.groups), 2)
-            self.assertEqual(len(bl.data_arrays), 4)
-            self.assertEqual(len(bl.tags), 4)
-            for g in bl.groups:
-                self.assertEqual(len(g.data_arrays), 2)
-                self.assertEqual(len(g.tags), 2)
+        for blk in nf.blocks:
+            self.assertEqual(len(blk.groups), 2)
+            self.assertEqual(len(blk.data_arrays), 4)
+            self.assertEqual(len(blk.tags), 4)
+            for grp in blk.groups:
+                self.assertEqual(len(grp.data_arrays), 2)
+                self.assertEqual(len(grp.tags), 2)
 
         # cross-block append
         with self.assertRaises(RuntimeError):
@@ -181,17 +179,17 @@ class TestContainer(unittest.TestCase):
             )
 
         # let's do sources
-        for bl in nf.blocks:
+        for blk in nf.blocks:
             for sourcename in ["a", "b"]:
-                src = bl.create_source(bl.name + sourcename, "source")
+                src = blk.create_source(blk.name + sourcename, "source")
                 for chsourcename in ["a", "b", "c"]:
-                    src.create_source(bl.name + sourcename + chsourcename,
+                    src.create_source(blk.name + sourcename + chsourcename,
                                       "source")
 
         # check counts
-        for bl in nf.blocks:
-            self.assertEqual(len(bl.sources), 2)
-            for src in bl.sources:
+        for blk in nf.blocks:
+            self.assertEqual(len(blk.sources), 2)
+            for src in blk.sources:
                 self.assertEqual(len(src.sources), 3)
 
         # cross-block source append
@@ -213,15 +211,15 @@ class TestContainer(unittest.TestCase):
 
         # bad membership test
         with self.assertRaises(TypeError):
-            nf.blocks[1].data_arrays[1] in nf.blocks[0].tags
+            _ = nf.blocks[1].data_arrays[1] in nf.blocks[0].tags
 
         # another
         with self.assertRaises(TypeError):
-            nf.blocks[1].data_arrays[1] in nf.blocks[0].groups[0]
+            _ = nf.blocks[1].data_arrays[1] in nf.blocks[0].groups[0]
 
         # bad membership test on LinkContainer
         with self.assertRaises(TypeError):
-            nf.blocks[1].data_arrays[1] in nf.blocks[0].groups[0].tags
+            _ = nf.blocks[1].data_arrays[1] in nf.blocks[0].groups[0].tags
 
     def test_delete_links_da(self):
         # delete DataArray from Block and check Group
@@ -270,7 +268,7 @@ class TestContainer(unittest.TestCase):
         self.assertEqual(mtag.positions, pos)
         del self.block.data_arrays[posname]
         with self.assertRaises(RuntimeError):
-            mtag.positions
+            _ = mtag.positions
         # ext still here
         self.assertEqual(mtag.extents, ext)
         # delete ext and check extents
@@ -471,7 +469,7 @@ class TestContainer(unittest.TestCase):
             self.assertNotIn(dataname, tag.features)
 
         with self.assertRaises(RuntimeError):
-            tag.features[dataname].data
+            _ = tag.features[dataname].data
 
     def test_delete_links_section_link(self):
         parsec = self.file.create_section("TopDog", "Root Section")

--- a/nixio/test/test_data_array.py
+++ b/nixio/test/test_data_array.py
@@ -35,80 +35,80 @@ class TestDataArray(unittest.TestCase):
         self.tmpdir.cleanup()
 
     def test_data_array_eq(self):
-        assert(self.array == self.array)
-        assert(not self.array == self.other)
-        assert(self.array is not None)
+        assert self.array == self.array
+        assert not self.array == self.other
+        assert self.array is not None
 
     def test_data_array_id(self):
-        assert(self.array.id is not None)
+        assert self.array.id is not None
 
     def test_data_array_name(self):
-        assert(self.array.name is not None)
+        assert self.array.name is not None
 
     def test_data_array_type(self):
         def set_none():
             self.array.type = None
 
-        assert(self.array.type is not None)
+        assert self.array.type is not None
         self.assertRaises(Exception, set_none)
 
         self.array.type = "foo type"
-        assert(self.array.type == "foo type")
+        assert self.array.type == "foo type"
 
     def test_data_array_definition(self):
-        assert(self.array.definition is None)
+        assert self.array.definition is None
 
         self.array.definition = "definition"
-        assert(self.array.definition == "definition")
+        assert self.array.definition == "definition"
 
         self.array.definition = None
-        assert(self.array.definition is None)
+        assert self.array.definition is None
 
     def test_data_array_timestamps(self):
         created_at = self.array.created_at
-        assert(created_at > 0)
+        assert created_at > 0
 
         updated_at = self.array.updated_at
-        assert(updated_at > 0)
+        assert updated_at > 0
 
         self.array.force_created_at(1403530068)
-        assert(self.array.created_at == 1403530068)
+        assert self.array.created_at == 1403530068
 
     def test_data_array_label(self):
-        assert(self.array.label is None)
+        assert self.array.label is None
 
         self.array.label = "label"
-        assert(self.array.label == "label")
+        assert self.array.label == "label"
 
         self.array.label = None
-        assert(self.array.label is None)
+        assert self.array.label is None
 
     def test_data_array_unit(self):
-        assert(self.array.unit is None)
+        assert self.array.unit is None
 
         self.array.unit = "mV"
-        assert(self.array.unit == "mV")
+        assert self.array.unit == "mV"
 
         self.array.unit = "0.5*ms"
-        assert(self.array.unit == "0.5*ms")
+        assert self.array.unit == "0.5*ms"
 
         self.array.unit = None
-        assert(self.array.unit is None)
+        assert self.array.unit is None
 
     def test_data_array_exp_origin(self):
-        assert(self.array.expansion_origin is None)
+        assert self.array.expansion_origin is None
 
         self.array.expansion_origin = 10.2
-        assert(self.array.expansion_origin == 10.2)
+        assert self.array.expansion_origin == 10.2
 
         self.array.expansion_origin = None
-        assert(self.array.expansion_origin is None)
+        assert self.array.expansion_origin is None
 
     def test_data_array_coefficients(self):
-        assert(self.array.polynom_coefficients == ())
+        assert self.array.polynom_coefficients == ()
 
         self.array.polynom_coefficients = (1.1, 2.2)
-        assert(self.array.polynom_coefficients == (1.1, 2.2))
+        assert self.array.polynom_coefficients == (1.1, 2.2)
 
         data = [10, 29, 33]
         intarray = self.block.create_data_array("intarray", "array",
@@ -121,44 +121,44 @@ class TestDataArray(unittest.TestCase):
 
     def test_data_array_data(self):
 
-        assert(self.array.polynom_coefficients == ())
+        assert self.array.polynom_coefficients == ()
 
         data = np.array([float(i) for i in range(100)])
         dout = np.empty_like(data)
         self.array.write_direct(data)
-        assert(self.array.dtype == np.dtype(float))
+        assert self.array.dtype == np.dtype(float)
         self.array.read_direct(dout)
-        assert(np.array_equal(data, dout))
+        assert np.array_equal(data, dout)
         dout = np.array(self.array)
-        assert(np.array_equal(data, dout))
-        assert(self.array.data_extent == data.shape)
-        assert(self.array.data_extent == self.array.shape)
-        assert(self.array.size == data.size)
+        assert np.array_equal(data, dout)
+        assert self.array.data_extent == data.shape
+        assert self.array.data_extent == self.array.shape
+        assert self.array.size == data.size
 
-        assert(len(self.array) == len(data))
+        assert len(self.array) == len(data)
 
         dout = np.array([self.array[i] for i in range(100)])
-        assert(np.array_equal(data, dout))
+        assert np.array_equal(data, dout)
 
         dout = self.array[...]
-        assert(np.array_equal(data, dout))
+        assert np.array_equal(data, dout)
 
         # indexed writing (1-d)
         data = np.array([float(-i) for i in range(100)])
         self.array[()] = data
-        assert(np.array_equal(self.array[...], data))
+        assert np.array_equal(self.array[...], data)
 
         self.array[...] = [float(-i) for i in range(100)]
-        assert(np.array_equal(self.array[()], data))
-        assert(np.array_equal(self.array[0:-10], data[0:-10]))
-        assert(np.array_equal(self.array[-10], data[-10]))
+        assert np.array_equal(self.array[()], data)
+        assert np.array_equal(self.array[0:-10], data[0:-10])
+        assert np.array_equal(self.array[-10], data[-10])
 
         self.array[0] = 42
-        assert(self.array[0] == 42.0)
+        assert self.array[0] == 42.0
 
         # changing shape via data_extent property
         self.array.data_extent = (200, )
-        assert(self.array.data_extent == (200, ))
+        assert self.array.data_extent == (200, )
 
         # TODO delete does not work
         data = np.eye(123)
@@ -168,61 +168,61 @@ class TestDataArray(unittest.TestCase):
         dset.write_direct(data)
         dout = np.empty_like(data)
         dset.read_direct(dout)
-        assert(np.array_equal(data, dout))
+        assert np.array_equal(data, dout)
 
         # indexing support in 2-d arrays
         with self.assertRaises(IndexError):
             self.array[[], [1, 2]]
 
         dout = dset[12]
-        assert(dout.shape == data[12].shape)
-        assert(np.array_equal(dout, data[12]))
-        assert(np.array_equal(dset[()], data))
-        assert(np.array_equal(dset[...], data))
-        assert(np.array_equal(dset[12, ...], data[12, ...]))
-        assert(np.array_equal(dset[..., 12], data[..., 12]))
-        assert(np.array_equal(dset[1:], data[1:]))
-        assert(np.array_equal(dset[-20:, -20:], data[123-20:, 123-20:]))
-        assert(np.array_equal(dset[:1], data[:1]))
-        assert(np.array_equal(dset[:-1, :-1], data[1:123, 1:123]))
-        assert(np.array_equal(dset[1:10, 1:10], data[1:10, 1:10]))
-        assert(np.array_equal(dset[1:-2, 1:-2], data[1:121, 1:121]))
+        assert dout.shape == data[12].shape
+        assert np.array_equal(dout, data[12])
+        assert np.array_equal(dset[()], data)
+        assert np.array_equal(dset[...], data)
+        assert np.array_equal(dset[12, ...], data[12, ...])
+        assert np.array_equal(dset[..., 12], data[..., 12])
+        assert np.array_equal(dset[1:], data[1:])
+        assert np.array_equal(dset[-20:, -20:], data[123-20:, 123-20:])
+        assert np.array_equal(dset[:1], data[:1])
+        assert np.array_equal(dset[:-1, :-1], data[1:123, 1:123])
+        assert np.array_equal(dset[1:10, 1:10], data[1:10, 1:10])
+        assert np.array_equal(dset[1:-2, 1:-2], data[1:121, 1:121])
 
         a3 = self.block.create_data_array("int identity array", "signal",
                                           nix.DataType.Int32, (123, 123))
-        assert(a3.shape == (123, 123))
-        assert(a3.dtype == np.dtype('i4'))
+        assert a3.shape == (123, 123)
+        assert a3.dtype == np.dtype('i4')
 
         data = np.random.rand(3, 4, 5)
         a4 = self.block.create_data_array("3d array", "signal",
                                           nix.DataType.Double, (3, 4, 5))
         dset = a4
         dset.write_direct(data)
-        assert(dset.shape == data.shape)
-        assert(len(dset) == len(data))
-        assert(dset.size == data.size)
-        assert(np.array_equal(dset[2, ...], data[2, ...]))
-        assert(np.array_equal(dset[-1, ...], data[2, ...]))
-        assert(np.array_equal(dset[..., 3], data[..., 3]))
-        assert(np.array_equal(dset[..., -2], data[..., 3]))
-        assert(np.array_equal(dset[2, ..., 3], data[2, ..., 3]))
-        assert(np.array_equal(dset[2, ..., -2], data[2, ..., 3]))
-        assert(np.array_equal(dset[1:2, ..., 3:5], data[1:2, ..., 3:5]))
-        assert(np.array_equal(dset[1:2, ..., 3:-1], data[1:2, ..., 3:4]))
+        assert dset.shape == data.shape
+        assert len(dset) == len(data)
+        assert dset.size == data.size
+        assert np.array_equal(dset[2, ...], data[2, ...])
+        assert np.array_equal(dset[-1, ...], data[2, ...])
+        assert np.array_equal(dset[..., 3], data[..., 3])
+        assert np.array_equal(dset[..., -2], data[..., 3])
+        assert np.array_equal(dset[2, ..., 3], data[2, ..., 3])
+        assert np.array_equal(dset[2, ..., -2], data[2, ..., 3])
+        assert np.array_equal(dset[1:2, ..., 3:5], data[1:2, ..., 3:5])
+        assert np.array_equal(dset[1:2, ..., 3:-1], data[1:2, ..., 3:4])
 
         # indexed writing (n-d)
         d2 = np.random.rand(2, 2)
         dset[1, 0:2, 0:2] = d2
-        assert(np.array_equal(dset[1, 0:2, 0:2], d2))
+        assert np.array_equal(dset[1, 0:2, 0:2], d2)
 
         # test inferring shape & dtype from data, and writing the data
         test_ten = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]
         test_data = np.array(test_ten, dtype=int)
         da = self.block.create_data_array('created_from_data', 'b',
                                           data=test_data)
-        assert(da.shape == test_data.shape)
-        assert(np.array_equal(test_data, da[:]))
-        assert(test_ten == [x for x in da])
+        assert da.shape == test_data.shape
+        assert np.array_equal(test_data, da[:])
+        assert test_ten == [x for x in da]
 
         # test for exceptions
         self.assertRaises(ValueError, self.block.create_data_array, 'x', 'y')
@@ -235,38 +235,38 @@ class TestDataArray(unittest.TestCase):
         to_append = np.zeros((2, 5))
 
         da.append(to_append)
-        assert(da.shape == (12, 5))
+        assert da.shape == (12, 5)
 
         to_append = np.zeros((12, 2))
         da.append(to_append, axis=1)
-        assert(da.shape == (12, 7))
+        assert da.shape == (12, 7)
 
         self.assertRaises(ValueError, da.append, np.zeros((3, 3, 3)))
         self.assertRaises(ValueError, da.append, np.zeros((5, 5)))
 
     def test_data_array_dtype(self):
         da = self.block.create_data_array('dtype_f8', 'b', 'f8', (10, 10))
-        assert(da.dtype == np.dtype('f8'))
+        assert da.dtype == np.dtype('f8')
 
         da = self.block.create_data_array('dtype_i16', 'b', np.int16, (10, 10))
         data = da[:]
-        assert(da.dtype == np.int16)
-        assert(data.dtype == np.int16)
+        assert da.dtype == np.int16
+        assert data.dtype == np.int16
 
         da = self.block.create_data_array('dtype_int', 'b', int, (10, 10))
-        assert(da.dtype == np.dtype(int))
+        assert da.dtype == np.dtype(int)
 
         da = self.block.create_data_array('dtype_ndouble', 'b',
                                           nix.DataType.Double, (10, 10))
-        assert(da.dtype == np.dtype('f8'))
+        assert da.dtype == np.dtype('f8')
 
         da = self.block.create_data_array('dtype_auto', 'b', None, (10, 10))
-        assert(da.dtype == np.dtype('f8'))
+        assert da.dtype == np.dtype('f8')
 
         test_data = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 0], dtype=int)
         da = self.block.create_data_array('dtype_int_from_data', 'b',
                                           data=test_data)
-        assert(da.dtype == test_data.dtype)
+        assert da.dtype == test_data.dtype
 
         bdata = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0']
         if sys.version_info[0] == 3:
@@ -274,8 +274,8 @@ class TestDataArray(unittest.TestCase):
 
         void_data = np.array(bdata, dtype='V1')
         da = self.block.create_data_array('dtype_opaque', 'b', data=void_data)
-        assert(da.dtype == np.dtype('V1'))
-        assert(np.array_equal(void_data, da[:]))
+        assert da.dtype == np.dtype('V1')
+        assert np.array_equal(void_data, da[:])
 
     def test_array_unicode(self):
         da = self.block.create_data_array("unicode", "lotsatext",
@@ -286,24 +286,24 @@ class TestDataArray(unittest.TestCase):
         assert data == list(da[:])
 
     def test_data_array_dimensions(self):
-        assert(len(self.array.dimensions) == 0)
+        assert len(self.array.dimensions) == 0
 
         self.array.append_set_dimension()
         self.array.append_range_dimension(range(10))
         self.array.append_sampled_dimension(0.1)
 
-        assert(len(self.array.dimensions) == 3)
+        assert len(self.array.dimensions) == 3
 
         self.assertRaises(KeyError, lambda: self.array.dimensions["notexist"])
         self.assertRaises(IndexError, lambda: self.array.dimensions[-4])
         self.assertRaises(IndexError, lambda: self.array.dimensions[3])
 
-        assert(isinstance(str(self.array.dimensions), string_types))
-        assert(isinstance(repr(self.array.dimensions), string_types))
+        assert isinstance(str(self.array.dimensions), string_types)
+        assert isinstance(repr(self.array.dimensions), string_types)
 
         dims = list(self.array.dimensions)
         for i in range(3):
-            assert(dims[i].index == self.array.dimensions[i].index)
+            assert dims[i].index == self.array.dimensions[i].index
             assert(dims[i].dimension_type ==
                    self.array.dimensions[i].dimension_type)
 
@@ -316,22 +316,22 @@ class TestDataArray(unittest.TestCase):
         source1 = self.block.create_source("source1", "channel")
         source2 = self.block.create_source("source2", "electrode")
 
-        assert(len(self.array.sources) == 0)
+        assert len(self.array.sources) == 0
 
         self.array.sources.append(source1)
         self.array.sources.append(source2)
 
         self.assertRaises(TypeError, self.array.sources.append, 100)
 
-        assert(len(self.array.sources) == 2)
-        assert(source1 in self.array.sources)
-        assert(source2 in self.array.sources)
+        assert len(self.array.sources) == 2
+        assert source1 in self.array.sources
+        assert source2 in self.array.sources
 
         del self.array.sources[source2]
-        assert(self.array.sources[0] == source1)
+        assert self.array.sources[0] == source1
 
         del self.array.sources[source1]
-        assert(len(self.array.sources) == 0)
+        assert len(self.array.sources) == 0
 
     def test_data_array_indexing(self):
         data = np.random.rand(50)

--- a/nixio/test/test_data_array.py
+++ b/nixio/test/test_data_array.py
@@ -162,9 +162,9 @@ class TestDataArray(unittest.TestCase):
 
         # TODO delete does not work
         data = np.eye(123)
-        a1 = self.block.create_data_array("double array", "signal",
-                                          nix.DataType.Double, (123, 123))
-        dset = a1
+        da1 = self.block.create_data_array("double array", "signal",
+                                           nix.DataType.Double, (123, 123))
+        dset = da1
         dset.write_direct(data)
         dout = np.empty_like(data)
         dset.read_direct(dout)
@@ -172,7 +172,7 @@ class TestDataArray(unittest.TestCase):
 
         # indexing support in 2-d arrays
         with self.assertRaises(IndexError):
-            self.array[[], [1, 2]]
+            _ = self.array[[], [1, 2]]
 
         dout = dset[12]
         assert dout.shape == data[12].shape
@@ -188,15 +188,15 @@ class TestDataArray(unittest.TestCase):
         assert np.array_equal(dset[1:10, 1:10], data[1:10, 1:10])
         assert np.array_equal(dset[1:-2, 1:-2], data[1:121, 1:121])
 
-        a3 = self.block.create_data_array("int identity array", "signal",
-                                          nix.DataType.Int32, (123, 123))
-        assert a3.shape == (123, 123)
-        assert a3.dtype == np.dtype('i4')
+        da3 = self.block.create_data_array("int identity array", "signal",
+                                           nix.DataType.Int32, (123, 123))
+        assert da3.shape == (123, 123)
+        assert da3.dtype == np.dtype('i4')
 
         data = np.random.rand(3, 4, 5)
-        a4 = self.block.create_data_array("3d array", "signal",
-                                          nix.DataType.Double, (3, 4, 5))
-        dset = a4
+        da4 = self.block.create_data_array("3d array", "signal",
+                                           nix.DataType.Double, (3, 4, 5))
+        dset = da4
         dset.write_direct(data)
         assert dset.shape == data.shape
         assert len(dset) == len(data)
@@ -211,9 +211,9 @@ class TestDataArray(unittest.TestCase):
         assert np.array_equal(dset[1:2, ..., 3:-1], data[1:2, ..., 3:4])
 
         # indexed writing (n-d)
-        d2 = np.random.rand(2, 2)
-        dset[1, 0:2, 0:2] = d2
-        assert np.array_equal(dset[1, 0:2, 0:2], d2)
+        data = np.random.rand(2, 2)
+        dset[1, 0:2, 0:2] = data
+        assert np.array_equal(dset[1, 0:2, 0:2], data)
 
         # test inferring shape & dtype from data, and writing the data
         test_ten = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]
@@ -375,11 +375,11 @@ class TestDataArray(unittest.TestCase):
         oobtestda = self.block.create_data_array("oobdatatest",
                                                  "data", data=[1, 2, 10])
         with self.assertRaises(IndexError):
-            oobtestda[3]
+            _ = oobtestda[3]
         with self.assertRaises(IndexError):
-            oobtestda[10]
+            _ = oobtestda[10]
         with self.assertRaises(IndexError):
-            oobtestda[-7]
+            _ = oobtestda[-7]
 
     def test_data_array_numpy_indexing(self):
         data = np.random.rand(50)
@@ -411,8 +411,8 @@ class TestDataArray(unittest.TestCase):
         data3d = np.random.random_sample((30, 30, 5))
         da3d = self.block.create_data_array("get_slice 3d", "Data",
                                             data=data3d)
-        sd = da3d.append_sampled_dimension(0.1)
-        sd.offset = 0.5
+        sdim = da3d.append_sampled_dimension(0.1)
+        sdim.offset = 0.5
         da3d.append_sampled_dimension(2.0)
         da3d.append_set_dimension()
 

--- a/nixio/test/test_data_array.py
+++ b/nixio/test/test_data_array.py
@@ -395,7 +395,7 @@ class TestDataArray(unittest.TestCase):
         check_idx(np.int64(9))
 
     def test_get_slice(self):
-        data2d = np.random.random((100, 2))
+        data2d = np.random.random_sample((100, 2))
         da2d = self.block.create_data_array("get_slice 2d", "Data",
                                             data=data2d)
         da2d.append_range_dimension(np.linspace(10, 19.8, 50))
@@ -408,7 +408,7 @@ class TestDataArray(unittest.TestCase):
                                 mode=nix.DataSliceMode.Data)
         np.testing.assert_almost_equal(data, dslice)
 
-        data3d = np.random.random((30, 30, 5))
+        data3d = np.random.random_sample((30, 30, 5))
         da3d = self.block.create_data_array("get_slice 3d", "Data",
                                             data=data3d)
         sd = da3d.append_sampled_dimension(0.1)

--- a/nixio/test/test_data_frame.py
+++ b/nixio/test/test_data_frame.py
@@ -123,7 +123,7 @@ class TestDataFrame(unittest.TestCase):
         multi_col = self.df1.read_columns(name=['sig1', 'sig2'])
         assert len(multi_col) == 10
         # read columns with slices
-        sl_col = self.df1.read_columns(name=['sig1', 'sig2'], sl=slice(0, 10))
+        sl_col = self.df1.read_columns(name=['sig1', 'sig2'], slc=slice(0, 10))
         assert len(sl_col) == 10
 
     def test_read_cell(self):

--- a/nixio/test/test_data_frame.py
+++ b/nixio/test/test_data_frame.py
@@ -21,8 +21,8 @@ class TestDataFrame(unittest.TestCase):
         self.testfilename = os.path.join(self.tmpdir.path, "dataframetest.nix")
         self.file = nix.File.open(self.testfilename, nix.FileMode.Overwrite)
         self.block = self.file.create_block("test block", "recordingsession")
-        di = OrderedDict([('name', np.int64), ('id', str), ('time', float),
-                          ('sig1', np.float64), ('sig2', np.int32)])
+        col_dict = OrderedDict([('name', np.int64), ('id', str), ('time', float),
+                                ('sig1', np.float64), ('sig2', np.int32)])
         arr = [(1, "a", 20.18, 5.0, 100), (2, 'b', 20.09, 5.5, 101),
                (2, 'c', 20.05, 5.1, 100), (1, "d", 20.15, 5.3, 150),
                (2, 'e', 20.23, 5.7, 200), (2, 'f', 20.07, 5.2, 300),
@@ -31,9 +31,9 @@ class TestDataFrame(unittest.TestCase):
         other_arr = np.arange(11101, 11200).reshape((33, 3))
         other_di = OrderedDict({'name': np.int64, 'id': int, 'time': float})
         self.df1 = self.block.create_data_frame("test df", "signal1",
-                                                data=arr, col_dict=di)
+                                                data=arr, col_dict=col_dict)
         self.df2 = self.block.create_data_frame("other df", "signal2",
-                                                data=arr, col_dict=di)
+                                                data=arr, col_dict=col_dict)
         self.df3 = self.block.create_data_frame("reference df", "signal3",
                                                 data=other_arr,
                                                 col_dict=other_di)
@@ -117,8 +117,8 @@ class TestDataFrame(unittest.TestCase):
     def test_read_column(self):
         # read single columns by index
         single_col = self.df1.read_columns(index=[1])
-        t = np.array(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'], dtype=bytes)
-        np.testing.assert_array_equal(single_col, t)
+        data = np.array(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'], dtype=bytes)
+        np.testing.assert_array_equal(single_col, data)
         # read multiple columns by name
         multi_col = self.df1.read_columns(name=['sig1', 'sig2'])
         assert len(multi_col) == 10
@@ -148,13 +148,13 @@ class TestDataFrame(unittest.TestCase):
         self.assertRaises(ValueError, self.df1.write_cell, 11, col_name='sig1')
 
     def test_append_column(self):
-        y = np.arange(start=16000, stop=16010, step=1)
-        self.df1.append_column(y, name='trial_col', datatype=int)
+        col_data = np.arange(start=16000, stop=16010, step=1)
+        self.df1.append_column(col_data, name='trial_col', datatype=int)
         assert self.df1.column_names == ('name', 'id', 'time',
                                          'sig1', 'sig2', 'trial_col')
         assert len(self.df1.dtype) == 6
         k = np.array(self.df1[0:10]["trial_col"], dtype=np.int64)
-        np.testing.assert_almost_equal(k, y)
+        np.testing.assert_almost_equal(k, col_data)
         # too short column
         sh_col = np.arange(start=16000, stop=16003, step=1)
         with self.assertRaises(ValueError):

--- a/nixio/test/test_data_view.py
+++ b/nixio/test/test_data_view.py
@@ -19,7 +19,7 @@ class TestDataView(unittest.TestCase):
         self.tmpdir = TempDir("dvtest")
         self.testfilename = os.path.join(self.tmpdir.path, "dvtest.nix")
         self.file = nix.File.open(self.testfilename, nix.FileMode.Overwrite)
-        self.data = np.random.random((40, 80))
+        self.data = np.random.random_sample((40, 80))
         block = self.file.create_block("testblock", "nix.test.block")
         block.create_data_array("data", "nix.test.data", data=self.data)
 
@@ -76,19 +76,19 @@ class TestDataView(unittest.TestCase):
         npeq = np.testing.assert_almost_equal
 
         # straightforward slicing
-        ow = np.random.random((3, 4))
+        ow = np.random.random_sample((3, 4))
         dv[0:3, 1:5] = ow
         newdata[10:13, 21:25] = ow
         npeq(da[:], newdata)
 
         # slicing with steps
-        ow = np.random.random((5, 3))
+        ow = np.random.random_sample((5, 3))
         dv[0:20:4, 0:15:5] = ow
         newdata[10:30:4, 20:35:5] = ow
         npeq(da[:], newdata)
 
         # steps only
-        ow = np.random.random((5, 3))
+        ow = np.random.random_sample((5, 3))
         dv[::4, ::5] = ow
         newdata[10:30:4, 20:35:5] = ow
         npeq(da[:], newdata)
@@ -104,19 +104,19 @@ class TestDataView(unittest.TestCase):
         npeq(da[:], newdata)
 
         # negative slice start
-        ow = np.random.random(3)
+        ow = np.random.random_sample(3)
         dv[-3::, 10] = ow
         newdata[27:30, 30] = ow
         npeq(da[:], newdata)
 
         # negative slice stop
-        ow = np.random.random(15)
+        ow = np.random.random_sample(15)
         dv[:-5, 2] = ow
         newdata[10:25, 22] = ow
         npeq(da[:], newdata)
 
         # negative slice start and stop
-        ow = np.random.random(10)
+        ow = np.random.random_sample(10)
         dv[10, -15:-5] = ow
         newdata[20, 20:30] = ow
         npeq(da[:], newdata)
@@ -158,7 +158,7 @@ class TestDataView(unittest.TestCase):
 
     def test_data_view_ellipsis(self):
         block = self.file.blocks[0]
-        data = np.random.random((10, 11, 12, 13, 14))
+        data = np.random.random_sample((10, 11, 12, 13, 14))
         da = block.create_data_array("data2", "nix.test.data", data=data)
 
         npeq = np.testing.assert_almost_equal

--- a/nixio/test/test_data_view.py
+++ b/nixio/test/test_data_view.py
@@ -76,21 +76,21 @@ class TestDataView(unittest.TestCase):
         npeq = np.testing.assert_almost_equal
 
         # straightforward slicing
-        ow = np.random.random_sample((3, 4))
-        dv[0:3, 1:5] = ow
-        newdata[10:13, 21:25] = ow
+        rand_data = np.random.random_sample((3, 4))
+        dv[0:3, 1:5] = rand_data
+        newdata[10:13, 21:25] = rand_data
         npeq(da[:], newdata)
 
         # slicing with steps
-        ow = np.random.random_sample((5, 3))
-        dv[0:20:4, 0:15:5] = ow
-        newdata[10:30:4, 20:35:5] = ow
+        rand_data = np.random.random_sample((5, 3))
+        dv[0:20:4, 0:15:5] = rand_data
+        newdata[10:30:4, 20:35:5] = rand_data
         npeq(da[:], newdata)
 
         # steps only
-        ow = np.random.random_sample((5, 3))
-        dv[::4, ::5] = ow
-        newdata[10:30:4, 20:35:5] = ow
+        rand_data = np.random.random_sample((5, 3))
+        dv[::4, ::5] = rand_data
+        newdata[10:30:4, 20:35:5] = rand_data
         npeq(da[:], newdata)
 
         # plain index
@@ -104,21 +104,21 @@ class TestDataView(unittest.TestCase):
         npeq(da[:], newdata)
 
         # negative slice start
-        ow = np.random.random_sample(3)
-        dv[-3::, 10] = ow
-        newdata[27:30, 30] = ow
+        rand_data = np.random.random_sample(3)
+        dv[-3::, 10] = rand_data
+        newdata[27:30, 30] = rand_data
         npeq(da[:], newdata)
 
         # negative slice stop
-        ow = np.random.random_sample(15)
-        dv[:-5, 2] = ow
-        newdata[10:25, 22] = ow
+        rand_data = np.random.random_sample(15)
+        dv[:-5, 2] = rand_data
+        newdata[10:25, 22] = rand_data
         npeq(da[:], newdata)
 
         # negative slice start and stop
-        ow = np.random.random_sample(10)
-        dv[10, -15:-5] = ow
-        newdata[20, 20:30] = ow
+        rand_data = np.random.random_sample(10)
+        dv[10, -15:-5] = rand_data
+        newdata[20, 20:30] = rand_data
         npeq(da[:], newdata)
 
     def test_data_view_oob(self):
@@ -136,25 +136,25 @@ class TestDataView(unittest.TestCase):
         dv = da.get_slice((5, 8), extents=(10, 20))
 
         with self.assertRaises(nix.exceptions.OutOfBounds):
-            dv[12, :]
+            _ = dv[12, :]
 
         with self.assertRaises(nix.exceptions.OutOfBounds):
-            dv[12, :]
+            _ = dv[12, :]
 
         with self.assertRaises(nix.exceptions.OutOfBounds):
-            dv[10]
+            _ = dv[10]
 
         with self.assertRaises(nix.exceptions.OutOfBounds):
-            dv[0, 20]
+            _ = dv[0, 20]
 
         with self.assertRaises(nix.exceptions.OutOfBounds):
-            dv[:, 25]
+            _ = dv[:, 25]
 
         with self.assertRaises(nix.exceptions.OutOfBounds):
-            dv[-11]
+            _ = dv[-11]
 
         with self.assertRaises(nix.exceptions.OutOfBounds):
-            dv[0, -21]
+            _ = dv[0, -21]
 
     def test_data_view_ellipsis(self):
         block = self.file.blocks[0]

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -15,9 +15,9 @@ from .tmp import TempDir
 from collections import OrderedDict
 
 
+TEST_SAMPL = 0.1
+TEST_LABEL = "test label"
 test_range = tuple([float(i) for i in range(10)])
-test_sampl = 0.1
-test_label = "test label"
 test_labels = tuple([str(i) + "_label" for i in range(10)])
 
 
@@ -32,7 +32,7 @@ class TestDimension(unittest.TestCase):
                                                   nix.DataType.Float, (0, ))
 
         self.set_dim = self.array.append_set_dimension()
-        self.sample_dim = self.array.append_sampled_dimension(test_sampl)
+        self.sample_dim = self.array.append_sampled_dimension(TEST_SAMPL)
         self.range_dim = self.array.append_range_dimension(test_range)
 
     def tearDown(self):
@@ -55,8 +55,8 @@ class TestDimension(unittest.TestCase):
         assert self.array.dimensions[1].index == 2
 
         assert self.sample_dim.label is None
-        self.sample_dim.label = test_label
-        assert self.sample_dim.label == test_label
+        self.sample_dim.label = TEST_LABEL
+        assert self.sample_dim.label == TEST_LABEL
         self.sample_dim.label = None
         assert self.sample_dim.label is None
 
@@ -66,7 +66,7 @@ class TestDimension(unittest.TestCase):
         self.sample_dim.unit = None
         assert self.sample_dim.unit is None
 
-        assert self.sample_dim.sampling_interval == test_sampl
+        assert self.sample_dim.sampling_interval == TEST_SAMPL
         self.sample_dim.sampling_interval = 1.123
         assert self.sample_dim.sampling_interval == 1.123
 
@@ -100,8 +100,8 @@ class TestDimension(unittest.TestCase):
         assert self.array.dimensions[2].index == 3
 
         assert self.range_dim.label is None
-        self.range_dim.label = test_label
-        assert self.range_dim.label == test_label
+        self.range_dim.label = TEST_LABEL
+        assert self.range_dim.label == TEST_LABEL
         self.range_dim.label = None
         assert self.range_dim.label is None
 
@@ -274,10 +274,10 @@ class TestLinkDimension(unittest.TestCase):
                                            ("duration", nix.DataType.Double)])
 
         def randtick():
-            ts = 0
+            time_stamp = 0
             while True:
-                ts += np.random.random_sample()
-                yield ts
+                time_stamp += np.random.random_sample()
+                yield time_stamp
 
         tickgen = randtick()
 

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -191,7 +191,7 @@ class TestLinkDimension(unittest.TestCase):
         self.block = self.file.create_block("test block", "test.session")
         self.array = self.block.create_data_array(
             "test array", "signal", nix.DataType.Float,
-            data=np.random.random((3, 15))
+            data=np.random.random_sample((3, 15))
         )
 
         self.set_dim = self.array.append_set_dimension()
@@ -216,10 +216,10 @@ class TestLinkDimension(unittest.TestCase):
 
         tickarray3d = self.block.create_data_array(
             "ticks3d", "array.dimension.ticks",
-            data=np.random.random((20, 15, 4))
+            data=np.random.random_sample((20, 15, 4))
         )
         tickarray3d.unit = "mA"
-        ticks = np.cumsum(np.random.random(15))
+        ticks = np.cumsum(np.random.random_sample(15))
         tickarray3d[3, :, 1] = ticks
         tickarray3d.label = "DIMENSION LABEL 2"
         self.range_dim.link_data_array(tickarray3d, [3, -1, 1])
@@ -249,7 +249,7 @@ class TestLinkDimension(unittest.TestCase):
     def test_data_array_self_link_range_dimension(self):
         # The new way of making alias range dimension
         da = self.block.create_data_array("alias da", "dimticks",
-                                          data=np.random.random(10))
+                                          data=np.random.random_sample(10))
         da.label = "alias dimension label"
         da.unit = "F"
         rdim = da.append_range_dimension()
@@ -262,7 +262,7 @@ class TestLinkDimension(unittest.TestCase):
     def test_data_array_self_link_set_dimension(self):
         # The new way of making alias range dimension
         labelda = self.block.create_data_array("alias da", "dimlabels",
-                                               data=np.random.random(10))
+                                               data=np.random.random_sample(10))
         rdim = labelda.append_set_dimension()
         rdim.link_data_array(labelda, [-1])
         assert len(labelda.dimensions) == 1
@@ -276,7 +276,7 @@ class TestLinkDimension(unittest.TestCase):
         def randtick():
             ts = 0
             while True:
-                ts += np.random.random()
+                ts += np.random.random_sample()
                 yield ts
 
         tickgen = randtick()
@@ -309,7 +309,7 @@ class TestLinkDimension(unittest.TestCase):
                                            ("duration", nix.DataType.Float)])
 
         def rdura():
-            return np.random.random() * 30
+            return np.random.random_sample() * 30
 
         values = [("Alpha", "a", rdura()),
                   ("Beta", 'b',  rdura()),
@@ -332,7 +332,7 @@ class TestLinkDimension(unittest.TestCase):
 
     def test_data_array_linking_errors(self):
         da = self.block.create_data_array("baddim", "dimension.error.test",
-                                          data=np.random.random((3, 4, 2)))
+                                          data=np.random.random_sample((3, 4, 2)))
 
         # index dimensionality mismatch
         with self.assertRaises(nix.exceptions.IncompatibleDimensions):
@@ -387,7 +387,7 @@ class TestLinkDimension(unittest.TestCase):
         sdim = self.array.append_sampled_dimension(0.1)
 
         da = self.block.create_data_array("baddim", "dimension.error.test",
-                                          data=np.random.random((3, 4, 2)))
+                                          data=np.random.random_sample((3, 4, 2)))
         with self.assertRaises(RuntimeError):
             sdim.link_data_array(da, [0])
 
@@ -414,10 +414,10 @@ class TestLinkDimension(unittest.TestCase):
     def test_write_linked_array_props(self):
         tickarray = self.block.create_data_array(
             "ticks3d", "array.dimension.ticks",
-            data=np.random.random((10, 5, 4))
+            data=np.random.random_sample((10, 5, 4))
         )
         tickarray.unit = "whatever"
-        ticks = np.cumsum(np.random.random(5))
+        ticks = np.cumsum(np.random.random_sample(5))
         tickarray[3, :, 1] = ticks
         tickarray.label = "DIMENSION LABEL"
         self.range_dim.link_data_array(tickarray, [3, -1, 1])
@@ -479,7 +479,7 @@ class TestLinkDimension(unittest.TestCase):
         assert "ticks" not in self.range_dim._h5group
 
         # replace with ticks
-        self.range_dim.ticks = np.cumsum(np.random.random(10))
+        self.range_dim.ticks = np.cumsum(np.random.random_sample(10))
         assert "link" not in self.range_dim._h5group
         assert "ticks" in self.range_dim._h5group
 

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -41,96 +41,96 @@ class TestDimension(unittest.TestCase):
         self.tmpdir.cleanup()
 
     def test_set_dimension(self):
-        assert(self.set_dim.index == 1)
-        assert(self.set_dim.dimension_type == nix.DimensionType.Set)
-        assert(self.array.dimensions[0].index == 1)
+        assert self.set_dim.index == 1
+        assert self.set_dim.dimension_type == nix.DimensionType.Set
+        assert self.array.dimensions[0].index == 1
 
-        assert(self.set_dim.labels == ())
+        assert self.set_dim.labels == ()
         self.set_dim.labels = test_labels
-        assert(self.set_dim.labels == test_labels)
+        assert self.set_dim.labels == test_labels
 
     def test_sample_dimension(self):
-        assert(self.sample_dim.index == 2)
-        assert(self.sample_dim.dimension_type == nix.DimensionType.Sample)
-        assert(self.array.dimensions[1].index == 2)
+        assert self.sample_dim.index == 2
+        assert self.sample_dim.dimension_type == nix.DimensionType.Sample
+        assert self.array.dimensions[1].index == 2
 
-        assert(self.sample_dim.label is None)
+        assert self.sample_dim.label is None
         self.sample_dim.label = test_label
-        assert(self.sample_dim.label == test_label)
+        assert self.sample_dim.label == test_label
         self.sample_dim.label = None
-        assert(self.sample_dim.label is None)
+        assert self.sample_dim.label is None
 
-        assert(self.sample_dim.unit is None)
+        assert self.sample_dim.unit is None
         self.sample_dim.unit = "mV"
-        assert(self.sample_dim.unit == "mV")
+        assert self.sample_dim.unit == "mV"
         self.sample_dim.unit = None
-        assert(self.sample_dim.unit is None)
+        assert self.sample_dim.unit is None
 
-        assert(self.sample_dim.sampling_interval == test_sampl)
+        assert self.sample_dim.sampling_interval == test_sampl
         self.sample_dim.sampling_interval = 1.123
-        assert(self.sample_dim.sampling_interval == 1.123)
+        assert self.sample_dim.sampling_interval == 1.123
 
-        assert(self.sample_dim.offset is None)
+        assert self.sample_dim.offset is None
         self.sample_dim.offset = 0.3
-        assert(self.sample_dim.offset == 0.3)
+        assert self.sample_dim.offset == 0.3
         self.sample_dim.offset = None
-        assert(self.sample_dim.offset is None)
+        assert self.sample_dim.offset is None
 
         self.sample_dim.sampling_interval = 2.
         self.sample_dim.offset = 3.
 
-        assert(self.sample_dim.index_of(3.14) == 0)
-        assert(self.sample_dim.index_of(23.) == 10)
-        assert(type(self.sample_dim.index_of(23.) == int))
+        assert self.sample_dim.index_of(3.14) == 0
+        assert self.sample_dim.index_of(23.) == 10
+        assert type(self.sample_dim.index_of(23.) == int)
 
-        assert(self.sample_dim.position_at(0) == 3.)
-        assert(self.sample_dim.position_at(200) == 200*2.+3.)
+        assert self.sample_dim.position_at(0) == 3.
+        assert self.sample_dim.position_at(200) == 200*2.+3.
 
-        assert(len(self.sample_dim.axis(10)) == 10)
-        assert(self.sample_dim.axis(10)[0] == 3.)
-        assert(self.sample_dim.axis(10)[-1] == 9*2.+3.)
+        assert len(self.sample_dim.axis(10)) == 10
+        assert self.sample_dim.axis(10)[0] == 3.
+        assert self.sample_dim.axis(10)[-1] == 9*2.+3.
 
-        assert(len(self.sample_dim.axis(10, 2)) == 10)
-        assert(self.sample_dim.axis(10, 2)[0] == 2 * 2. + 3.)
-        assert(self.sample_dim.axis(10, 2)[-1] == (9 + 2) * 2. + 3.)
+        assert len(self.sample_dim.axis(10, 2)) == 10
+        assert self.sample_dim.axis(10, 2)[0] == 2 * 2. + 3.
+        assert self.sample_dim.axis(10, 2)[-1] == (9 + 2) * 2. + 3.
 
     def test_range_dimension(self):
-        assert(self.range_dim.index == 3)
-        assert(self.range_dim.dimension_type == nix.DimensionType.Range)
-        assert(self.array.dimensions[2].index == 3)
+        assert self.range_dim.index == 3
+        assert self.range_dim.dimension_type == nix.DimensionType.Range
+        assert self.array.dimensions[2].index == 3
 
-        assert(self.range_dim.label is None)
+        assert self.range_dim.label is None
         self.range_dim.label = test_label
-        assert(self.range_dim.label == test_label)
+        assert self.range_dim.label == test_label
         self.range_dim.label = None
-        assert(self.range_dim.label is None)
+        assert self.range_dim.label is None
 
-        assert(self.range_dim.unit is None)
+        assert self.range_dim.unit is None
         self.range_dim.unit = "mV"
-        assert(self.range_dim.unit == "mV")
+        assert self.range_dim.unit == "mV"
         self.range_dim.unit = None
-        assert(self.range_dim.unit is None)
+        assert self.range_dim.unit is None
 
-        assert(self.range_dim.ticks == test_range)
+        assert self.range_dim.ticks == test_range
         other = tuple([i*3.14 for i in range(10)])
         self.range_dim.ticks = other
-        assert(self.range_dim.ticks == other)
+        assert self.range_dim.ticks == other
 
-        assert(self.range_dim.index_of(0.) == 0)
-        assert(self.range_dim.index_of(10.) == (np.floor(10./3.14)))
-        assert(self.range_dim.index_of(18.84) == 6)
-        assert(self.range_dim.index_of(28.26) == 9)
-        assert(self.range_dim.index_of(100.) == 9)
-        assert(self.range_dim.index_of(-100.) == 0)
+        assert self.range_dim.index_of(0.) == 0
+        assert self.range_dim.index_of(10.) == (np.floor(10./3.14))
+        assert self.range_dim.index_of(18.84) == 6
+        assert self.range_dim.index_of(28.26) == 9
+        assert self.range_dim.index_of(100.) == 9
+        assert self.range_dim.index_of(-100.) == 0
 
-        assert(self.range_dim.tick_at(0) == 0)
-        assert(self.range_dim.tick_at(9) == other[-1])
+        assert self.range_dim.tick_at(0) == 0
+        assert self.range_dim.tick_at(9) == other[-1]
         with self.assertRaises(IndexError):
             self.range_dim.tick_at(100)
 
-        assert(self.range_dim.axis(10) == other)
-        assert(self.range_dim.axis(2) == other[:2])
-        assert(self.range_dim.axis(2, 2) == other[2:4])
+        assert self.range_dim.axis(10) == other
+        assert self.range_dim.axis(2) == other[:2]
+        assert self.range_dim.axis(2, 2) == other[2:4]
         with self.assertRaises(IndexError):
             self.range_dim.axis(10, 2)
             self.range_dim.axis(100)

--- a/nixio/test/test_feature.py
+++ b/nixio/test/test_feature.py
@@ -48,34 +48,34 @@ class TestFeatures(unittest.TestCase):
         self.tmpdir.cleanup()
 
     def test_feature_eq(self):
-        assert(self.feature_1 == self.feature_1)
-        assert(not self.feature_1 == self.feature_2)
-        assert(self.feature_1 is not None)
+        assert self.feature_1 == self.feature_1
+        assert not self.feature_1 == self.feature_2
+        assert self.feature_1 is not None
 
     def test_feature_id(self):
-        assert(self.feature_1.id is not None)
+        assert self.feature_1.id is not None
 
     def test_feature_link_type(self):
         def set_none():
             self.feature_1.link_type = None
 
-        assert(self.feature_1.link_type is not None)
+        assert self.feature_1.link_type is not None
         self.assertRaises(Exception, set_none)
 
         self.feature_1.link_type = nix.LinkType.Untagged
-        assert(self.feature_1.link_type == nix.LinkType.Untagged)
+        assert self.feature_1.link_type == nix.LinkType.Untagged
 
     def test_feature_data(self):
         def set_none():
             self.feature_1.data = None
 
-        assert(self.feature_1.data is not None)
+        assert self.feature_1.data is not None
         self.assertRaises(Exception, set_none)
 
         new_data_ref = self.block.create_data_array("test", "current",
                                                     nix.DataType.Float, (0, ))
         self.feature_1.data = new_data_ref
-        assert(self.feature_1.data == new_data_ref)
+        assert self.feature_1.data == new_data_ref
 
     def test_feature_dataframe(self):
         coltypes = OrderedDict(

--- a/nixio/test/test_file.py
+++ b/nixio/test/test_file.py
@@ -229,8 +229,8 @@ class TestFileVer(unittest.TestCase):
     fformat = filepy.FILE_FORMAT
 
     def try_open(self, mode):
-        f = nix.File.open(self.testfilename, mode)
-        f.close()
+        nix_file = nix.File.open(self.testfilename, mode)
+        nix_file.close()
 
     def set_header(self, fformat=None, version=None, fileid=None):
         if fformat is None:
@@ -263,28 +263,28 @@ class TestFileVer(unittest.TestCase):
         self.try_open(nix.FileMode.ReadWrite)
 
     def test_read_only(self):
-        vx, vy, vz = self.filever
-        roversion = (vx, vy, vz+2)
+        ver_x, ver_y, ver_z = self.filever
+        roversion = (ver_x, ver_y, ver_z+2)
         self.set_header(version=roversion)
         self.try_open(nix.FileMode.ReadOnly)
         with self.assertRaises(RuntimeError):
             self.try_open(nix.FileMode.ReadWrite)
 
     def test_no_open(self):
-        vx, vy, vz = self.filever
-        noversion = (vx, vy+3, vz+2)
+        ver_x, ver_y, ver_z = self.filever
+        noversion = (ver_x, ver_y+3, ver_z+2)
         self.set_header(version=noversion)
         with self.assertRaises(RuntimeError):
             self.try_open(nix.FileMode.ReadWrite)
         with self.assertRaises(RuntimeError):
             self.try_open(nix.FileMode.ReadOnly)
-        noversion = (vx, vy+1, vz)
+        noversion = (ver_x, ver_y+1, ver_z)
         self.set_header(version=noversion)
         with self.assertRaises(RuntimeError):
             self.try_open(nix.FileMode.ReadWrite)
         with self.assertRaises(RuntimeError):
             self.try_open(nix.FileMode.ReadOnly)
-        noversion = (vx+1, vy, vz)
+        noversion = (ver_x+1, ver_y, ver_z)
         self.set_header(version=noversion)
         with self.assertRaises(RuntimeError):
             self.try_open(nix.FileMode.ReadWrite)

--- a/nixio/test/test_file.py
+++ b/nixio/test/test_file.py
@@ -30,54 +30,54 @@ class TestFile(unittest.TestCase):
         self.tmpdir.cleanup()
 
     def test_file_format(self):
-        assert(self.file.format == "nix")
-        assert(self.file.version == filepy.HDF_FF_VERSION)
+        assert self.file.format == "nix"
+        assert self.file.version == filepy.HDF_FF_VERSION
 
     def test_file_timestamps(self):
         created_at = self.file.created_at
-        assert(created_at > 0)
+        assert created_at > 0
 
         updated_at = self.file.updated_at
-        assert(updated_at > 0)
+        assert updated_at > 0
 
         self.file.force_created_at(1403530068)
-        assert(self.file.created_at == 1403530068)
+        assert self.file.created_at == 1403530068
 
     def test_file_blocks(self):
-        assert(len(self.file.blocks) == 0)
+        assert len(self.file.blocks) == 0
 
         block = self.file.create_block("test block", "recordingsession")
 
-        assert(len(self.file.blocks) == 1)
+        assert len(self.file.blocks) == 1
 
-        assert(block in self.file.blocks)
-        assert(block.id in self.file.blocks)
-        assert("notexist" not in self.file.blocks)
+        assert block in self.file.blocks
+        assert block.id in self.file.blocks
+        assert "notexist" not in self.file.blocks
 
-        assert(block.id == self.file.blocks[0].id)
-        assert(block.id == self.file.blocks[-1].id)
+        assert block.id == self.file.blocks[0].id
+        assert block.id == self.file.blocks[-1].id
 
         del self.file.blocks[0]
 
-        assert(len(self.file.blocks) == 0)
+        assert len(self.file.blocks) == 0
 
     def test_file_sections(self):
-        assert(len(self.file.sections) == 0)
+        assert len(self.file.sections) == 0
 
         section = self.file.create_section("test section", "recordingsession")
 
-        assert(len(self.file.sections) == 1)
+        assert len(self.file.sections) == 1
 
-        assert(section in self.file.sections)
-        assert(section.id in self.file.sections)
-        assert("notexist" not in self.file.sections)
+        assert section in self.file.sections
+        assert section.id in self.file.sections
+        assert "notexist" not in self.file.sections
 
-        assert(section.id == self.file.sections[0].id)
-        assert(section.id == self.file.sections[-1].id)
+        assert section.id == self.file.sections[0].id
+        assert section.id == self.file.sections[-1].id
 
         del self.file.sections[0]
 
-        assert(len(self.file.sections) == 0)
+        assert len(self.file.sections) == 0
 
     def test_file_find_sections(self):
         for i in range(2):
@@ -93,8 +93,8 @@ class TestFile(unittest.TestCase):
                 "level3-p1-s" + str(i), "dummy"
             )
 
-        assert(len(self.file.find_sections()) == 8)
-        assert(len(self.file.find_sections(limit=1)) == 2)
+        assert len(self.file.find_sections()) == 8
+        assert len(self.file.find_sections(limit=1)) == 2
         assert(len(self.file.find_sections(filtr=lambda x: "level2-p1-s" in
                                                            x.name)) == 2)
         assert(len(self.file.find_sections(filtr=lambda x: "level2-p1-s" in

--- a/nixio/test/test_group.py
+++ b/nixio/test/test_group.py
@@ -43,47 +43,47 @@ class TestGroups(unittest.TestCase):
         self.tmpdir.cleanup()
 
     def test_group_eq(self):
-        assert(self.my_group == self.my_group)
-        assert(not self.my_group == self.your_group)
-        assert(self.my_group is not None)
+        assert self.my_group == self.my_group
+        assert not self.my_group == self.your_group
+        assert self.my_group is not None
 
     def test_group_id(self):
-        assert(self.my_group.id is not None)
+        assert self.my_group.id is not None
 
     def test_group_name(self):
-        assert(self.my_group.name is not None)
+        assert self.my_group.name is not None
 
     def test_group_type(self):
         def set_none():
             self.my_group.type = None
 
-        assert(self.my_group.type is not None)
+        assert self.my_group.type is not None
         self.assertRaises(Exception, set_none)
 
         self.my_group.type = "foo type"
-        assert(self.my_group.type == "foo type")
+        assert self.my_group.type == "foo type"
 
     def test_group_definition(self):
-        assert(self.my_group.definition is None)
+        assert self.my_group.definition is None
 
         self.my_group.definition = "definition"
-        assert(self.my_group.definition == "definition")
+        assert self.my_group.definition == "definition"
 
         self.my_group.definition = None
-        assert(self.my_group.definition is None)
+        assert self.my_group.definition is None
 
     def test_group_timestamps(self):
         created_at = self.my_group.created_at
-        assert(created_at > 0)
+        assert created_at > 0
 
         updated_at = self.my_group.updated_at
-        assert(updated_at > 0)
+        assert updated_at > 0
 
         self.my_group.force_created_at(1403530068)
-        assert(self.my_group.created_at == 1403530068)
+        assert self.my_group.created_at == 1403530068
 
     def test_group_data_arrays(self):
-        assert(len(self.my_group.data_arrays) == 1)
+        assert len(self.my_group.data_arrays) == 1
 
         self.assertRaises(TypeError, self.my_group.data_arrays.append, 100)
 
@@ -95,19 +95,19 @@ class TestGroups(unittest.TestCase):
         self.my_group.data_arrays.append(a1)
         self.my_group.data_arrays.append(a2)
 
-        assert(len(self.my_group.data_arrays) == 3)
-        assert(a1 in self.my_group.data_arrays)
-        assert(a2 in self.my_group.data_arrays)
+        assert len(self.my_group.data_arrays) == 3
+        assert a1 in self.my_group.data_arrays
+        assert a2 in self.my_group.data_arrays
 
         del self.my_group.data_arrays[a2]
-        assert(self.my_array in self.my_group.data_arrays)
-        assert(a1 in self.my_group.data_arrays)
+        assert self.my_array in self.my_group.data_arrays
+        assert a1 in self.my_group.data_arrays
 
         del self.my_group.data_arrays[a1]
-        assert(len(self.my_group.data_arrays) == 1)
+        assert len(self.my_group.data_arrays) == 1
 
     def test_group_tags(self):
-        assert(len(self.my_group.tags) == 1)
+        assert len(self.my_group.tags) == 1
 
         self.assertRaises(TypeError, self.my_group.tags.append, 100)
 
@@ -117,22 +117,22 @@ class TestGroups(unittest.TestCase):
         self.my_group.tags.append(t1)
         self.my_group.tags.append(t2)
 
-        assert(len(self.my_group.tags) == 3)
-        assert(t1 in self.my_group.tags)
-        assert(t2 in self.my_group.tags)
+        assert len(self.my_group.tags) == 3
+        assert t1 in self.my_group.tags
+        assert t2 in self.my_group.tags
 
         del self.my_group.tags[t2]
-        assert(self.my_tag in self.my_group.tags)
-        assert(t1 in self.my_group.tags)
+        assert self.my_tag in self.my_group.tags
+        assert t1 in self.my_group.tags
 
         del self.my_group.tags[t1]
-        assert(len(self.my_group.tags) == 1)
+        assert len(self.my_group.tags) == 1
 
         self.my_group.tags.extend([t1, t2])
-        assert(len(self.my_group.tags) == 3)
+        assert len(self.my_group.tags) == 3
 
     def test_group_multi_tags(self):
-        assert(len(self.my_group.multi_tags) == 1)
+        assert len(self.my_group.multi_tags) == 1
 
         self.assertRaises(TypeError, self.my_group.multi_tags.append, 100)
 
@@ -142,19 +142,19 @@ class TestGroups(unittest.TestCase):
         self.my_group.multi_tags.append(mt1)
         self.my_group.multi_tags.append(mt2)
 
-        assert(len(self.my_group.multi_tags) == 3)
-        assert(mt1 in self.my_group.multi_tags)
-        assert(mt2 in self.my_group.multi_tags)
+        assert len(self.my_group.multi_tags) == 3
+        assert mt1 in self.my_group.multi_tags
+        assert mt2 in self.my_group.multi_tags
 
         del self.my_group.multi_tags[mt2]
-        assert(self.my_multiTag in self.my_group.multi_tags)
-        assert(mt1 in self.my_group.multi_tags)
+        assert self.my_multiTag in self.my_group.multi_tags
+        assert mt1 in self.my_group.multi_tags
 
         del self.my_group.multi_tags[mt1]
-        assert(len(self.my_group.multi_tags) == 1)
+        assert len(self.my_group.multi_tags) == 1
 
         self.my_group.multi_tags.extend([mt1, mt2])
-        assert(len(self.my_group.multi_tags) == 3)
+        assert len(self.my_group.multi_tags) == 3
 
     def test_group_get_by_name(self):
         for idx in range(3):
@@ -179,7 +179,7 @@ class TestGroups(unittest.TestCase):
             assert(self.block.multi_tags[name].id ==
                    self.my_group.multi_tags[name].id)
         for name in tg_names:
-            assert(self.block.tags[name].id == self.my_group.tags[name].id)
+            assert self.block.tags[name].id == self.my_group.tags[name].id
 
     def test_group_invalid_add(self):
         da = self.block.data_arrays[0]

--- a/nixio/test/test_group.py
+++ b/nixio/test/test_group.py
@@ -24,12 +24,11 @@ class TestGroups(unittest.TestCase):
                                                      nix.DataType.Int16, (1, ))
         self.my_tag = self.block.create_tag("my tag", "test", [0.25])
         self.my_group = self.block.create_group("my group", "group")
-        self.my_multiTag = self.block.create_multi_tag("my_mt", "test",
-                                                       self.my_array)
+        self.my_multi_tag = self.block.create_multi_tag("my_mt", "test", self.my_array)
 
         self.my_group.data_arrays.append(self.my_array)
         self.my_group.tags.append(self.my_tag)
-        self.my_group.multi_tags.append(self.my_multiTag)
+        self.my_group.multi_tags.append(self.my_multi_tag)
 
         self.your_array = self.block.create_data_array("your array", "test",
                                                        nix.DataType.Int16,
@@ -87,23 +86,23 @@ class TestGroups(unittest.TestCase):
 
         self.assertRaises(TypeError, self.my_group.data_arrays.append, 100)
 
-        a1 = self.block.create_data_array("reference1", "stimuli",
-                                          nix.DataType.Int16, (1, ))
-        a2 = self.block.create_data_array("reference2", "stimuli",
-                                          nix.DataType.Int16, (1, ))
+        da1 = self.block.create_data_array("reference1", "stimuli",
+                                           nix.DataType.Int16, (1, ))
+        da2 = self.block.create_data_array("reference2", "stimuli",
+                                           nix.DataType.Int16, (1, ))
 
-        self.my_group.data_arrays.append(a1)
-        self.my_group.data_arrays.append(a2)
+        self.my_group.data_arrays.append(da1)
+        self.my_group.data_arrays.append(da2)
 
         assert len(self.my_group.data_arrays) == 3
-        assert a1 in self.my_group.data_arrays
-        assert a2 in self.my_group.data_arrays
+        assert da1 in self.my_group.data_arrays
+        assert da2 in self.my_group.data_arrays
 
-        del self.my_group.data_arrays[a2]
+        del self.my_group.data_arrays[da2]
         assert self.my_array in self.my_group.data_arrays
-        assert a1 in self.my_group.data_arrays
+        assert da1 in self.my_group.data_arrays
 
-        del self.my_group.data_arrays[a1]
+        del self.my_group.data_arrays[da1]
         assert len(self.my_group.data_arrays) == 1
 
     def test_group_tags(self):
@@ -111,24 +110,24 @@ class TestGroups(unittest.TestCase):
 
         self.assertRaises(TypeError, self.my_group.tags.append, 100)
 
-        t1 = self.block.create_tag("tag1", "stimuli", [1.0])
-        t2 = self.block.create_tag("tag2", "stimuli", [2.])
+        tag1 = self.block.create_tag("tag1", "stimuli", [1.0])
+        tag2 = self.block.create_tag("tag2", "stimuli", [2.])
 
-        self.my_group.tags.append(t1)
-        self.my_group.tags.append(t2)
+        self.my_group.tags.append(tag1)
+        self.my_group.tags.append(tag2)
 
         assert len(self.my_group.tags) == 3
-        assert t1 in self.my_group.tags
-        assert t2 in self.my_group.tags
+        assert tag1 in self.my_group.tags
+        assert tag2 in self.my_group.tags
 
-        del self.my_group.tags[t2]
+        del self.my_group.tags[tag2]
         assert self.my_tag in self.my_group.tags
-        assert t1 in self.my_group.tags
+        assert tag1 in self.my_group.tags
 
-        del self.my_group.tags[t1]
+        del self.my_group.tags[tag1]
         assert len(self.my_group.tags) == 1
 
-        self.my_group.tags.extend([t1, t2])
+        self.my_group.tags.extend([tag1, tag2])
         assert len(self.my_group.tags) == 3
 
     def test_group_multi_tags(self):
@@ -147,7 +146,7 @@ class TestGroups(unittest.TestCase):
         assert mt2 in self.my_group.multi_tags
 
         del self.my_group.multi_tags[mt2]
-        assert self.my_multiTag in self.my_group.multi_tags
+        assert self.my_multi_tag in self.my_group.multi_tags
         assert mt1 in self.my_group.multi_tags
 
         del self.my_group.multi_tags[mt1]
@@ -165,12 +164,12 @@ class TestGroups(unittest.TestCase):
             mt = self.block.create_multi_tag("mt"+str(idx), "mt",
                                              da)
             self.my_group.multi_tags.append(mt)
-            tg = self.block.create_tag("tg"+str(idx), "tg", [0.3, 0.6])
-            self.my_group.tags.append(tg)
+            tag = self.block.create_tag("tg"+str(idx), "tg", [0.3, 0.6])
+            self.my_group.tags.append(tag)
 
         da_names = [da.name for da in self.my_group.data_arrays]
         mt_names = [mt.name for mt in self.my_group.multi_tags]
-        tg_names = [tg.name for tg in self.my_group.tags]
+        tg_names = [tag.name for tag in self.my_group.tags]
 
         for name in da_names:
             assert(self.block.data_arrays[name].id ==
@@ -184,13 +183,13 @@ class TestGroups(unittest.TestCase):
     def test_group_invalid_add(self):
         da = self.block.data_arrays[0]
         mt = self.block.multi_tags[0]
-        tg = self.block.tags[0]
+        tag = self.block.tags[0]
 
         newblock = self.file.create_block("second block", "block")
         newgroup = newblock.create_group("second block group", "group")
 
         self.assertRaises(RuntimeError, newgroup.data_arrays.append, da)
         self.assertRaises(RuntimeError, newgroup.multi_tags.append, mt)
-        self.assertRaises(RuntimeError, newgroup.tags.append, tg)
+        self.assertRaises(RuntimeError, newgroup.tags.append, tag)
 
         del self.file.blocks[newblock.id]

--- a/nixio/test/test_multi_tag.py
+++ b/nixio/test/test_multi_tag.py
@@ -371,11 +371,11 @@ class TestMultiTags(unittest.TestCase):
 
     def test_multi_tag_tagged_data(self):
         sample_iv = 0.001
-        x = np.arange(0, 10, sample_iv)
-        y = np.sin(2 * np.pi * x)
+        x_data = np.arange(0, 10, sample_iv)
+        y_data = np.sin(2 * np.pi * x_data)
 
         block = self.block
-        da = block.create_data_array("sin", "data", data=y)
+        da = block.create_data_array("sin", "data", data=y_data)
         da.unit = 'dB'
         dim = da.append_sampled_dimension(sample_iv)
         dim.unit = 's'
@@ -397,17 +397,17 @@ class TestMultiTags(unittest.TestCase):
         mtag.references.append(da)
 
         assert mtag.tagged_data(0, 0).shape == (2001,)
-        assert np.array_equal(y[:2001], mtag.tagged_data(0, 0)[:])
+        assert np.array_equal(y_data[:2001], mtag.tagged_data(0, 0)[:])
 
         # get by name
         data = mtag.tagged_data(0, da.name)
         assert data.shape == (2001,)
-        assert np.array_equal(y[:2001], data[:])
+        assert np.array_equal(y_data[:2001], data[:])
 
         # get by id
         data = mtag.tagged_data(0, da.id)
         assert data.shape == (2001,)
-        assert np.array_equal(y[:2001], data[:])
+        assert np.array_equal(y_data[:2001], data[:])
 
         # multi dimensional data
         sample_iv = 1.0

--- a/nixio/test/test_multi_tag.py
+++ b/nixio/test/test_multi_tag.py
@@ -19,7 +19,7 @@ from .tmp import TempDir
 class TestMultiTags(unittest.TestCase):
 
     def setUp(self):
-        iv = 1.0
+        interval = 1.0
         ticks = [1.2, 2.3, 3.4, 4.5, 6.7]
         unit = "ms"
 
@@ -59,7 +59,7 @@ class TestMultiTags(unittest.TestCase):
 
         set_dim = self.data_array.append_set_dimension()
         set_dim.labels = ["label_a", "label_b"]
-        sampled_dim = self.data_array.append_sampled_dimension(iv)
+        sampled_dim = self.data_array.append_sampled_dimension(interval)
         sampled_dim.unit = unit
         range_dim = self.data_array.append_range_dimension(ticks)
         range_dim.unit = unit
@@ -106,8 +106,8 @@ class TestMultiTags(unittest.TestCase):
         self.tmpdir.cleanup()
 
     def test_multi_tag_new_constructor(self):
-        pos = np.random.random((2, 3))
-        ext = np.random.random((2, 3))
+        pos = np.random.random_sample((2, 3))
+        ext = np.random.random_sample((2, 3))
         mt = self.block.create_multi_tag("conv_test", "test", pos, ext)
         np.testing.assert_almost_equal(pos, mt.positions[:])
         np.testing.assert_almost_equal(ext, mt.extents[:])
@@ -118,23 +118,23 @@ class TestMultiTags(unittest.TestCase):
         assert mt.extents.type == "test-extents"
         # test positions extents deleted if multitag creation failed
         pos = None
-        ext = np.random.random((2, 3))
+        ext = np.random.random_sample((2, 3))
         self.assertRaises(ValueError, self.block.create_multi_tag,
                           "err_test", "test", pos, ext)
         self.block.create_data_array("dup_test-"
                                      "positions", "test", data=[0])
-        pos = np.random.random((2, 3))
-        ext = np.random.random((2, 3))
+        pos = np.random.random_sample((2, 3))
+        ext = np.random.random_sample((2, 3))
         self.assertRaises(DuplicateName, self.block.create_multi_tag,
                           "dup_test", "test", pos, ext)
         del self.block.data_arrays["dup_test-positions"]
         self.block.create_data_array("dup_test2-"
                                      "extents", "test", data=[0])
-        pos = np.random.random((2, 3))
-        ext = np.random.random((2, 3))
+        pos = np.random.random_sample((2, 3))
+        ext = np.random.random_sample((2, 3))
         self.assertRaises(DuplicateName, self.block.create_multi_tag,
                           "dup_test2", "test", pos, ext)
-        pos = np.random.random((2, 3))
+        pos = np.random.random_sample((2, 3))
         ext = [None, None]
         self.assertRaises(TypeError, self.block.create_multi_tag,
                           "dup_test3", "test", pos, ext)
@@ -424,7 +424,7 @@ class TestMultiTags(unittest.TestCase):
         ext.append_set_dimension()
         ext.append_set_dimension()
         units = ["none", "ms", "ms"]
-        data = np.random.random((3, 10, 5))
+        data = np.random.random_sample((3, 10, 5))
         da = self.block.create_data_array("dimtest", "test",
                                           data=data)
         setdim = da.append_set_dimension()

--- a/nixio/test/test_nix_compatibility.py
+++ b/nixio/test/test_nix_compatibility.py
@@ -156,7 +156,7 @@ def test_tags(tmpdir, bindir):
     blk = nix_file.create_block("test_block", "blocktype")
     grp = blk.create_group("test_group", "grouptype")
     da1 = blk.create_data_array("feature_tag", "afea",
-                                data=np.random.random(20))
+                                data=np.random.random_sample(20))
 
     for idx in range(8):
         if idx == 2:
@@ -164,12 +164,12 @@ def test_tags(tmpdir, bindir):
                                  [0, 10, 10**2, 10**3, 10**4])
         else:
             tag = blk.create_tag("tag_" + str(idx), "atag",
-                                 np.random.random(idx*2))
+                                 np.random.random_sample(idx*2))
         tag.definition = "tag def " + str(idx)
         if idx == 2:
-            tag.extent = np.random.random(5)
+            tag.extent = np.random.random_sample(5)
         else:
-            tag.extent = np.random.random(idx*2)
+            tag.extent = np.random.random_sample(idx*2)
         if idx == 0:
             tag.units = ["V", "ms"]
         else:
@@ -197,26 +197,26 @@ def test_multi_tags(tmpdir, bindir):
     for idx in range(11):
         if idx == 5:
             posda = blk.create_data_array("pos_" + str(idx), "positions",
-                                          data=np.random.random((idx, idx)))
+                                          data=np.random.random_sample((idx, idx)))
             extda = blk.create_data_array("ext_" + str(idx), "extents",
-                                          data=np.random.random((idx, idx)))
+                                          data=np.random.random_sample((idx, idx)))
 
         else:
             posda = blk.create_data_array("pos_" + str(idx), "positions",
-                                          data=np.random.random(idx*10))
+                                          data=np.random.random_sample(idx*10))
             extda = blk.create_data_array("ext_" + str(idx), "extents",
-                                          data=np.random.random(idx*10))
+                                          data=np.random.random_sample(idx*10))
         mt = blk.create_multi_tag("mt_" + str(idx), "some multi tag", posda)
         if idx == 3:
             feada = blk.create_data_array("feature", "afea",
-                                          data=np.random.random(200))
+                                          data=np.random.random_sample(200))
             mt.create_feature(feada, nix.LinkType.Tagged)
 
         if idx != 1:
             mt.extents = extda
         if idx == 2:
             refda = blk.create_data_array("ref", "reference",
-                                          data=np.random.random(13))
+                                          data=np.random.random_sample(13))
             refda.append_range_dimension([0.1, 0.2, 0.3], "A", "s")
             mt.references.append(refda)
             mt.units = ["ms"]
@@ -240,9 +240,9 @@ def _test_sources(tmpdir):
     blk = nix_file.create_block("testblock", "sourcetest")
     grp = blk.create_group("testgroup", "sourcetest")
     da = blk.create_data_array("da", "sourcetest",
-                               data=np.random.random(10))
+                               data=np.random.random_sample(10))
     pos = blk.create_data_array("pos", "sourcetest",
-                                data=np.random.random(10))
+                                data=np.random.random_sample(10))
     mtag = blk.create_multi_tag("mtag", "sourcetest", pos)
     grp.data_arrays.append(da)
 
@@ -272,18 +272,18 @@ def _test_dimensions(tmpdir):
     blk = nix_file.create_block("testblock", "dimtest")
 
     da_set = blk.create_data_array("da with set", "datype",
-                                   data=np.random.random(20))
+                                   data=np.random.random_sample(20))
     da_set.append_set_dimension()
     da_set.dimensions[0].labels = ["label one", "label two"]
 
     da_range = blk.create_data_array("da with range", "datype",
-                                     data=np.random.random(12))
-    rngdim = da_range.append_range_dimension(np.random.random(12))
+                                     data=np.random.random_sample(12))
+    rngdim = da_range.append_range_dimension(np.random.random_sample(12))
     rngdim.label = "range dim label"
     rngdim.unit = "ms"
 
     da_sample = blk.create_data_array("da with sample", "datype",
-                                      data=np.random.random(10))
+                                      data=np.random.random_sample(10))
     smpldim = da_sample.append_sampled_dimension(0.3)
     smpldim.offset = 0.1
     smpldim.unit = "mV"
@@ -291,16 +291,16 @@ def _test_dimensions(tmpdir):
     da_sample.dimensions[0].label = "sample dim label"
 
     da_alias = blk.create_data_array("da with alias", "datype",
-                                     data=np.random.random(19))
+                                     data=np.random.random_sample(19))
     da_alias.unit = "F"
     da_alias.label = "fee fi fo fum"
     da_alias.append_alias_range_dimension()
 
     da_multi_dim = blk.create_data_array("da with multiple", "datype",
-                                         data=np.random.random(30))
+                                         data=np.random.random_sample(30))
     da_multi_dim.append_sampled_dimension(0.1)
     da_multi_dim.append_set_dimension()
-    da_multi_dim.append_range_dimension(np.random.random(10))
+    da_multi_dim.append_range_dimension(np.random.random_sample(10))
 
     nix_file.close()
     # validate(nixfilepath)
@@ -313,7 +313,7 @@ def _test_tag_features(tmpdir):
     blk = nix_file.create_block("testblock", "feattest")
     da_ref = blk.create_data_array("da for ref", "datype",
                                    nix.DataType.Double,
-                                   data=np.random.random(15))
+                                   data=np.random.random_sample(15))
     da_ref.append_sampled_dimension(0.2)
     tag_feat = blk.create_tag("tag for feat", "tagtype", [2])
     tag_feat.references.append(da_ref)
@@ -323,7 +323,7 @@ def _test_tag_features(tmpdir):
     for idx in range(6):
         da_feat = blk.create_data_array("da for feat " + str(idx),
                                         "datype", nix.DataType.Float,
-                                        data=np.random.random(12))
+                                        data=np.random.random_sample(12))
         da_feat.append_sampled_dimension(1.0)
         tag_feat.create_feature(da_feat, linktypes[idx % 3])
 
@@ -380,9 +380,9 @@ def test_multi_tag_features(tmpdir):
     event_labels = ["event 1", "event 2"]
     dim_labels = ["dim 0", "dim 1", "dim 2"]
     event_array = blk.create_data_array("positions", "test",
-                                        data=np.random.random((2, 3)))
+                                        data=np.random.random_sample((2, 3)))
     extent_array = blk.create_data_array("extents", "test",
-                                         data=np.random.random((2, 3)))
+                                         data=np.random.random_sample((2, 3)))
     extent_set_dim = extent_array.append_set_dimension()
     extent_set_dim.labels = event_labels
     extent_set_dim = extent_array.append_set_dimension()
@@ -392,7 +392,7 @@ def test_multi_tag_features(tmpdir):
                                        event_array)
     data_array = blk.create_data_array("featureTest", "test",
                                        nix.DataType.Double, (2, 10, 5))
-    data = np.random.random((2, 10, 5))
+    data = np.random.random_sample((2, 10, 5))
     data_array[:, :, :] = data
 
     feature_tag.extents = extent_array

--- a/nixio/test/test_property.py
+++ b/nixio/test/test_property.py
@@ -33,139 +33,139 @@ class TestProperties(unittest.TestCase):
         self.tmpdir.cleanup()
 
     def test_property_eq(self):
-        assert(self.prop == self.prop)
-        assert(not self.prop == self.other)
-        assert(self.prop is not None)
+        assert self.prop == self.prop
+        assert not self.prop == self.other
+        assert self.prop is not None
 
     def test_property_id(self):
-        assert(self.prop.id is not None)
+        assert self.prop.id is not None
 
         oid = "4a6e8483-0a9a-464d-bdd9-b39818334bcd"
         aprop = self.section.create_property("assign id", 0, oid)
-        assert (aprop.id == oid)
+        assert aprop.id == oid
 
         nonid = "I am not a proper uuid"
         noprop = self.section.create_property("invalid id", 0, nonid)
-        assert (noprop.id != nonid)
+        assert noprop.id != nonid
 
     def test_property_name(self):
-        assert(self.prop.name is not None)
+        assert self.prop.name is not None
 
     def test_property_definition(self):
-        assert(self.prop.definition is None)
+        assert self.prop.definition is None
 
         self.prop.definition = "definition"
-        assert(self.prop.definition == "definition")
+        assert self.prop.definition == "definition"
 
         self.prop.definition = None
-        assert(self.prop.definition is None)
+        assert self.prop.definition is None
         self.prop.definition = None
 
     def test_property_uncertainty(self):
-        assert(self.prop.uncertainty is None)
+        assert self.prop.uncertainty is None
 
         self.prop.uncertainty = 5
-        assert(self.prop.uncertainty == 5)
+        assert self.prop.uncertainty == 5
 
         self.prop.uncertainty = None
-        assert(self.prop.uncertainty is None)
+        assert self.prop.uncertainty is None
         self.prop.uncertainty = None
 
     def test_property_reference(self):
-        assert(self.prop.reference is None)
+        assert self.prop.reference is None
 
         self.prop.reference = "reference"
-        assert(self.prop.reference == "reference")
+        assert self.prop.reference == "reference"
 
         self.prop.reference = None
-        assert(self.prop.reference is None)
+        assert self.prop.reference is None
         self.prop.reference = None
 
     def test_property_dependency(self):
-        assert(self.prop.dependency is None)
+        assert self.prop.dependency is None
 
         self.prop.dependency = "dependency"
-        assert(self.prop.dependency == "dependency")
+        assert self.prop.dependency == "dependency"
 
         self.prop.dependency = None
-        assert(self.prop.dependency is None)
+        assert self.prop.dependency is None
         self.prop.dependency = None
 
     def test_property_dependency_value(self):
-        assert(self.prop.dependency_value is None)
+        assert self.prop.dependency_value is None
 
         self.prop.dependency_value = "dependency value"
-        assert(self.prop.dependency_value == "dependency value")
+        assert self.prop.dependency_value == "dependency value"
 
         self.prop.dependency_value = None
-        assert(self.prop.dependency_value is None)
+        assert self.prop.dependency_value is None
         self.prop.dependency_value = None
 
     def test_property_value_origin(self):
-        assert(self.prop.value_origin is None)
+        assert self.prop.value_origin is None
 
         self.prop.value_origin = "value origin"
-        assert(self.prop.value_origin == "value origin")
+        assert self.prop.value_origin == "value origin"
 
         self.prop.value_origin = None
-        assert(self.prop.value_origin is None)
+        assert self.prop.value_origin is None
         self.prop.value_origin = None
 
     def test_property_unit(self):
-        assert(self.prop.unit is None)
+        assert self.prop.unit is None
 
         self.prop.unit = "s"
-        assert(self.prop.unit == "s")
+        assert self.prop.unit == "s"
 
         self.prop.unit = None
-        assert(self.prop.unit is None)
+        assert self.prop.unit is None
         self.prop.unit = None
 
         # empty string units
         self.prop.unit = ""
-        assert(self.prop.unit is None)
+        assert self.prop.unit is None
         self.prop.unit = " "
-        assert(self.prop.unit is None)
+        assert self.prop.unit is None
 
         # non-si units
         self.prop.unit = "deg"
-        assert(self.prop.unit == "deg")
+        assert self.prop.unit == "deg"
         self.prop.unit = "mV/30"
-        assert(self.prop.unit == "mV/30")
+        assert self.prop.unit == "mV/30"
 
     def test_property_values(self):
         self.prop.values = [10]
 
-        assert (self.prop.data_type == nix.DataType.Int64)
-        assert(len(self.prop.values) == 1)
+        assert self.prop.data_type == nix.DataType.Int64
+        assert len(self.prop.values) == 1
 
-        assert(self.prop.values[0] == 10)
-        assert(10 in self.prop.values)
-        assert(12 not in self.prop.values)
-        assert(self.prop.values[0] != 42)
+        assert self.prop.values[0] == 10
+        assert 10 in self.prop.values
+        assert 12 not in self.prop.values
+        assert self.prop.values[0] != 42
 
         self.prop.delete_values()
-        assert(len(self.prop.values) == 0)
+        assert len(self.prop.values) == 0
 
         self.prop_s.values = ["foo", "bar"]
-        assert(self.prop_s.data_type == nix.DataType.String)
-        assert(len(self.prop_s.values) == 2)
+        assert self.prop_s.data_type == nix.DataType.String
+        assert len(self.prop_s.values) == 2
 
-        assert(self.prop_s.values[0] == "foo")
-        assert("foo" in self.prop_s.values)
-        assert(self.prop_s.values[0] != "bla")
-        assert("bla" not in self.prop_s.values)
+        assert self.prop_s.values[0] == "foo"
+        assert "foo" in self.prop_s.values
+        assert self.prop_s.values[0] != "bla"
+        assert "bla" not in self.prop_s.values
 
     def test_empties(self):
         self.prop.values = list()
-        assert(self.prop.values == tuple())  # comes back as tuple
+        assert self.prop.values == tuple()  # comes back as tuple
 
         self.prop.values = tuple()
-        assert(self.prop.values == tuple())
+        assert self.prop.values == tuple()
 
         self.prop_s.values = ""
-        assert(self.prop_s.values == tuple())
-        assert(self.prop_s.data_type == nix.DataType.String)
+        assert self.prop_s.values == tuple()
+        assert self.prop_s.data_type == nix.DataType.String
 
     def test_extend_values(self):
         values = (1, 2, 3)

--- a/nixio/test/test_section.py
+++ b/nixio/test/test_section.py
@@ -159,8 +159,8 @@ class TestSections(unittest.TestCase):
 
         assert len(self.section) == 1
 
-        for p in self.section:
-            assert p in self.section
+        for prop in self.section:
+            assert prop in self.section
 
         assert "test prop" in self.section
         assert "notexist" not in self.section
@@ -199,8 +199,7 @@ class TestSections(unittest.TestCase):
 
         self.section.props["cp_str"].values = "anotherstr"
 
-        res = [x in self.section for x in ['ep_str', 'ep_int', 'ep_float']]
-        assert all(res)
+        assert all([name in self.section for name in ['ep_str', 'ep_int', 'ep_float']])
 
         assert self.section['ep_str'] == 'str'
         assert self.section['ep_int'] == 23
@@ -212,9 +211,9 @@ class TestSections(unittest.TestCase):
 
         self.assertRaises(TypeError, create_hetero_section)
 
-        sections = [x.id for x in self.section]
-        for x in sections:
-            del self.section[x]
+        section_ids = [sec.id for sec in self.section]
+        for s_id in section_ids:
+            del self.section[s_id]
 
         assert len(self.section) == 0
 
@@ -290,13 +289,13 @@ class TestSections(unittest.TestCase):
 
         self.assertNotIn("PropOnSection", self.other)
         with self.assertRaises(KeyError):
-            self.other["PropOnSection"]
+            _ = self.other["PropOnSection"]
 
         self.other.link = self.section
 
         self.assertNotIn("PropOnSection", self.other)
         with self.assertRaises(KeyError):
-            self.other["PropOnSection"]
+            _ = self.other["PropOnSection"]
 
         inhpropnames = [p.name for p in self.other.inherited_properties()]
         self.assertIn("PropOnSection", inhpropnames)

--- a/nixio/test/test_section.py
+++ b/nixio/test/test_section.py
@@ -31,100 +31,100 @@ class TestSections(unittest.TestCase):
         self.tmpdir.cleanup()
 
     def test_section_eq(self):
-        assert(self.section == self.section)
-        assert(not self.section == self.other)
-        assert(self.section is not None)
+        assert self.section == self.section
+        assert not self.section == self.other
+        assert self.section is not None
 
     def test_section_id(self):
-        assert(self.section.id is not None)
+        assert self.section.id is not None
 
         # Check setting id on section via file create
         oid = "4a6e8483-0a9a-464d-bdd9-b39818334bcd"
         sec = self.file.create_section("assign id", "sec type", oid)
-        assert (sec.id == oid)
+        assert sec.id == oid
 
         nonid = "I am not a proper uuid"
         sec = self.file.create_section("invalid id", "sec type", nonid)
-        assert (sec.id != nonid)
+        assert sec.id != nonid
 
         # Check setting id on section via section create
         oid = "4a6e8483-0a9a-464d-bdd9-b39818334bcd"
         sub_sec = sec.create_section("assign id", "sec type", oid)
-        assert (sub_sec.id == oid)
+        assert sub_sec.id == oid
 
         nonid = "I am not a proper uuid"
         sub_sec = sec.create_section("invalid id", "sec type", nonid)
-        assert (sub_sec.id != nonid)
+        assert sub_sec.id != nonid
 
     def test_section_name(self):
-        assert(self.section.name is not None)
+        assert self.section.name is not None
 
     def test_section_type(self):
         def set_none():
             self.section.type = None
 
-        assert(self.section.type is not None)
+        assert self.section.type is not None
         self.assertRaises(Exception, set_none)
 
         self.section.type = "foo type"
-        assert(self.section.type == "foo type")
+        assert self.section.type == "foo type"
 
     def test_section_definition(self):
-        assert(self.section.definition is None)
+        assert self.section.definition is None
 
         self.section.definition = "definition"
-        assert(self.section.definition == "definition")
+        assert self.section.definition == "definition"
 
         self.section.definition = None
-        assert(self.section.definition is None)
+        assert self.section.definition is None
 
     def test_section_repository(self):
-        assert(self.section.repository is None)
+        assert self.section.repository is None
 
         self.section.repository = "repository"
-        assert(self.section.repository == "repository")
+        assert self.section.repository == "repository"
 
         self.section.repository = None
-        assert(self.section.repository is None)
+        assert self.section.repository is None
 
     def test_property_reference(self):
-        assert(self.section.reference is None)
+        assert self.section.reference is None
 
         self.section.reference = "reference"
-        assert(self.section.reference == "reference")
+        assert self.section.reference == "reference"
 
         self.section.reference = None
-        assert(self.section.reference is None)
+        assert self.section.reference is None
         self.section.reference = None
 
     def test_section_sections(self):
-        assert(len(self.section.sections) == 0)
+        assert len(self.section.sections) == 0
 
         child = self.section.create_section("test section", "electrode")
-        assert(child.parent == self.section)
+        assert child.parent == self.section
 
-        assert(len(self.section.sections) == 1)
+        assert len(self.section.sections) == 1
 
-        assert(child in self.section.sections)
-        assert(child.id in self.section.sections)
-        assert("notexist" not in self.section.sections)
+        assert child in self.section.sections
+        assert child.id in self.section.sections
+        assert "notexist" not in self.section.sections
 
-        assert(child.id == self.section.sections[0].id)
-        assert(child.id == self.section.sections[-1].id)
+        assert child.id == self.section.sections[0].id
+        assert child.id == self.section.sections[-1].id
 
         del self.section.sections[0]
 
-        assert(len(self.section.sections) == 0)
+        assert len(self.section.sections) == 0
 
         self.section['easy subsection'] = nix.S('electrode')
         subject = self.section['subject'] = nix.S('subject')
 
-        assert(self.section['subject'] == subject)
-        assert(self.section['subject'].id == subject.id)
+        assert self.section['subject'] == subject
+        assert self.section['subject'].id == subject.id
         assert('easy subsection' in
                [v.name for k, v in self.section.sections.items()])
-        assert('easy subsection' in self.section.sections)
-        assert(self.section['easy subsection'].name == 'easy subsection')
+        assert 'easy subsection' in self.section.sections
+        assert self.section['easy subsection'].name == 'easy subsection'
 
     def test_section_find_sections(self):
         for i in range(2):
@@ -140,8 +140,8 @@ class TestSections(unittest.TestCase):
                 "level3-p1-s" + str(i), "dummy"
             )
 
-        assert(len(self.section.find_sections()) == 9)
-        assert(len(self.section.find_sections(limit=1)) == 3)
+        assert len(self.section.find_sections()) == 9
+        assert len(self.section.find_sections(limit=1)) == 3
         assert(len(self.section.find_sections(
             filtr=lambda x: "level2-p1-s" in x.name)) == 2
                )
@@ -149,37 +149,37 @@ class TestSections(unittest.TestCase):
             filtr=lambda x: "level2-p1-s" in x.name, limit=1)) == 0
                )
 
-        assert(len(self.section.find_related()) == 3)
-        assert(len(self.section.sections[0].find_related()) == 5)
+        assert len(self.section.find_related()) == 3
+        assert len(self.section.sections[0].find_related()) == 5
 
     def test_section_properties(self):
-        assert(len(self.section) == 0)
+        assert len(self.section) == 0
 
         prop = self.section.create_property("test prop", nix.DataType.String)
 
-        assert(len(self.section) == 1)
+        assert len(self.section) == 1
 
         for p in self.section:
-            assert(p in self.section)
+            assert p in self.section
 
-        assert("test prop" in self.section)
-        assert("notexist" not in self.section)
-        assert(self.section["test prop"] is not None)
+        assert "test prop" in self.section
+        assert "notexist" not in self.section
+        assert self.section["test prop"] is not None
         # NOTE: the following raises KeyError: Do we want it to return None?
-        # assert(self.section["notexist"] is None)
+        # assert self.section["notexist"] is None
 
-        assert(len(self.section.inherited_properties()) == 1)
+        assert len(self.section.inherited_properties()) == 1
 
-        assert(prop in self.section)
-        assert(prop.id in self.section)
-        assert(prop.name in self.section)
-        assert("notexist" not in self.section)
+        assert prop in self.section
+        assert prop.id in self.section
+        assert prop.name in self.section
+        assert "notexist" not in self.section
 
         props = dict(self.section.items())
-        assert(props["test prop"] == prop)
+        assert props["test prop"] == prop
 
-        assert(prop.id == self.section.props[0].id)
-        assert(prop.id == self.section.props[-1].id)
+        assert prop.id == self.section.props[0].id
+        assert prop.id == self.section.props[-1].id
 
         # easy prop creation
         self.section['ep_str'] = 'str'
@@ -200,12 +200,12 @@ class TestSections(unittest.TestCase):
         self.section.props["cp_str"].values = "anotherstr"
 
         res = [x in self.section for x in ['ep_str', 'ep_int', 'ep_float']]
-        assert(all(res))
+        assert all(res)
 
-        assert(self.section['ep_str'] == 'str')
-        assert(self.section['ep_int'] == 23)
-        assert(self.section['ep_float'] == 42.0)
-        assert(self.section['ep_list'] == [1, 2, 3])
+        assert self.section['ep_str'] == 'str'
+        assert self.section['ep_int'] == 23
+        assert self.section['ep_float'] == 42.0
+        assert self.section['ep_list'] == [1, 2, 3]
 
         def create_hetero_section():
             self.section['ep_ex'] = [1, 1.0]
@@ -216,7 +216,7 @@ class TestSections(unittest.TestCase):
         for x in sections:
             del self.section[x]
 
-        assert(len(self.section) == 0)
+        assert len(self.section) == 0
 
     def test_parent(self):
         self.assertIs(self.section.parent, None)

--- a/nixio/test/test_source.py
+++ b/nixio/test/test_source.py
@@ -33,62 +33,62 @@ class TestSources(unittest.TestCase):
         self.tmpdir.cleanup()
 
     def test_source_eq(self):
-        assert(self.source == self.source)
-        assert(not self.source == self.other)
-        assert(self.source is not None)
+        assert self.source == self.source
+        assert not self.source == self.other
+        assert self.source is not None
 
     def test_source_id(self):
-        assert(self.source.id is not None)
+        assert self.source.id is not None
 
     def test_source_name(self):
-        assert(self.source.name is not None)
+        assert self.source.name is not None
 
     def test_source_type(self):
         def set_none():
             self.source.type = None
 
-        assert(self.source.type is not None)
+        assert self.source.type is not None
         self.assertRaises(Exception, set_none)
 
         self.source.type = "foo type"
-        assert(self.source.type == "foo type")
+        assert self.source.type == "foo type"
 
     def test_source_definition(self):
-        assert(self.source.definition is None)
+        assert self.source.definition is None
 
         self.source.definition = "definition"
-        assert(self.source.definition == "definition")
+        assert self.source.definition == "definition"
 
         self.source.definition = None
-        assert(self.source.definition is None)
+        assert self.source.definition is None
 
     def test_source_timestamps(self):
         created_at = self.source.created_at
-        assert(created_at > 0)
+        assert created_at > 0
 
         updated_at = self.source.updated_at
-        assert(updated_at > 0)
+        assert updated_at > 0
 
         self.source.force_created_at(1403530068)
-        assert(self.source.created_at == 1403530068)
+        assert self.source.created_at == 1403530068
 
     def test_source_sources(self):
-        assert(len(self.source.sources) == 0)
+        assert len(self.source.sources) == 0
 
         source = self.source.create_source("test source", "electrode")
 
-        assert(len(self.source.sources) == 1)
+        assert len(self.source.sources) == 1
 
-        assert(source in self.source.sources)
-        assert(source.id in self.source.sources)
-        assert("notexist" not in self.source.sources)
+        assert source in self.source.sources
+        assert source.id in self.source.sources
+        assert "notexist" not in self.source.sources
 
-        assert(source.id == self.source.sources[0].id)
-        assert(source.id == self.source.sources[-1].id)
+        assert source.id == self.source.sources[0].id
+        assert source.id == self.source.sources[-1].id
 
         del self.source.sources[0]
 
-        assert(len(self.source.sources) == 0)
+        assert len(self.source.sources) == 0
 
     def test_source_find_sources(self):
         for i in range(2):
@@ -104,8 +104,8 @@ class TestSources(unittest.TestCase):
                 "level3-p1-s" + str(i), "dummy"
             )
 
-        assert(len(self.source.find_sources()) == 9)
-        assert(len(self.source.find_sources(limit=1)) == 3)
+        assert len(self.source.find_sources()) == 9
+        assert len(self.source.find_sources(limit=1)) == 3
         assert(len(self.source.find_sources(filtr=lambda x:
                                             "level2-p1-s" in x.name)) == 2)
         assert(len(self.source.find_sources(filtr=lambda x:
@@ -113,14 +113,14 @@ class TestSources(unittest.TestCase):
                                             limit=1)) == 0)
 
     def test_sources_extend(self):
-        assert(len(self.array.sources) == 0)
+        assert len(self.array.sources) == 0
         self.array.sources.extend([self.source, self.other])
-        assert(len(self.array.sources) == 2)
+        assert len(self.array.sources) == 2
         with self.assertRaises(TypeError):
             self.array.sources.extend(self.third)
-        assert(len(self.array.sources) == 2)
+        assert len(self.array.sources) == 2
         self.array.sources.extend([self.third])
-        assert(len(self.array.sources) == 3)
+        assert len(self.array.sources) == 3
 
     def test_inverse_search(self):
         da_one = self.block.create_data_array("foo", "data_array",

--- a/nixio/test/test_tag.py
+++ b/nixio/test/test_tag.py
@@ -244,7 +244,7 @@ class TestTags(unittest.TestCase):
         pos = [0.0, 2.0, 3.4]
         ext = [0.0, 6.0, 2.3]
         units = ["none", "ms", "ms"]
-        data = np.random.random((2, 10, 5))
+        data = np.random.random_sample((2, 10, 5))
         da = self.block.create_data_array("dimtest", "test",
                                           data=data)
         setdim = da.append_set_dimension()

--- a/nixio/test/test_tag.py
+++ b/nixio/test/test_tag.py
@@ -65,8 +65,8 @@ class TestTags(unittest.TestCase):
         tag1d.references.extend([da1d, da2d, da3d])
         assert list(tag1d.references) == [da1d, da2d, da3d]
         ref1 = tag1d.tagged_data(1)  # 1d tag to 2d data
-        for (y, z) in zip(ref1[:].flatten(), da2d[1:3, :].flatten()):
-            assert y == z
+        for (ref_val, da_val) in zip(ref1[:].flatten(), da2d[1:3, :].flatten()):
+            assert ref_val == da_val
         tag2d.extent = [1, 2]
         tag2d.references.extend([da1d, da2d, da3d])
         tag2d.tagged_data(0)  # 2d tag to 1d data

--- a/nixio/test/test_util.py
+++ b/nixio/test/test_util.py
@@ -91,11 +91,11 @@ class TestUtil(unittest.TestCase):
         unit_2 = 'mV^2'
         unit_3 = 'Hz^-1'
 
-        p, u, po = units.split(unit_1)
-        assert p == 'k' and u == 'V' and po == ''
+        prefix, base, power = units.split(unit_1)
+        assert prefix == 'k' and base == 'V' and power == ''
 
-        p, u, po = units.split(unit_2)
-        assert p == 'm' and u == 'V' and po == '2'
+        prefix, base, power = units.split(unit_2)
+        assert prefix == 'm' and base == 'V' and power == '2'
 
-        p, u, po = units.split(unit_3)
-        assert p == '' and u == 'Hz' and po == '-1'
+        prefix, base, power = units.split(unit_3)
+        assert prefix == '' and base == 'Hz' and power == '-1'

--- a/nixio/test/test_util.py
+++ b/nixio/test/test_util.py
@@ -19,51 +19,51 @@ class TestUtil(unittest.TestCase):
         pass
 
     def test_name_sanitizer(self):
-        assert(names.sanitizer("validName") == "validName")
-        assert(names.sanitizer("invalid/name") == "invalid_name")
+        assert names.sanitizer("validName") == "validName"
+        assert names.sanitizer("invalid/name") == "invalid_name"
 
     def test_name_check(self):
-        assert(names.check("validName"))
-        assert(not names.check("invalid/name"))
+        assert names.check("validName")
+        assert not names.check("invalid/name")
 
     def test_unit_sanitizer(self):
-        assert(units.sanitizer("µV") == "uV")
-        assert(units.sanitizer("muOhm") == "uOhm")
+        assert units.sanitizer("µV") == "uV"
+        assert units.sanitizer("muOhm") == "uOhm"
 
     def test_unit_is_si(self):
-        assert(units.is_si('V'))
-        assert(units.is_si('mV'))
-        assert(units.is_si('kV'))
-        assert(not units.is_si('Kv'))
-        assert(not units.is_si('in'))
-        assert(not units.is_si('pt'))
-        assert(not units.is_si('ft'))
-        assert(not units.is_si('yrd'))
+        assert units.is_si('V')
+        assert units.is_si('mV')
+        assert units.is_si('kV')
+        assert not units.is_si('Kv')
+        assert not units.is_si('in')
+        assert not units.is_si('pt')
+        assert not units.is_si('ft')
+        assert not units.is_si('yrd')
 
     def test_unit_is_atomic(self):
-        assert(units.is_atomic('mV'))
-        assert(units.is_atomic('mV^2'))
-        assert(not units.is_atomic('mV^2/Hz'))
+        assert units.is_atomic('mV')
+        assert units.is_atomic('mV^2')
+        assert not units.is_atomic('mV^2/Hz')
 
     def test_unit_is_compound(self):
-        assert(units.is_compound('mV^2/Hz'))
-        assert(not units.is_compound('mV'))
+        assert units.is_compound('mV^2/Hz')
+        assert not units.is_compound('mV')
 
     def test_unit_split_compound(self):
         unit_1 = "mV^2/Hz"
         unit_2 = "mV^2 * Hz^-1"
 
-        assert(len(units.split_compound('mV')) == 1)
+        assert len(units.split_compound('mV')) == 1
 
         atomics = units.split_compound(unit_1)
-        assert(len(atomics) == 2)
+        assert len(atomics) == 2
         # FIXME the following is not entirely correct should be Hz^-1
         # needs to be fixed in nix!
-        assert(atomics[0] == "mV^2" and atomics[1] == "Hz^-1")
+        assert atomics[0] == "mV^2" and atomics[1] == "Hz^-1"
 
         atomics = units.split_compound(unit_2)
-        assert(len(atomics) == 2)
-        assert(atomics[0] == "mV^2" and atomics[1] == "Hz^-1")
+        assert len(atomics) == 2
+        assert atomics[0] == "mV^2" and atomics[1] == "Hz^-1"
 
     def test_unit_scalable(self):
         base_unit = 'V'
@@ -71,10 +71,10 @@ class TestUtil(unittest.TestCase):
         scalable_2 = 'uV'
         inscalable = 'g'
 
-        assert(units.scalable([base_unit], [scalable_1]))
-        assert(units.scalable([base_unit], [scalable_2]))
-        assert(units.scalable([base_unit], [base_unit]))
-        assert(not units.scalable([base_unit], [inscalable]))
+        assert units.scalable([base_unit], [scalable_1])
+        assert units.scalable([base_unit], [scalable_2])
+        assert units.scalable([base_unit], [base_unit])
+        assert not units.scalable([base_unit], [inscalable])
         assert(units.scalable([base_unit, scalable_1],
                               [base_unit, scalable_2]))
 
@@ -83,8 +83,8 @@ class TestUtil(unittest.TestCase):
         scalable_1 = 'kV'
         scalable_2 = 'uV'
 
-        assert(units.scaling(base_unit, scalable_1) == 1e-03)
-        assert(units.scaling(base_unit, scalable_2) == 1e06)
+        assert units.scaling(base_unit, scalable_1) == 1e-03
+        assert units.scaling(base_unit, scalable_2) == 1e06
 
     def test_unit_split(self):
         unit_1 = 'kV'
@@ -92,10 +92,10 @@ class TestUtil(unittest.TestCase):
         unit_3 = 'Hz^-1'
 
         p, u, po = units.split(unit_1)
-        assert(p == 'k' and u == 'V' and po == '')
+        assert p == 'k' and u == 'V' and po == ''
 
         p, u, po = units.split(unit_2)
-        assert(p == 'm' and u == 'V' and po == '2')
+        assert p == 'm' and u == 'V' and po == '2'
 
         p, u, po = units.split(unit_3)
-        assert(p == '' and u == 'Hz' and po == '-1')
+        assert p == '' and u == 'Hz' and po == '-1'

--- a/nixio/test/test_validator.py
+++ b/nixio/test/test_validator.py
@@ -29,14 +29,14 @@ class TestValidate (unittest.TestCase):
             da1d = blk.create_data_array("data-1d",
                                          "validation-test.data_array",
                                          dtype=nix.DataType.Float,
-                                         data=np.random.random(5))
+                                         data=np.random.random_sample(5))
             rdim = da1d.append_range_dimension(ticks=[0.1, 0.2, 1.5, 2.4, 3.0])
             rdim.unit = "ms"
 
             da2d = blk.create_data_array("data-2d",
                                          "validation-test.data_array",
                                          dtype=nix.DataType.Float,
-                                         data=np.random.random((2, 10)))
+                                         data=np.random.random_sample((2, 10)))
             setdim = da2d.append_set_dimension()
             setdim.labels = ("A", "B")
             da2d.append_sampled_dimension(0.1)
@@ -44,7 +44,7 @@ class TestValidate (unittest.TestCase):
             da3d = blk.create_data_array("data-3d",
                                          "validation-test.data_array",
                                          dtype=nix.DataType.Float,
-                                         data=np.random.random((4, 2, 10)))
+                                         data=np.random.random_sample((4, 2, 10)))
             setdim = da3d.append_set_dimension()
             setdim.labels = ("1", "2", "3", "4")
             da3d.append_set_dimension()  # set dim without labels

--- a/nixio/test/xcompat/compile.py
+++ b/nixio/test/xcompat/compile.py
@@ -21,10 +21,10 @@ if platform.platform().startswith("Windows"):
     WINDOWS = True
 
 
-def cc(filenames, dest,
-       library_dirs=None, include_dirs=None,
-       libraries=None, compile_args=None,
-       runtime_lib_dirs=None):
+def ccomp(filenames, destination,
+          library_dirs=None, include_dirs=None,
+          libraries=None, compile_args=None,
+          runtime_lib_dirs=None):
     compiler = ccompiler.new_compiler()
 
     distutils.sysconfig.customize_compiler(compiler)
@@ -38,12 +38,12 @@ def cc(filenames, dest,
         compiler.set_runtime_library_dirs(runtime_lib_dirs)
 
     try:
-        objnames = compiler.compile(filenames, output_dir=dest,
+        objnames = compiler.compile(filenames, output_dir=destination,
                                     extra_postargs=compile_args)
         for obj in objnames:
             execname, _ = os.path.splitext(obj)
             compiler.link_executable(
-                [obj], execname, output_dir=dest,
+                [obj], execname, output_dir=destination,
                 target_lang="c++",
             )
     except (CompileError, LinkError):
@@ -51,7 +51,7 @@ def cc(filenames, dest,
     return True
 
 
-def maketests(dest):
+def maketests(destination):
     scriptloc, _ = os.path.split(os.path.abspath(__file__))
     os.chdir(scriptloc)
     filenames = glob("*.cpp")
@@ -66,7 +66,7 @@ def maketests(dest):
                     "/usr/include/nixio-1.0", "/usr/local/include/nixio-1.0",
                     "src"]
     incenv = os.getenv("NIX_INCDIR", None)
-    if incenv:
+    if incenv and libenv:
         include_dirs.append(libenv)
 
     boost_libenv = os.getenv("BOOST_LIBDIR", None)
@@ -86,12 +86,12 @@ def maketests(dest):
         compile_args = []
 
     print("Compiling {}".format(" ".join(filenames)))
-    success = cc(filenames, dest,
-                 library_dirs=library_dirs,
-                 include_dirs=include_dirs,
-                 libraries=libraries,
-                 compile_args=compile_args,
-                 runtime_lib_dirs=runtime_dirs)
+    success = ccomp(filenames, destination,
+                    library_dirs=library_dirs,
+                    include_dirs=include_dirs,
+                    libraries=libraries,
+                    compile_args=compile_args,
+                    runtime_lib_dirs=runtime_dirs)
     if success:
         print("Done")
     else:

--- a/nixio/util/find.py
+++ b/nixio/util/find.py
@@ -37,14 +37,14 @@ def _find_sources(with_sources, filtr, limit):
         fifo += [Cont(e, level) for e in with_sources.sources]
 
     while len(fifo) > 0:
-        c = fifo.pop(0)
+        child = fifo.pop(0)
 
-        level = c.level + 1
+        level = child.level + 1
         if level <= limit:
-            fifo += [Cont(e, level) for e in c.elem.sources]
+            fifo += [Cont(e, level) for e in child.elem.sources]
 
-        if filtr(c.elem):
-            result.append(c.elem)
+        if filtr(child.elem):
+            result.append(child.elem)
 
     return result
 
@@ -66,13 +66,13 @@ def _find_sections(with_sections, filtr, limit):
         fifo += [Cont(e, level) for e in with_sections.sections]
 
     while len(fifo) > 0:
-        c = fifo.pop(0)
+        child = fifo.pop(0)
 
-        level = c.level + 1
+        level = child.level + 1
         if level <= limit:
-            fifo += [Cont(e, level) for e in c.elem.sections]
+            fifo += [Cont(e, level) for e in child.elem.sections]
 
-        if filtr(c.elem):
-            result.append(c.elem)
+        if filtr(child.elem):
+            result.append(child.elem)
 
     return result

--- a/nixio/util/units.py
+++ b/nixio/util/units.py
@@ -112,7 +112,7 @@ def is_compound(unit):
     return unit and compound_unit.search(unit)
 
 
-def scalable(unit_a, unit_b):
+def scalable(units_a, units_b):
     """
     Checks whether units are scalable versions of the same SI unit.
     Method works on two lists and compares the corresponding units in both
@@ -124,21 +124,21 @@ def scalable(unit_a, unit_b):
     :returns: True if all corresponding units are scalable.
     :rtype: bool
     """
-    if (isinstance(unit_a, Sequence) and isinstance(unit_b, Sequence) and
-            not isinstance(unit_a, string_types) and
-            not isinstance(unit_b, string_types)):
-        if len(unit_a) != len(unit_b):
+    if (isinstance(units_a, Sequence) and isinstance(units_b, Sequence) and
+            not isinstance(units_a, string_types) and
+            not isinstance(units_b, string_types)):
+        if len(units_a) != len(units_b):
             return False
-        for a, b in zip(unit_a, unit_b):
-            if not scalable(a, b):
+        for unit_a, unit_b in zip(units_a, units_b):
+            if not scalable(unit_a, unit_b):
                 return False
         return True
 
-    if not (is_si(unit_a) and is_si(unit_b)):
+    if not (is_si(units_a) and is_si(units_b)):
         return False
 
-    _, a_unit, a_power = split(unit_a)
-    _, b_unit, b_power = split(unit_b)
+    _, a_unit, a_power = split(units_a)
+    _, b_unit, b_power = split(units_b)
     if a_unit != b_unit or a_power != b_power:
         return False
 
@@ -195,8 +195,8 @@ def split(combined_unit):
     unit_re = "(?P<unit>{})".format(UNITS)
     power_re = "(?P<power>{})".format(POWER)
     pup = re.compile(prefix_re + unit_re + power_re)
-    pu = re.compile(prefix_re + unit_re)
-    up = re.compile(unit_re + power_re)
+    prefix_matcher = re.compile(prefix_re + unit_re)
+    unit_matcher = re.compile(unit_re + power_re)
     # u = re.compile(unit_re)
     # p = re.compile(prefix_re)
 
@@ -207,14 +207,14 @@ def split(combined_unit):
         power = match.group("power")[1:]
         return prefix, unit, power
 
-    match = up.match(combined_unit)
+    match = unit_matcher.match(combined_unit)
     if match:
         prefix = ""
         unit = match.group("unit")
         power = match.group("power")[1:]
         return prefix, unit, power
 
-    match = pu.match(combined_unit)
+    match = prefix_matcher.match(combined_unit)
     if match:
         prefix = match.group("prefix")
         unit = match.group("unit")

--- a/nixio/util/util.py
+++ b/nixio/util/util.py
@@ -29,9 +29,9 @@ def create_id():
     return str(uuid4())
 
 
-def is_uuid(id_):
+def is_uuid(id_str):
     try:
-        UUID(str(id_))
+        UUID(str(id_str))
         return True
     except ValueError:
         return False
@@ -87,20 +87,20 @@ def now_int():
     return int(now.total_seconds())
 
 
-def time_to_str(t):
+def time_to_str(time):
     """
     Returns the time represented by the parameter in the format of Boost's
     posix time `to_iso_string` function.
 
-    :param t: integer POSIX time
+    :param time: integer POSIX time
     :return: string in the form "YYYYMMDDTHHMMSS", where T is the date-time
     separator
     """
-    dt = datetime.utcfromtimestamp(t)
+    dt = datetime.utcfromtimestamp(time)
     return dt.strftime("%Y%m%dT%H%M%S").encode("utf-8")
 
 
-def str_to_time(s):
+def str_to_time(time_str):
     """
     Returns the POSIX time represented by the given string as an integer.
 
@@ -108,9 +108,9 @@ def str_to_time(s):
     separator
     :return: integer POSIX time
     """
-    if isinstance(s, bytes):
-        s = s.decode()
-    dt = datetime.strptime(s, "%Y%m%dT%H%M%S") - datetime(1970, 1, 1)
+    if isinstance(time_str, bytes):
+        time_str = time_str.decode()
+    dt = datetime.strptime(time_str, "%Y%m%dT%H%M%S") - datetime(1970, 1, 1)
     return int(dt.total_seconds())
 
 

--- a/nixio/validator.py
+++ b/nixio/validator.py
@@ -237,11 +237,7 @@ def check_data_array(da):
             if dim.labels and len(dim.labels) != datalen:
                 # empty labels is allowed
                 errors.append(ValidationError.SetDimLabelsMismatch.format(idx))
-            dim_errors, dim_warnings = check_set_dimension(dim, idx)
-        elif dim.dimension_type == DimensionType.DataFrame:
-            df_len = dim.data_frame.row_count()
-            if df_len != da.shape[0]:
-                dim_errors, dim_warnings = check_df_dimension(dim, idx)
+            dim_errors, dim_warnings = check_set_dimension()
         errors.extend(dim_errors)
         warnings.extend(dim_warnings)
     return errors, warnings
@@ -430,7 +426,7 @@ def check_range_dimension(dim, idx):
     return errors, warnings
 
 
-def check_set_dimension(dim, idx):
+def check_set_dimension():
     """
     Validate a SetDimension and return all errors and warnings.
 
@@ -493,10 +489,10 @@ def get_dim_units(data_array):
 
 
 def tag_units_match_refs_units(tag_units, refs_units):
-    for ref in refs_units:
-        for ru, tu in zip(tag_units, ref):
-            if ru == "" and tu == "":
+    for ref_units in refs_units:
+        for tag_unit, ref_unit in zip(tag_units, ref_units):
+            if tag_unit == "" and ref_unit == "":
                 continue
-            if not units.scalable(ru, tu):
+            if not units.scalable(tag_unit, ref_unit):
                 return False
     return True


### PR DESCRIPTION
Added a pylintrc file with the error/warning codes listed in #472 and addressed all the issues it produced.

- Some codes were disabled because they require large code restructuring to be addressed (opened issue #488).
- Some common "bad" names were added to the list of good names, like `da` for DataArray and `mt` for MultiTag.

Closes #472 