### PR TITLE
[DataView] Use data object's _read_data()

### DIFF
--- a/nixio/data_view.py
+++ b/nixio/data_view.py
@@ -23,7 +23,7 @@ class DataView(DataSet):
             # the check here for future bug catching
             raise IncompatibleDimensions(
                 "Number of dimensions for DataView does not match underlying "
-                "DataArray: {} != {}".format(len(slices), len(da.shape)),
+                "data object: {} != {}".format(len(slices), len(da.shape)),
                 "DataView"
             )
 
@@ -63,7 +63,7 @@ class DataView(DataSet):
         tsl = self._slices
         if sl:
             tsl = self._transform_coordinates(sl)
-        return super(DataView, self)._read_data(tsl)
+        return self.array._read_data(tsl)
 
     def _transform_coordinates(self, user_slices):
         """

--- a/nixio/test/test_multi_tag.py
+++ b/nixio/test/test_multi_tag.py
@@ -481,6 +481,39 @@ class TestMultiTags(unittest.TestCase):
         segtag.extents = wrong_ext
         self.assertRaises(IndexError, segtag.tagged_data, 0, 1)
 
+    def test_multi_tag_data_coefficients(self):
+        sample_iv = 0.001
+        x_data = np.arange(0, 10, sample_iv)
+        y_data = np.sin(2 * np.pi * x_data)
+
+        block = self.block
+        da = block.create_data_array("sin", "data", data=y_data)
+        da.unit = 'V'
+        da.polynom_coefficients = (10, 0.3)
+        dim = da.append_sampled_dimension(sample_iv)
+        dim.unit = 's'
+
+        pos = block.create_data_array('pos1', 'positions',
+                                      data=np.array([0.]).reshape(1, 1))
+        pos.append_set_dimension()
+        pos.append_set_dimension()
+        pos.unit = 'ms'
+        ext = block.create_data_array('ext1', 'extents',
+                                      data=np.array([2000.]).reshape(1, 1))
+        ext.append_set_dimension()
+        ext.append_set_dimension()
+        ext.unit = 'ms'
+
+        mtag = block.create_multi_tag("sin1", "tag", pos)
+        mtag.extents = ext
+        mtag.units = ['ms']
+        mtag.references.append(da)
+
+        assert np.array_equal(da[:2001], mtag.tagged_data(0, 0)[:])
+
+        da.expansion_origin = 0.89
+        assert np.array_equal(da[:2001], mtag.tagged_data(0, 0)[:])
+
     def test_multi_tag_tagged_data_1d(self):
         # MultiTags to vectors behave a bit differently
         # Testing separately


### PR DESCRIPTION
Instead of reading from the underlying DataSet object's _read_data(), call the linked data object's method.  In the case of a DataArray, this will apply polynomial coefficients and the expansion origin to the data slice before returning.

Test added for retrieving data with coefficients and expansion origin through a MultiTag.

Fixes #482.