### PR TITLE
[.pylintrc] Exclude C0103 to enable CI builds to pass after pylint update

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -27,11 +27,12 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Update pip
       run: |
         python -m pip install --upgrade pip
-        pip install six
-        pip install h5py
+    - name: Run install
+    - run: |
+        python setup.py install
     - name: Lint with Pylint
       run: |
         pip install pylint
@@ -70,9 +71,7 @@ jobs:
           conda --version
       - name: Install Python dependencies
         run: |
-          python setup.py install
-          pip install h5py
-          pip install six
+          pip install .
           pip install pytest
       - name: Run tests
         run: |
@@ -90,8 +89,6 @@ jobs:
       - name: Install dependencies
         run: |
           python setup.py install
-          pip install h5py
-          pip install six
           pip install pytest coveralls
       - name: Create coverage
         run: |
@@ -113,8 +110,6 @@ jobs:
       - name: Install dependencies
         run: |
           python setup.py install
-          pip install h5py
-          pip install six
           pip install pytest pytest-cov
       - name: Create coverage
         run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -27,11 +27,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Update pip
-      run: |
-        python -m pip install --upgrade pip
     - name: Run install
-    - run: |
+      run: |
         python setup.py install
     - name: Lint with Pylint
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -30,6 +30,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install six
         pip install h5py
     - name: Lint with Pylint
       run: |
@@ -71,6 +72,7 @@ jobs:
         run: |
           python setup.py install
           pip install h5py
+          pip install six
           pip install pytest
       - name: Run tests
         run: |
@@ -89,6 +91,7 @@ jobs:
         run: |
           python setup.py install
           pip install h5py
+          pip install six
           pip install pytest coveralls
       - name: Create coverage
         run: |
@@ -111,6 +114,7 @@ jobs:
         run: |
           python setup.py install
           pip install h5py
+          pip install six
           pip install pytest pytest-cov
       - name: Create coverage
         run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -29,7 +29,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Run install
       run: |
-        python setup.py install
+        pip install .
     - name: Lint with Pylint
       run: |
         pip install pylint
@@ -68,7 +68,7 @@ jobs:
           conda --version
       - name: Install Python dependencies
         run: |
-          pip install .
+          python setup.py install
           pip install pytest
       - name: Run tests
         run: |

--- a/.pylintrc
+++ b/.pylintrc
@@ -67,7 +67,6 @@ disable=all
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once). See also the "--disable" option for examples.
 enable=C0102,  # Black listed name "%s"**
-       C0103,  # Invalid %s name "%s"**
        C0121,  # Missing required attribute "%s"**
        C0202,  # Class method %s should have cls as first argument**
        C0203,  # Metaclass method %s should have mcs as first argument**


### PR DESCRIPTION
Due to a pylint update (2.6 -> 2.7) additional rules are applied to C0103: "Enums are now required to be named in
UPPER_CASE by `invalid-name`.". Excluding c0103 for the time being to enable CI builds to pass. For more details check [pylint issue #3834](https://github.com/PyCQA/pylint/issues?q=is%3Aissue+3834+)

Further the pylint update removed a dependency installation of the `six` package, which is also required to run the nixpy tests. The `six` package is now explicitly installed as a dependency.

Also `python setup.py install` always installs the latest version of a dependency package and includes beta versions which can lead to installation issues. The main `gh/actions` builds now install via `pip install .` which only installs the latest stable version. The `conda` builds run `python setup.py install` as an early warning for dependency issues.
