### PR TITLE
Tag retrieval: Inclusive and Exclusive stop rule

### DIFF
--- a/nixio/__init__.py
+++ b/nixio/__init__.py
@@ -29,6 +29,7 @@ from .datatype import DataType
 from .dimension_type import DimensionType
 from .link_type import LinkType
 from .compression import Compression
+from .tag import SliceMode
 
 # version
 from .info import VERSION
@@ -37,7 +38,7 @@ __all__ = ("File", "Block", "Group", "DataArray", "DataFrame", "Tag",
            "MultiTag", "Source", "Section", "S", "Feature", "Property",
            "OdmlType", "SampledDimension", "RangeDimension", "SetDimension",
            "FileMode", "DataSliceMode", "DataType", "DimensionType",
-           "LinkType", "Compression", "validator")
+           "LinkType", "Compression",  "SliceMode", "validator")
 __author__ = ('Christian Kellner, Adrian Stoewer, Andrey Sobolev, Jan Grewe, '
               'Balint Morvai, Achilleas Koutsou')
 __version__ = VERSION

--- a/nixio/__init__.py
+++ b/nixio/__init__.py
@@ -19,7 +19,7 @@ from .section import Section, S
 from .property import Property, OdmlType
 from .feature import Feature
 from .data_frame import DataFrame
-from .dimensions import SampledDimension, RangeDimension, SetDimension
+from .dimensions import SampledDimension, RangeDimension, SetDimension, IndexMode
 from . import validator
 
 # enums
@@ -38,7 +38,7 @@ __all__ = ("File", "Block", "Group", "DataArray", "DataFrame", "Tag",
            "MultiTag", "Source", "Section", "S", "Feature", "Property",
            "OdmlType", "SampledDimension", "RangeDimension", "SetDimension",
            "FileMode", "DataSliceMode", "DataType", "DimensionType",
-           "LinkType", "Compression",  "SliceMode", "validator")
+           "LinkType", "Compression",  "SliceMode", "IndexMode", "validator")
 __author__ = ('Christian Kellner, Adrian Stoewer, Andrey Sobolev, Jan Grewe, '
               'Balint Morvai, Achilleas Koutsou')
 __version__ = VERSION

--- a/nixio/data_view.py
+++ b/nixio/data_view.py
@@ -61,7 +61,7 @@ class DataView(DataSet):
 
     def _read_data(self, sl=None):
         tsl = self._slices
-        if sl:
+        if sl is not None:
             tsl = self._transform_coordinates(sl)
         return self.array._read_data(tsl)
 

--- a/nixio/tag.py
+++ b/nixio/tag.py
@@ -145,7 +145,7 @@ class BaseTag(Entity):
                     scaling = util.units.scaling(unit, dimunit)
                 except InvalidUnit:
                     raise IncompatibleDimensions(
-                        "Cannot apply a position with unit to a SetDimension",
+                        "Cannot scale Tag unit {} to match dimension unit {}".format(unit, dimunit),
                         "Tag._pos_to_idx"
                     )
             index = dim.index_of(pos * scaling, stop_rule == SliceMode.Inclusive)
@@ -168,7 +168,7 @@ class BaseTag(Entity):
                     scaling = util.units.scaling(unit, dimunit)
                 except InvalidUnit:
                     raise IncompatibleDimensions(
-                        "Provided units are not scalable!",
+                        "Cannot scale Tag unit {} to match dimension unit {}".format(unit, dimunit),
                         "Tag._pos_to_idx"
                     )
             index = dim.index_of(pos * scaling, stop_rule == SliceMode.Inclusive)

--- a/nixio/tag.py
+++ b/nixio/tag.py
@@ -247,20 +247,22 @@ class Tag(BaseTag):
         extent = self.extent
         dimcount = len(data.dimensions)
         if dimcount > len(position):
-            ldiff = dimcount-len(position)
-            tmp_pos = list(position)
-            tmp_pos.extend([0] * ldiff)
-            position = tuple(tmp_pos)
+            # Tag doesn't specify (pos, ext) for all dimensions: will return entire remaining dimensions (0:len)
+            pdiff = dimcount-len(position)
+            pos_list = list(position)
+            pos_list.extend([0] * pdiff)
+            position = tuple(pos_list)
+            # if there is at least one extent dimension, pad it with the length of the data on each
             if extent is not None and len(extent) != 0:
-                tmp_ext = list(extent)
+                lext = list(extent)
                 for i in range(len(position)-1, dimcount):
-                    tmp_ext.append(len(data[i])-1)
-                extent = tuple(tmp_ext)
+                    lext.append(len(data[i])+1)
+                extent = tuple(lext)
         elif dimcount < len(position):
-            ldiff = dimcount - len(position)  # a negative value
-            position = position[:ldiff]
+            pdiff = dimcount - len(position)  # a negative value
+            position = position[:pdiff]
             if extent is not None and len(extent) != 0:
-                extent = extent[:ldiff]
+                extent = extent[:pdiff]
 
         for idx, (pos, dim) in enumerate(zip(position, data.dimensions)):
             if self.units:

--- a/nixio/tag.py
+++ b/nixio/tag.py
@@ -275,7 +275,7 @@ class Tag(BaseTag):
             if idx < len(extent):
                 ext = extent[idx]
                 stop = self._pos_to_idx(pos + ext, unit, dim, stop_rule)
-            if stop == 0:
+            if stop <= start:
                 # always return at least one element per dimension
                 stop = start + 1
             refslice.append(slice(start, stop))

--- a/nixio/tag.py
+++ b/nixio/tag.py
@@ -25,6 +25,12 @@ from .dimension_type import DimensionType
 from .link_type import LinkType
 from . import util
 from .section import Section
+from enum import Enum
+
+
+class SliceMode(Enum):
+    Exclusive = "exclusive"
+    Inclusive = "inclusive"
 
 
 class FeatureContainer(Container):

--- a/nixio/test/test_multi_tag.py
+++ b/nixio/test/test_multi_tag.py
@@ -805,7 +805,7 @@ class TestMultiTags(unittest.TestCase):
         data.
         Set dimension slicing.
         """
-        nsignals = 30
+        nsignals = 10
         data = np.random.random_sample((nsignals, 100))
         da = self.block.create_data_array("data", "data", data=data)
         da.append_set_dimension()
@@ -857,7 +857,7 @@ class TestMultiTags(unittest.TestCase):
         data.
         Range dimension slicing.
         """
-        nticks = 30
+        nticks = 10
         data = np.random.random_sample((nticks, 100))
         da = self.block.create_data_array("data", "data", data=data)
         da.append_range_dimension(ticks=range(nticks))
@@ -909,7 +909,7 @@ class TestMultiTags(unittest.TestCase):
         data.
         Sampled dimension slicing.
         """
-        nticks = 30
+        nticks = 10
         data = np.random.random_sample((nticks, 100))
         da = self.block.create_data_array("data", "data", data=data)
         da.append_sampled_dimension(sampling_interval=1).unit = "V"

--- a/nixio/test/test_multi_tag.py
+++ b/nixio/test/test_multi_tag.py
@@ -28,23 +28,13 @@ class TestMultiTags(unittest.TestCase):
         self.file = nix.File.open(self.testfilename, nix.FileMode.Overwrite)
         self.block = self.file.create_block("test block", "recordingsession")
 
-        self.my_array = self.block.create_data_array("my array", "test",
-                                                     nix.DataType.Int16,
-                                                     (0, 0))
-        self.my_tag = self.block.create_multi_tag(
-            "my tag", "tag", self.my_array
-        )
+        self.my_array = self.block.create_data_array("my array", "test", nix.DataType.Int16, (0, 0))
+        self.my_tag = self.block.create_multi_tag("my tag", "tag", self.my_array)
 
-        self.your_array = self.block.create_data_array("your array", "test",
-                                                       nix.DataType.Int16,
-                                                       (0, 0))
-        self.your_tag = self.block.create_multi_tag(
-            "your tag", "tag", self.your_array
-        )
+        self.your_array = self.block.create_data_array("your array", "test", nix.DataType.Int16, (0, 0))
+        self.your_tag = self.block.create_multi_tag("your tag", "tag", self.your_array)
 
-        self.data_array = self.block.create_data_array("featureTest", "test",
-                                                       nix.DataType.Double,
-                                                       (2, 10, 5))
+        self.data_array = self.block.create_data_array("featureTest", "test", nix.DataType.Double, (2, 10, 5))
 
         data = np.zeros((2, 10, 5))
         value = 0.
@@ -142,16 +132,12 @@ class TestMultiTags(unittest.TestCase):
     def test_multi_tag_flex(self):
         pos1d = self.block.create_data_array("pos1", "pos", data=[[0], [1]])
         pos1d1d = self.block.create_data_array("pos1d1d", "pos", data=[0, 1])
-        pos2d = self.block.create_data_array("pos2", "pos",
-                                             data=[[0, 0], [1, 1]])
-        pos3d = self.block.create_data_array("pos3", "pos",
-                                             data=[[0, 1, 2], [1, 2, 3]])
+        pos2d = self.block.create_data_array("pos2", "pos", data=[[0, 0], [1, 1]])
+        pos3d = self.block.create_data_array("pos3", "pos", data=[[0, 1, 2], [1, 2, 3]])
         ext1d = self.block.create_data_array('ext1', 'ext', data=[[1], [1]])
         ext1d1d = self.block.create_data_array('ext1d1d', 'ext', data=[1, 1])
-        ext2d = self.block.create_data_array('ext2', 'ext',
-                                             data=[[1, 2], [0, 2]])
-        ext3d = self.block.create_data_array('ext3', 'ext',
-                                             data=[[1, 1, 1], [1, 1, 1]])
+        ext2d = self.block.create_data_array('ext2', 'ext', data=[[1, 2], [0, 2]])
+        ext3d = self.block.create_data_array('ext3', 'ext', data=[[1, 1, 1], [1, 1, 1]])
         mt1d = self.block.create_multi_tag("mt1d", "mt", pos1d)
         mt1d.extents = ext1d
         mt1d1d = self.block.create_multi_tag("mt1d1d", "mt", pos1d1d)
@@ -163,14 +149,10 @@ class TestMultiTags(unittest.TestCase):
         # create some references
         da1d = self.block.create_data_array('ref1d', 'ref', data=np.arange(10))
         da1d.append_sampled_dimension(1., label="time", unit="s")
-        da2d = self.block.create_data_array('ref2d', 'ref',
-                                            data=np.arange(100).reshape(
-                                                (10, 10)))
+        da2d = self.block.create_data_array('ref2d', 'ref', data=np.arange(100).reshape((10, 10)))
         da2d.append_sampled_dimension(1., label="time", unit="s")
         da2d.append_set_dimension()
-        da3d = self.block.create_data_array('ref3d', 'ref',
-                                            data=np.arange(1000).reshape(
-                                                (10, 10, 10)))
+        da3d = self.block.create_data_array('ref3d', 'ref', data=np.arange(1000).reshape((10, 10, 10)))
         da3d.append_sampled_dimension(1., label="time", unit="s")
         da3d.append_set_dimension()
         da3d.append_set_dimension()
@@ -178,25 +160,18 @@ class TestMultiTags(unittest.TestCase):
         mt1d1d.references.extend([da1d, da2d, da3d])
         mt2d.references.extend([da1d, da2d, da3d])
         mt3d.references.extend([da1d, da2d, da3d])
-        np.testing.assert_almost_equal(mt1d.tagged_data(0, 0)[:], da1d[0:2])
-        np.testing.assert_almost_equal(mt1d.tagged_data(0, 1)[:], da2d[0:2, :])
-        np.testing.assert_almost_equal(mt1d.tagged_data(0, 2)[:],
-                                       da3d[0:2, :, :])
-        np.testing.assert_almost_equal(mt1d1d.tagged_data(0, 0)[:], da1d[0:2])
-        np.testing.assert_almost_equal(mt1d1d.tagged_data(0, 1)[:],
-                                       da2d[0:2, :])
-        np.testing.assert_almost_equal(mt1d1d.tagged_data(0, 2)[:],
-                                       da3d[0:2, :, :])
-        np.testing.assert_almost_equal(mt2d.tagged_data(0, 0)[:], da1d[0:2])
-        np.testing.assert_almost_equal(mt2d.tagged_data(0, 1)[:],
-                                       da2d[0:2, 0:3])
-        np.testing.assert_almost_equal(mt2d.tagged_data(0, 2)[:],
-                                       da3d[0:2, 0:3, :])
-        np.testing.assert_almost_equal(mt3d.tagged_data(1, 0)[:], da1d[1:3])
-        np.testing.assert_almost_equal(mt3d.tagged_data(1, 1)[:],
-                                       da2d[1:3, 2:4])
-        np.testing.assert_almost_equal(mt3d.tagged_data(1, 2)[:],
-                                       da3d[1:3, 2:4, 3:5])
+        np.testing.assert_almost_equal(mt1d.tagged_data(0, 0)[:], da1d[0:1])
+        np.testing.assert_almost_equal(mt1d.tagged_data(0, 1)[:], da2d[0:1, :])
+        np.testing.assert_almost_equal(mt1d.tagged_data(0, 2)[:], da3d[0:1, :, :])
+        np.testing.assert_almost_equal(mt1d1d.tagged_data(0, 0)[:], da1d[0:1])
+        np.testing.assert_almost_equal(mt1d1d.tagged_data(0, 1)[:], da2d[0:1, :])
+        np.testing.assert_almost_equal(mt1d1d.tagged_data(0, 2)[:], da3d[0:1, :, :])
+        np.testing.assert_almost_equal(mt2d.tagged_data(0, 0)[:], da1d[0:1])
+        np.testing.assert_almost_equal(mt2d.tagged_data(0, 1)[:], da2d[0:1, 0:2])
+        np.testing.assert_almost_equal(mt2d.tagged_data(0, 2)[:], da3d[0:1, 0:2, :])
+        np.testing.assert_almost_equal(mt3d.tagged_data(1, 0)[:], da1d[1:2])
+        np.testing.assert_almost_equal(mt3d.tagged_data(1, 1)[:], da2d[1:2, 2:3])
+        np.testing.assert_almost_equal(mt3d.tagged_data(1, 2)[:], da3d[1:2, 2:3, 3:4])
 
     def test_multi_tag_eq(self):
         assert self.my_tag == self.my_tag
@@ -380,13 +355,11 @@ class TestMultiTags(unittest.TestCase):
         dim = da.append_sampled_dimension(sample_iv)
         dim.unit = 's'
 
-        pos = block.create_data_array('pos1', 'positions',
-                                      data=np.array([0.]).reshape(1, 1))
+        pos = block.create_data_array('pos1', 'positions', data=np.array([0.]).reshape(1, 1))
         pos.append_set_dimension()
         pos.append_set_dimension()
         pos.unit = 'ms'
-        ext = block.create_data_array('ext1', 'extents',
-                                      data=np.array([2000.]).reshape(1, 1))
+        ext = block.create_data_array('ext1', 'extents', data=np.array([2000.]).reshape(1, 1))
         ext.append_set_dimension()
         ext.append_set_dimension()
         ext.unit = 'ms'
@@ -396,37 +369,34 @@ class TestMultiTags(unittest.TestCase):
         mtag.units = ['ms']
         mtag.references.append(da)
 
-        assert mtag.tagged_data(0, 0).shape == (2001,)
-        assert np.array_equal(y_data[:2001], mtag.tagged_data(0, 0)[:])
+        assert mtag.tagged_data(0, 0).shape == (2000,)
+        assert np.array_equal(y_data[:2000], mtag.tagged_data(0, 0)[:])
+        assert mtag.tagged_data(0, 0, stop_rule=nix.SliceMode.Inclusive).shape == (2001,)
+        assert np.array_equal(y_data[:2001], mtag.tagged_data(0, 0, stop_rule=nix.SliceMode.Inclusive)[:])
 
         # get by name
         data = mtag.tagged_data(0, da.name)
-        assert data.shape == (2001,)
-        assert np.array_equal(y_data[:2001], data[:])
+        assert data.shape == (2000,)
+        assert np.array_equal(y_data[:2000], data[:])
 
         # get by id
         data = mtag.tagged_data(0, da.id)
-        assert data.shape == (2001,)
-        assert np.array_equal(y_data[:2001], data[:])
+        assert data.shape == (2000,)
+        assert np.array_equal(y_data[:2000], data[:])
 
         # multi dimensional data
         sample_iv = 1.0
         ticks = [1.2, 2.3, 3.4, 4.5, 6.7]
         unit = "ms"
-        pos = self.block.create_data_array("pos", "test",
-                                           data=[[1, 1, 1],
-                                                 [1, 1, 1]])
+        pos = self.block.create_data_array("pos", "test", data=[[1, 1, 1], [1, 1, 1]])
         pos.append_set_dimension()
         pos.append_set_dimension()
-        ext = self.block.create_data_array("ext", "test",
-                                           data=[[1, 5, 2],
-                                                 [0, 4, 1]])
+        ext = self.block.create_data_array("ext", "test", data=[[1, 5, 2], [0, 4, 1]])
         ext.append_set_dimension()
         ext.append_set_dimension()
         units = ["none", "ms", "ms"]
         data = np.random.random_sample((3, 10, 5))
-        da = self.block.create_data_array("dimtest", "test",
-                                          data=data)
+        da = self.block.create_data_array("dimtest", "test", data=data)
         setdim = da.append_set_dimension()
         setdim.labels = ["Label A", "Label B", "Label D"]
         samdim = da.append_sampled_dimension(sample_iv)
@@ -455,27 +425,23 @@ class TestMultiTags(unittest.TestCase):
 
         segdata = segtag.tagged_data(0, 0)
         assert len(segdata.shape) == 3
-        assert segdata.shape == (2, 6, 2)
+        assert segdata.shape == (1, 5, 2)
 
         segdata = segtag.tagged_data(1, 0)
         assert len(segdata.shape) == 3
-        assert segdata.shape == (1, 5, 1)
+        assert segdata.shape == (1, 4, 1)
 
         # retrieve all positions for all references
         for ridx, _ in enumerate(mtag.references):
             for pidx, _ in enumerate(mtag.positions):
                 mtag.tagged_data(pidx, ridx)
 
-        wrong_pos = self.block.create_data_array("incorpos", "test",
-                                                 data=[[1, 1, 1],
-                                                       [100, 1, 1]])
+        wrong_pos = self.block.create_data_array("incorpos", "test", data=[[1, 1, 1], [100, 1, 1]])
         wrong_pos.append_set_dimension()
         wrong_pos.append_set_dimension()
         postag.positions = wrong_pos
         self.assertRaises(IndexError, postag.tagged_data, 1, 1)
-        wrong_ext = self.block.create_data_array("incorext", "test",
-                                                 data=[[1, 500, 2],
-                                                       [0, 4, 1]])
+        wrong_ext = self.block.create_data_array("incorext", "test", data=[[1, 500, 2], [0, 4, 1]])
         wrong_ext.append_set_dimension()
         wrong_ext.append_set_dimension()
         segtag.extents = wrong_ext
@@ -493,13 +459,11 @@ class TestMultiTags(unittest.TestCase):
         dim = da.append_sampled_dimension(sample_iv)
         dim.unit = 's'
 
-        pos = block.create_data_array('pos1', 'positions',
-                                      data=np.array([0.]).reshape(1, 1))
+        pos = block.create_data_array('pos1', 'positions', data=np.array([0.]).reshape(1, 1))
         pos.append_set_dimension()
         pos.append_set_dimension()
         pos.unit = 'ms'
-        ext = block.create_data_array('ext1', 'extents',
-                                      data=np.array([2000.]).reshape(1, 1))
+        ext = block.create_data_array('ext1', 'extents', data=np.array([2000.]).reshape(1, 1))
         ext.append_set_dimension()
         ext.append_set_dimension()
         ext.unit = 'ms'
@@ -509,10 +473,10 @@ class TestMultiTags(unittest.TestCase):
         mtag.units = ['ms']
         mtag.references.append(da)
 
-        assert np.array_equal(da[:2001], mtag.tagged_data(0, 0)[:])
+        assert np.array_equal(da[:2000], mtag.tagged_data(0, 0)[:])
 
         da.expansion_origin = 0.89
-        assert np.array_equal(da[:2001], mtag.tagged_data(0, 0)[:])
+        assert np.array_equal(da[:2000], mtag.tagged_data(0, 0)[:])
 
     def test_multi_tag_tagged_data_1d(self):
         # MultiTags to vectors behave a bit differently
@@ -529,10 +493,8 @@ class TestMultiTags(unittest.TestCase):
             onedmtag.tagged_data(pidx, 0)
 
     def test_multi_tag_feature_data(self):
-        index_data = self.block.create_data_array("indexed feature data",
-                                                  "test",
-                                                  dtype=nix.DataType.Double,
-                                                  shape=(10, 10))
+        index_data = self.block.create_data_array("indexed feature data", "test",
+                                                  dtype=nix.DataType.Double, shape=(10, 10))
         dim1 = index_data.append_sampled_dimension(1.0)
         dim1.unit = "ms"
         dim2 = index_data.append_sampled_dimension(1.0)
@@ -550,10 +512,8 @@ class TestMultiTags(unittest.TestCase):
 
         index_data[:, :] = data1
 
-        tagged_data = self.block.create_data_array("tagged feature data",
-                                                   "test",
-                                                   dtype=nix.DataType.Double,
-                                                   shape=(10, 20, 10))
+        tagged_data = self.block.create_data_array("tagged feature data", "test",
+                                                   dtype=nix.DataType.Double, shape=(10, 20, 10))
         dim1 = tagged_data.append_sampled_dimension(1.0)
         dim1.unit = "ms"
         dim2 = tagged_data.append_sampled_dimension(1.0)

--- a/nixio/test/test_tag.py
+++ b/nixio/test/test_tag.py
@@ -72,10 +72,9 @@ class TestTags(unittest.TestCase):
         tag2d.tagged_data(0)  # 2d tag to 1d data
         tag3d.extent = [1, 2, 3]
         tag3d.references.extend([da1d, da2d, da3d])
-        np.testing.assert_array_equal(tag3d.tagged_data(0), da1d[1:3])
-        np.testing.assert_array_equal(tag3d.tagged_data(1), da2d[1:3, 1:4])
-        np.testing.assert_array_equal(tag3d.tagged_data(2),
-                                      da3d[1:3, 1:4, 1:5])
+        np.testing.assert_array_equal(tag3d.tagged_data(0), da1d[1:2])
+        np.testing.assert_array_equal(tag3d.tagged_data(1), da2d[1:2, 1:3])
+        np.testing.assert_array_equal(tag3d.tagged_data(2), da3d[1:2, 1:3, 1:4])
 
     def test_tag_eq(self):
         assert self.my_tag == self.my_tag
@@ -269,7 +268,7 @@ class TestTags(unittest.TestCase):
 
         segdata = segtag.tagged_data(0)
         assert len(segdata.shape) == 3
-        assert segdata.shape == (1, 7, 2)
+        assert segdata.shape == (1, 6, 2)
 
         # retrieve data by id and name
         posdata = postag.tagged_data(da.name)
@@ -277,14 +276,14 @@ class TestTags(unittest.TestCase):
         assert posdata.shape == (1, 1, 1)
         segdata = segtag.tagged_data(da.name)
         assert len(segdata.shape) == 3
-        assert segdata.shape == (1, 7, 2)
+        assert segdata.shape == (1, 6, 2)
 
         posdata = postag.tagged_data(da.id)
         assert len(posdata.shape) == 3
         assert posdata.shape == (1, 1, 1)
         segdata = segtag.tagged_data(da.id)
         assert len(segdata.shape) == 3
-        assert segdata.shape == (1, 7, 2)
+        assert segdata.shape == (1, 6, 2)
 
     def test_tag_tagged_data_slice_mode(self):
         data = np.random.random_sample((3, 100, 10))
@@ -412,10 +411,10 @@ class TestTags(unittest.TestCase):
         data5 = pos_tag.feature_data(4)
         data6 = pos_tag.feature_data(5)
 
-        assert np.all(data1[:] == number_data[4:7])  # end is inclusive
+        assert np.all(data1[:] == number_data[4:6])
         assert np.all(data2[:] == number_data[:])
         assert np.all(data3[:] == number_data[:])
-        assert np.all(data4[:] == ramp_data[3:6])  # end is inclusive
+        assert np.all(data4[:] == ramp_data[3:5])
         assert np.all(data5[:] == ramp_data[:])
         assert np.all(data6[:] == ramp_data[:])
 

--- a/nixio/test/test_tag.py
+++ b/nixio/test/test_tag.py
@@ -511,7 +511,7 @@ class TestTags(unittest.TestCase):
         data.
         Set dimension slicing.
         """
-        nsignals = 30
+        nsignals = 10
         data = np.random.random_sample((nsignals, 100))
         da = self.block.create_data_array("data", "data", data=data)
         da.append_set_dimension()
@@ -558,7 +558,7 @@ class TestTags(unittest.TestCase):
         data.
         Range dimension slicing.
         """
-        nticks = 30
+        nticks = 10
         data = np.random.random_sample((nticks, 100))
         da = self.block.create_data_array("data", "data", data=data)
         da.append_range_dimension(ticks=range(nticks))
@@ -605,7 +605,7 @@ class TestTags(unittest.TestCase):
         data.
         Sampled dimension slicing.
         """
-        nticks = 30
+        nticks = 10
         data = np.random.random_sample((nticks, 100))
         da = self.block.create_data_array("data", "data", data=data)
         da.append_sampled_dimension(sampling_interval=1).unit = "V"


### PR DESCRIPTION
This PR implements the slicing rules described in https://github.com/G-Node/nix/blob/master/docs/slicing_and_indices.md.
Slicing is by default excludes the right endpoint now.  The endpoint can be included by specifying `stop_rule=nix.SliceMode.Inclusive` in the `tagged_data()` method of a Tag or MultiTag.

To clarify, the new Exclusive rules work as follows:
- The first element in the DataView returned by `tagged_data` is the value at the last index of each dimension that is **less than or equal to** the Tag's `position`.
- The last element in the DataView returned by  `tagged_data` is the value at the last index of each dimension that is **less than** the Tag's `position+extent`.

Using Inclusive changes the second behaviour of the last element to be the same as for the first element:
- The last element in the DataView returned by  `tagged_data` is the value at the last index of each dimension that is **less than or equal to** the Tag's `position+extent`.

Note that when the value of `position+extent` falls between two dimension ticks, the behaviour is the same for both cases.  For example, if a dimension has integer ticks `[0, 1, 2, 3, 4...]` and `position + extent = 2.2`, then the last index of the DataView will always be `2`.

This is covered in the tests and described by diagrams in comments for future reference (because it always takes me a while to figure out what I'm doing and this will definitely help going forward).

The PR also includes a bit of a rewrite of the code for calculating the slices which simplifies and merges the methods for Tag and MultiTag.

Closes #484.
Closes #494.