### PR TITLE
DataFrame string columns

### DIFF
--- a/nixio/block.py
+++ b/nixio/block.py
@@ -334,11 +334,11 @@ class Block(Entity):
             else:  # if col_names is None
                 if data is not None and type(data[0]) == np.void:
                     col_dtype = data[0].dtype
-                    col_name = list(col_dtype.fields.keys())
+                    col_names = list(col_dtype.fields.keys())
                     raw_dt = col_dtype.fields.values()
                     raw_dt = list(raw_dt)
                     raw_dt_list = [ele[0] for ele in raw_dt]
-                    col_dict = OrderedDict(zip(col_name, raw_dt_list))
+                    col_dict = OrderedDict(zip(col_names, raw_dt_list))
                     if len(col_dtype.fields.values()) != len(col_dict):
                         raise exceptions.DuplicateColumnName
 

--- a/nixio/data_frame.py
+++ b/nixio/data_frame.py
@@ -34,11 +34,11 @@ class DataFrame(Entity, DataSet):
         self._rows = None
 
     def __getitem__(self, index):
-        get_row = self._read_data(slc=index)
-        if get_row.dtype.fields:
+        data = self._read_data(slc=index)
+        if data.dtype.fields:
             # compound type
-            return self._convert_string_cols(get_row)
-        return get_row
+            return self._convert_string_cols(data)
+        return data
 
     @classmethod
     def create_new(cls, nixfile, nixparent, h5parent, name, type_, shape, col_dtype, compression):
@@ -147,20 +147,20 @@ class DataFrame(Entity, DataSet):
         else:
             slc = np.s_[slc]
         if len(name) == 1:
-            get_col = self._read_data(slc=slc)[name[0]]
-            if get_col.dtype == util.vlen_str_dtype:
-                get_col = np.array([ensure_str(s) for s in get_col], dtype=util.vlen_str_dtype)
-            return get_col
+            data = self._read_data(slc=slc)[name[0]]
+            if data.dtype == util.vlen_str_dtype:
+                data = np.array([ensure_str(s) for s in data], dtype=util.vlen_str_dtype)
+            return data
         if group_by_cols:
             gcol = list()
             for col_name in name:
-                get_col = self._read_data(slc=slc)[col_name]
-                get_col = [i for i in get_col]
-                gcol.append(get_col)
+                data = self._read_data(slc=slc)[col_name]
+                data = [i for i in data]
+                gcol.append(data)
             return np.array(gcol)
 
-        get_col = self._read_data(slc=slc)[name]
-        return self._convert_string_cols(get_col)
+        data = self._read_data(slc=slc)[name]
+        return self._convert_string_cols(data)
 
     @staticmethod
     def _convert_string_cols(data):

--- a/nixio/data_frame.py
+++ b/nixio/data_frame.py
@@ -206,8 +206,13 @@ class DataFrame(Entity, DataSet):
         :type index: list of int
         """
         if isinstance(index, Iterable):
-            index = list(index)
-        get_row = self._read_data(slc=(index,))
+            index_list = list(index)
+        else:
+            index_list = [index]
+        get_row = self._read_data(slc=(index_list,))
+        get_row = self._convert_string_cols(get_row)
+        if not isinstance(index, Iterable):
+            get_row = get_row[0]
         return get_row
 
     def write_cell(self, cell, position=None, col_name=None, row_idx=None):

--- a/nixio/data_frame.py
+++ b/nixio/data_frame.py
@@ -33,6 +33,9 @@ class DataFrame(Entity, DataSet):
         self._columns = None
         self._rows = None
 
+    def __getitem__(self, index):
+        return self.read_rows(index)
+
     @classmethod
     def create_new(cls, nixfile, nixparent, h5parent, name, type_, shape, col_dtype, compression):
         newentity = super(DataFrame, cls).create_new(nixfile, nixparent, h5parent, name, type_)
@@ -206,10 +209,11 @@ class DataFrame(Entity, DataSet):
         :type index: list of int
         """
         if isinstance(index, Iterable):
-            index_list = list(index)
+            get_row = self._read_data(slc=(list(index),))
+        elif not isinstance(index, slice):
+            get_row = self._read_data(slc=([index],))
         else:
-            index_list = [index]
-        get_row = self._read_data(slc=(index_list,))
+            get_row = self._read_data(slc=index)
         get_row = self._convert_string_cols(get_row)
         if not isinstance(index, Iterable):
             get_row = get_row[0]

--- a/nixio/data_set.py
+++ b/nixio/data_set.py
@@ -7,8 +7,6 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 import numpy as np
-from six import ensure_str
-from . import util
 
 
 class DataSet(object):
@@ -123,12 +121,7 @@ class DataSet(object):
         dataset.write_data(data,  slc)
 
     def _read_data(self, slc=None):
-        dataset = self._h5group.get_dataset("data")
-        data = dataset.read_data(slc)
-        if data.dtype == util.vlen_str_dtype:
-            data = np.array([ensure_str(d) for d in data],
-                            dtype=util.vlen_str_dtype)
-        return data
+        return self._h5group.get_dataset("data").read_data(slc)
 
     @property
     def data_extent(self):

--- a/nixio/data_set.py
+++ b/nixio/data_set.py
@@ -58,7 +58,7 @@ class DataSet(object):
     @property
     def dtype(self):
         """
-        :type: :class:`numpy.dtype` object holding type infromation about
+        :type: :class:`numpy.dtype` object holding type information about
                the data stored in the DataSet.
         """
         return np.dtype(self._get_dtype())

--- a/nixio/hdf5/h5dataset.py
+++ b/nixio/hdf5/h5dataset.py
@@ -67,13 +67,14 @@ class H5DataSet(object):
     @staticmethod
     def _convert_string_cols(data):
         str_cols = list()
-        for idx, (_, (col_type, _)) in enumerate(data.dtype.fields.items()):
+        for field_name, (col_type, _) in data.dtype.fields.items():
             if col_type == util.vlen_str_dtype:
-                str_cols.append(idx)
+                str_cols.append(field_name)
 
         def conv_row(row):
-            for idx in str_cols:
-                row[idx] = ensure_str(row[idx])
+            for field in str_cols:
+                print(field, row[field])
+                row[field] = ensure_str(row[field])
         if str_cols:
             if not data.shape:
                 # single row

--- a/nixio/hdf5/h5dataset.py
+++ b/nixio/hdf5/h5dataset.py
@@ -107,7 +107,10 @@ class H5DataSet(object):
 
     @property
     def dtype(self):
-        return self.dataset.dtype
+        dtype = self.dataset.dtype
+        if dtype == util.vlen_str_dtype:
+            return DataType.String
+        return dtype
 
     def __str__(self):
         return "<H5DataSet object: {}>".format(self.dataset.name)

--- a/nixio/property.py
+++ b/nixio/property.py
@@ -330,12 +330,7 @@ class Property(Entity):
 
     @property
     def data_type(self):
-        dtype = self._h5dataset.dtype
-
-        if dtype == util.vlen_str_dtype:
-            return DataType.String
-
-        return dtype
+        return self._h5dataset.dtype
 
     def delete_values(self):
         self._h5dataset.shape = (0,)

--- a/nixio/tag.py
+++ b/nixio/tag.py
@@ -306,9 +306,7 @@ class Tag(BaseTag):
 
     def feature_data(self, featidx):
         if len(self.features) == 0:
-            raise OutOfBounds(
-                "There are no features associated with this tag!"
-            )
+            raise OutOfBounds("There are no features associated with this tag!")
 
         try:
             feat = self.features[featidx]

--- a/nixio/test/test_data_frame.py
+++ b/nixio/test/test_data_frame.py
@@ -65,7 +65,7 @@ class TestDataFrame(unittest.TestCase):
         assert df_li.column_names == self.df1.column_names
         assert df_li.dtype == self.df1.dtype
         for i in df_li[:]:
-            self.assertIsInstance(i['id'], (bytes, string_types))
+            self.assertIsInstance(i['id'], string_types)
             self.assertIsInstance(i['sig2'], np.int32)
 
     def test_column_name_collision(self):
@@ -87,9 +87,9 @@ class TestDataFrame(unittest.TestCase):
     def test_write_row(self):
         # test write single row
         row = ["1", 'abc', 3, 4.4556356242341, 5.1111111]
-        assert list(self.df1[9]) == [2, b'j', 20.08, 5.1, 200]
+        assert list(self.df1[9]) == [2, 'iota', 20.08, 5.1, 200]
         self.df1.write_rows([row], [9])
-        assert list(self.df1[9]) == [1, b'abc', 3., 4.4556356242341, 5]
+        assert list(self.df1[9]) == [1, 'abc', 3., 4.4556356242341, 5]
         self.assertIsInstance(self.df1[9]['name'],  np.integer)
         self.assertIsInstance(self.df1[9]['sig2'],  np.int32)
         assert self.df1[9]['sig2'] == int(5)
@@ -97,8 +97,8 @@ class TestDataFrame(unittest.TestCase):
         multi_rows = [[1775, '12355', 1777, 1778, 1779],
                       [1785, '12355', 1787, 1788, 1789]]
         self.df1.write_rows(multi_rows, [1, 2])
-        assert list(self.df1[1]) == [1775, b'12355', 1777, 1778, 1779]
-        assert list(self.df1[2]) == [1785, b'12355', 1787, 1788, 1789]
+        assert list(self.df1[1]) == [1775, '12355', 1777, 1778, 1779]
+        assert list(self.df1[2]) == [1785, '12355', 1787, 1788, 1789]
 
     def test_write_column(self):
         # write by name
@@ -164,7 +164,7 @@ class TestDataFrame(unittest.TestCase):
         assert scell == 5.2
         # read cell by row_idx + col_name
         crcell = self.df1.read_cell(col_name=['id'], row_idx=9)
-        assert crcell == b'j'
+        assert crcell == 'iota'
         # test error raise if only one param given
         self.assertRaises(ValueError, self.df1.read_cell, row_idx=10)
         self.assertRaises(ValueError, self.df1.read_cell, col_name='sig1')
@@ -175,7 +175,7 @@ class TestDataFrame(unittest.TestCase):
         assert self.df1[8]['sig1'] == 105
         # write cell by rowid colname
         self.df1.write_cell('test', col_name='id', row_idx=3)
-        assert self.df1[3]['id'] == b'test'
+        assert self.df1[3]['id'] == 'test'
         # test error raise
         self.assertRaises(ValueError, self.df1.write_cell, 11, col_name='sig1')
 
@@ -198,13 +198,13 @@ class TestDataFrame(unittest.TestCase):
 
     def test_append_rows(self):
         # append single row
-        srow = [1, b"test", 3, 4, 5]
+        srow = (1, "test", 3, 4, 5)
         self.df1.append_rows([srow])
-        assert list(self.df1[10]) == srow
+        assert self.df1[10] == np.array(srow, dtype=list(self.df1_dtype.items()))
         # append multi-rows
-        mrows = [[1, "2", 3, 4, 5], [6, "testing", 8, 9, 10]]
+        mrows = [(1, "2", 3, 4, 5), (6, "testing", 8, 9, 10)]
         self.df1.append_rows(mrows)
-        assert [list(i) for i in self.df1[-2:]] == [[1, b'2', 3., 4., 5], [6, b'testing', 8., 9., 10]]
+        assert all(self.df1[-2:] == np.array(mrows, dtype=list(self.df1_dtype.items())))
         # append row with incorrect length
         errrow = [5, 6, 7, 8]
         self.assertRaises(ValueError, self.df1.append_rows, [errrow])
@@ -231,7 +231,7 @@ class TestDataFrame(unittest.TestCase):
         assert self.df1.dtype[0] != self.df1.dtype[4]
         assert self.df1.dtype[2] == self.df1.dtype[3]
 
-    def test_creation_without_name(self):
+    def test_create_without_dtypes(self):
         data = np.array([("a", 1, 2.2), ("b", 2, 3.3), ("c", 3, 4.4)],
                         dtype=[('name', 'U10'), ("id", 'i4'), ('val', 'f4')])
         df = self.block.create_data_frame("without_name", "test", data=data)

--- a/nixio/test/test_data_frame.py
+++ b/nixio/test/test_data_frame.py
@@ -16,23 +16,22 @@ import sys
 class TestDataFrame(unittest.TestCase):
 
     def setUp(self):
-
         self.tmpdir = TempDir("dataframetest")
         self.testfilename = os.path.join(self.tmpdir.path, "dataframetest.nix")
         self.file = nix.File.open(self.testfilename, nix.FileMode.Overwrite)
         self.block = self.file.create_block("test block", "recordingsession")
         self.df1_dtype = OrderedDict([('name', np.int64), ('id', str), ('time', float),
                                       ('sig1', np.float64), ('sig2', np.int32)])
-        self.df1_data = [(1, "a", 20.18, 5.0, 100),
-                         (2, "b", 20.09, 5.5, 101),
-                         (2, "c", 20.05, 5.1, 100),
-                         (1, "d", 20.15, 5.3, 150),
-                         (2, "e", 20.23, 5.7, 200),
-                         (2, "f", 20.07, 5.2, 300),
-                         (1, "g", 20.12, 5.1,  39),
-                         (1, "h", 20.27, 5.1, 600),
-                         (2, "i", 20.15, 5.6, 400),
-                         (2, "j", 20.08, 5.1, 200)]
+        self.df1_data = [(1, "alpha", 20.18, 5.0, 100),
+                         (2, "beta", 20.09, 5.5, 101),
+                         (2, "gamma", 20.05, 5.1, 100),
+                         (1, "delta", 20.15, 5.3, 150),
+                         (2, "epsilon", 20.23, 5.7, 200),
+                         (2, "fi", 20.07, 5.2, 300),
+                         (1, "zeta", 20.12, 5.1,  39),
+                         (1, "eta", 20.27, 5.1, 600),
+                         (2, "theta", 20.15, 5.6, 400),
+                         (2, "iota", 20.08, 5.1, 200)]
         other_arr = np.arange(11101, 11200).reshape((33, 3))
         other_di = OrderedDict({'name': np.int64, 'id': int, 'time': float})
         self.df1 = self.block.create_data_frame("test df", "signal1",

--- a/nixio/test/test_data_frame.py
+++ b/nixio/test/test_data_frame.py
@@ -153,6 +153,11 @@ class TestDataFrame(unittest.TestCase):
         for data_row, df_row in zip(data, slice_str_cols):
             assert data_row == tuple(df_row)
 
+    def test_index_column_by_name(self):
+        for colidx, colname in enumerate(self.df1_dtype.keys()):
+            expdata = [row[colidx] for row in self.df1_data]
+            assert all(self.df1[colname] == expdata)
+
     def test_read_cell(self):
         # read cell by position
         scell = self.df1.read_cell(position=[5, 3])

--- a/nixio/test/test_data_frame.py
+++ b/nixio/test/test_data_frame.py
@@ -112,11 +112,14 @@ class TestDataFrame(unittest.TestCase):
         assert list(self.df1[:]['sig2']) == list(column2)
 
     def test_read_row(self):
+        df1_array = np.array(self.df1_data, dtype=list(self.df1_dtype.items()))
         # read single row
-        assert list(self.df1.read_rows(0)) == [1, b'a', 20.18, 5.0, 100]
+        assert self.df1.read_rows(0) == df1_array[0]
         # read multiple
         multi_rows = self.df1.read_rows(np.arange(4, 9))
-        np.testing.assert_array_equal(multi_rows, self.df1[4:9])
+        np.testing.assert_array_equal(multi_rows, df1_array[4:9])
+        multi_rows = self.df1.read_rows([3, 6])
+        np.testing.assert_array_equal(multi_rows, [df1_array[3], df1_array[6]])
 
     def test_read_column(self):
         # read single column by index

--- a/nixio/test/test_property.py
+++ b/nixio/test/test_property.py
@@ -8,7 +8,6 @@
 # LICENSE file in the root of the Project.
 import os
 import unittest
-import six
 import nixio as nix
 from .tmp import TempDir
 
@@ -200,5 +199,4 @@ class TestProperties(unittest.TestCase):
 
         # read them back
         for name, value in unistrings.items():
-            value = [six.ensure_text(v) for v in value]  # py2compat
             assert tuple(value) == sec.props[name].values

--- a/nixio/test/test_tag.py
+++ b/nixio/test/test_tag.py
@@ -360,14 +360,10 @@ class TestTags(unittest.TestCase):
             col_dict=OrderedDict([("number", nix.DataType.Float)]),
             data=[(n,) for n in numberdata]
         )
-        column_descriptions = OrderedDict([("name", nix.DataType.String),
-                                           ("duration", nix.DataType.Double)])
-        values = [("One", 0.1), ("Two", 0.2), ("Three", 0.3), ("Four", 0.4),
-                  ("Five", 0.5), ("Six", 0.6), ("Seven", 0.7), ("Eight", 0.8),
-                  ("Nine", 0.9), ("Ten", 1.0)]
-        ramp_feat = self.block.create_data_frame("ramp feature", "test",
-                                                 col_dict=column_descriptions,
-                                                 data=values)
+        column_descriptions = OrderedDict([("name", nix.DataType.String), ("duration", nix.DataType.Double)])
+        values = [("One", 0.1), ("Two", 0.2), ("Three", 0.3), ("Four", 0.4), ("Five", 0.5),
+                  ("Six", 0.6), ("Seven", 0.7), ("Eight", 0.8), ("Nine", 0.9), ("Ten", 1.0)]
+        ramp_feat = self.block.create_data_frame("ramp feature", "test", col_dict=column_descriptions, data=values)
         ramp_feat.label = "voltage"
         ramp_feat.units = (None, "s")
 


### PR DESCRIPTION
Changes the way strings are handled in DataFrame columns.

The core change is in H5DataSet, where the `read_data()` method checks for two cases:
- if the dtype of the data coming from disk is `vlen_str_dtype` (`h5py.string_dtype(encoding='utf-8', length=None)`), then it decodes all the data to Python string (from bytes) using `ensure_str()` from the six package (for Python 2 compatibility).
- if the dtype has `fields` (struct/compound dtype), the fields are iterated and any `vlen_str_dtype` columns are decoded like above.

Similarly, if the dtype of a dataset is requested, it returns `DataType.String` (`np.unicode_`).

Moving the string conversion down into the H5DataSet class is moreappropriate:
- The data type conversion is HDF5-specific: We convert the dtype of string objects from disk into Python strings to be returned to the upper layers of the library.  Other (hypothetical, future) implementations would likely have other requirements.
- It avoids needing to make the conversion in all the places where data is read.

Tests have been updated to reflect these changes.

### A note about the commits

There's a bit of flip flopping with the commits.  The conversion was originally written in the DataFrame data retrieval function and then moved to the H5DataSet.  If you want, I can squash the commits so the PR is cleaner.