### PR TITLE
Github actions update

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,16 @@
 name: NIXPy tests and linting
 
-on: [push]
+on:
+  # Run one build a month at 01:00
+  schedule:
+  - cron:  '0 1 1 * *'
+  push:
+    branches:
+      - master
+      - dev
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:
@@ -9,7 +19,8 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.8]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -19,7 +19,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -22,9 +22,9 @@ jobs:
         python-version: [3.8]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -42,6 +42,39 @@ jobs:
         # pytest will skip cross-compatibility tests since NIX isn't installed
         pytest
 
+  run-conda-test:
+    name: Running tests using miniconda
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      max-parallel: 4
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.8]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: deptest-${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
+          channels: conda-forge
+      - name: Show conda details
+        run: |
+          conda info
+          conda list
+          which python
+          conda --version
+      - name: Install Python dependencies
+        run: |
+          python setup.py install
+          pip install h5py
+          pip install pytest
+      - name: Run tests
+        run: |
+          pytest
+
   run-coveralls:
     runs-on: [ubuntu-latest]
     steps:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -14,8 +14,7 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 4
       matrix:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -95,3 +95,25 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: coveralls --service=github
+
+  run-codecov:
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: Install dependencies
+        run: |
+          python setup.py install
+          pip install h5py
+          pip install pytest pytest-cov
+      - name: Create coverage
+        run: |
+          pytest --cov=./ --cov-report=xml
+      - uses: codecov/codecov-action@v1
+        with:
+          name: Submit Codecov coverage
+          files: ./coverage.xml
+          verbose: true # optional (default = false)

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -41,3 +41,24 @@ jobs:
         pip install pytest
         # pytest will skip cross-compatibility tests since NIX isn't installed
         pytest
+
+  run-coveralls:
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: Install dependencies
+        run: |
+          python setup.py install
+          pip install h5py
+          pip install pytest coveralls
+      - name: Create coverage
+        run: |
+          coverage run --source=nixio -m pytest nixio/test/
+      - name: Submit to coveralls
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: coveralls --service=github

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -43,6 +43,7 @@ jobs:
         pytest
 
   run-conda-test:
+    needs: [build]
     name: Running tests using miniconda
     runs-on: ${{ matrix.os }}
     defaults:
@@ -76,6 +77,7 @@ jobs:
           pytest
 
   run-coveralls:
+    needs: [build]
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
@@ -97,6 +99,7 @@ jobs:
         run: coveralls --service=github
 
   run-codecov:
+    needs: [build]
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ pip-log.txt
 # Unit test / coverage reports
 .coverage
 .tox
+coverage.xml
 
 # temp files
 *~

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,51 +9,15 @@ env:
 
 matrix:
   include:
-    - python: "2.7"
-      os: linux
-      dist: xenial
-      env: pymajor=2
-    - python: "3.6"
-      os: linux
-      dist: xenial
-      env: pymajor=3
     - python: "3.7"
       os: linux
       env: pymajor=3 compat=1
       dist: xenial
       sudo: true
-    - python: "3.7"
-      os: linux
-      env: pymajor=3
-      dist: xenial
     - python: "3.8"
       os: linux
-      env: pymajor=3 coverage=1
-      dist: xenial
-    - language: generic
-      os: osx
-      env: pymajor=2
-      addons:
-        homebrew:
-          packages:
-            - python2
-            - cmake
-            - cppunit
-            - hdf5
-            - numpy
-          update: false
-    - language: generic
-      os: osx
       env: pymajor=3
-      addons:
-        homebrew:
-          packages:
-            - python3
-            - cmake
-            - cppunit
-            - hdf5
-            - numpy
-          update: false
+      dist: xenial
   allow_failures:
     - env: pymajor=3 compat=1
 
@@ -100,10 +64,4 @@ script:
       pytest --cov=nixio --nix-compat -nauto;
     else
       pytest --cov=nixio -nauto;
-    fi
-
-after_success:
-  - if [[ "${coverage}" == 1 ]]; then
-      pip install codecov;
-      codecov;
     fi

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,13 @@
+.. image:: https://github.com/G-Node/nixpy/workflows/NIXPy%20tests%20and%20linting/badge.svg?branch=master
+    :target: https://github.com/G-Node/nixpy/actions
 .. image:: https://travis-ci.org/G-Node/nixpy.svg?branch=v1.4
     :target: https://travis-ci.org/G-Node/nixpy
 .. image:: https://ci.appveyor.com/api/projects/status/72l10ooxbvf0vfgd/branch/master?svg=true
     :target: https://ci.appveyor.com/project/G-Node/nixpy
 .. image:: https://coveralls.io/repos/github/G-Node/nixpy/badge.svg?branch=master
     :target: https://coveralls.io/github/G-Node/nixpy?branch=master
+.. image:: https://codecov.io/gh/G-Node/nixpy/branch/master/graph/badge.svg?token=xT5rz1BlGJ
+    :target: https://codecov.io/gh/G-Node/nixpy
 
 
 ----

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,16 +16,6 @@ environment:
 
 
   matrix:
-    # Python 2.7 32 bit
-    - PYTHON: "C:\\Python27"
-      pyver: 2
-      bits: 32
-
-    # Python 2.7 64 bit
-    - PYTHON: "C:\\Python27-x64"
-      pyver: 2
-      bits: 64
-
     # Python 3.6 64 bit
     - PYTHON: "C:\\Python36-x64"
       pyver: 3


### PR DESCRIPTION
This PR moves builds from travis to github actions.

- the `gh/actions` workflow now runs tests in an os [Linux, MacOS, Windows] Python [3.6, 3.7, 3.8, 3.9] matrix .
- dependent on this test build, the`gh/actions` workflow builds an os [Linux, MacOS, Windows] Python [3.8] matrix using miniconda to make sure anaconda installations on all OS work without issue.
- also dependent on the test build, the `gh/actions` workflow runs coverage builds on Linux with Python 3.8 and for both `codecov` and `coveralls` and pushes the results to the respective services.
- the `gh/actions` workflow also adds a timed build, now running `gh/actions` once a month.
- the travis build is significantly reduced and now includes only a singe Linux build with Python 3.8 and a single allow failures build for the compatibility tests.
- the README file is updated to now also link to the github actions page and to the codecov page.

Ideally the compatibility tests will also migrate to the `gh/actions` build, but since I am not aware of the background and the current status of these builds I'll keep them on travis for the time being.
