### PR TITLE
quick fix for parent block access  on sources

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,6 +58,7 @@ install:
   #     Invoke-WebRequest -URI $env:nix_exe_url -OutFile "nix.exe"
   # - 7z x nix.exe
   # - cd ..
+  - python -m pip install certifi
   - python -m pip install -U pip wheel
   - python -m pip install numpy h5py pytest-xdist
   - ps: cd "$env:APPVEYOR_BUILD_FOLDER"

--- a/nixio/source.py
+++ b/nixio/source.py
@@ -88,9 +88,8 @@ class Source(Entity):
         block = self.parent_block
         if self in block.sources:
             return None
-        id = self.id
         for s in block.sources:
-            p = Source._find_parent_recursive(s, id)
+            p = Source._find_parent_recursive(s, self.id)
             if p is not None:
                 return p
         return None

--- a/nixio/source.py
+++ b/nixio/source.py
@@ -109,6 +109,12 @@ class Source(Entity):
 
     @property
     def referring_objects(self):
+        """
+        Returns the list of entities that link to this source.
+
+        :returns: all objects referring to this source.
+        :rtype: list
+        """
         objs = []
         objs.extend(self.referring_data_arrays)
         objs.extend(self.referring_tags)
@@ -117,16 +123,34 @@ class Source(Entity):
 
     @property
     def referring_data_arrays(self):
+        """
+        Returns all DataArray entities linking to this source.
+
+        :returns: all DataArrays referring to this source.
+        :rtype: list
+        """
         block = self.parent_block
         return [da for da in block.data_arrays if self in da.sources]
 
     @property
     def referring_tags(self):
+        """
+        Returns all Tag entities linking to this source.
+
+        :returns: all Tags referring to this source.
+        :rtype: list
+        """
         block = self.parent_block
         return [tg for tg in block.tags if self in tg.sources]
 
     @property
     def referring_multi_tags(self):
+        """
+        Returns all MultiTag entities linking to this source.
+
+        :returns: all MultiTags referring to this source.
+        :rtype: list
+        """
         block = self.parent_block
         return [mt for mt in block.multi_tags if self in mt.sources]
 
@@ -182,6 +206,14 @@ class Source(Entity):
 
     @metadata.setter
     def metadata(self, sect):
+        """
+        Setter for the metadata section that contains meta information about this Source.
+
+        :param sect: The metadata section.
+        :type sect: Section
+
+        :raises: TypeError if sect is not of type Section
+        """
         if not isinstance(sect, Section):
             raise TypeError("{} is not of type Section".format(sect))
         self._h5group.create_link(sect, "metadata")

--- a/nixio/source.py
+++ b/nixio/source.py
@@ -54,8 +54,8 @@ class Source(Entity):
         """
         Returns the block this source is contained in.
 
-        Returns:
-            block [nix.Block]: the Block containing this source
+        :returns: the Block containing this source
+        :rtype: Block
         """
         if self._parent_block is not None:
             return self._parent_block
@@ -79,10 +79,10 @@ class Source(Entity):
     @property
     def parent_source(self):
         """
-        Get the parent source of this source. If this source at the root, None will be returned
+        Get the parent source of this source. If this source is at the root, None will be returned
 
-        Returns:
-            nix.Source or None: the parent source
+        :returns: the parent source
+        :rtype: Source or None
         """
         # for now we need to do a search
         block = self.parent_block

--- a/nixio/source.py
+++ b/nixio/source.py
@@ -65,15 +65,28 @@ class Source(Entity):
         self._parent_block = maybe_block
         return self._parent_block
 
-    @staticmethod
-    def _find_parent_recursive(source, name_or_id_of_child):
-        if name_or_id_of_child in source.sources:
-            return source
+    def _find_parent_recursive(self, child_id, check_id=True):
+        """
+        Find the parent source of this source. Search is based on the ID of of a child source. Searching by name might be ambiguous.
+        By default it will raise an ValueError if the child_id does not look like an UUID.
+
+        :param child_id: The ID of the child whose parent is searched.
+        :type child_id: str
+        :param check_id: Controls whether or not to check if the child_is looks like an UUID. Defaults to True.
+        :type check_id: bool
+
+        :returns: the parent source, if any, otherwise None.
+        :rtype: Source
+        """
+        if check_id and not util.is_uuid(child_id):
+            raise ValueError("Error calling find_parent_source: argument child_id (%s) does not look like an UUID " % child_id)
+        if child_id in self.sources:
+            return self
         else:
-            for s in source.sources:
-                s = Source._find_parent_recursive(s, name_or_id_of_child)
-                if s is not None:
-                    return s
+            for s in self.sources:
+                src = s._find_parent_recursive(child_id, False)
+                if src is not None:
+                    return src
         return None
 
     @property
@@ -89,7 +102,7 @@ class Source(Entity):
         if self in block.sources:
             return None
         for s in block.sources:
-            p = Source._find_parent_recursive(s, self.id)
+            p = s._find_parent_recursive(self.id, False)
             if p is not None:
                 return p
         return None

--- a/nixio/source.py
+++ b/nixio/source.py
@@ -21,6 +21,7 @@ class Source(Entity):
     def __init__(self, nixfile, nixparent, h5group):
         super(Source, self).__init__(nixfile, nixparent, h5group)
         self._sources = None
+        self._parent_block = None
 
     @classmethod
     def create_new(cls, nixfile, nixparent, h5parent, name, type_):
@@ -47,6 +48,16 @@ class Source(Entity):
             raise exceptions.DuplicateName("create_source")
         src = Source.create_new(self.file, self, sources, name, type_)
         return src
+    
+    @property
+    def parent_block(self):
+        if self._parent_block is not None:
+            return self._parent_block
+        maybe_block = self._parent
+        if not hasattr(maybe_block, "data_arrays"):
+            maybe_block = maybe_block.parent_block
+        self._parent_block = maybe_block
+        return self._parent_block
 
     @property
     def referring_objects(self):
@@ -58,15 +69,18 @@ class Source(Entity):
 
     @property
     def referring_data_arrays(self):
-        return [da for da in self._parent.data_arrays if self in da.sources]
+        block = self.parent_block
+        return [da for da in block.data_arrays if self in da.sources]
 
     @property
     def referring_tags(self):
-        return [tg for tg in self._parent.tags if self in tg.sources]
+        block = self.parent_block
+        return [tg for tg in block.tags if self in tg.sources]
 
     @property
     def referring_multi_tags(self):
-        return [mt for mt in self._parent.multi_tags if self in mt.sources]
+        block = self.parent_block
+        return [mt for mt in block.multi_tags if self in mt.sources]
 
     def find_sources(self, filtr=lambda _: True, limit=None):
         """

--- a/nixio/test/test_source.py
+++ b/nixio/test/test_source.py
@@ -159,3 +159,30 @@ class TestSources(unittest.TestCase):
         self.assertEqual(lvl2.sources["lvl3"]._parent, lvl3._parent)
         # TODO: Uncomment once fixed
         # self.assertEqual(group.sources["lvl3"]._parent, lvl3._parent)
+
+    def test_referring_objects(self):
+        nested = self.third.create_source("nested source", "sometype")
+        self.array.sources.append(nested)
+        
+        tag = self.block.create_tag("test tag", "some type", [0.0])
+        tag.sources.append(nested)
+
+        positions = self.block.create_data_array("positions array", "positions",
+                                                 dtype=nix.DataType.Double,
+                                                 shape=(1, 1) )
+        mtag = self.block.create_multi_tag("points", "points", positions=positions)
+        mtag.sources.append(nested)
+
+        self.assertEqual(len(nested.referring_data_arrays), 1)
+        self.assertEqual(nested.referring_data_arrays[0], self.array)
+        
+        self.assertEqual(len(nested.referring_tags), 1)
+        self.assertEqual(nested.referring_tags[0], tag)
+        
+        self.assertEqual(len(nested.referring_multi_tags), 1)
+        self.assertEqual(nested.referring_multi_tags[0], mtag)
+        
+        self.assertEqual(len(nested.referring_objects), 3)
+        self.assertTrue(self.array in nested.referring_objects)
+        self.assertTrue(tag in nested.referring_objects)
+        self.assertTrue(mtag in nested.referring_objects)

--- a/nixio/test/test_source.py
+++ b/nixio/test/test_source.py
@@ -163,7 +163,7 @@ class TestSources(unittest.TestCase):
     def test_referring_objects(self):
         nested = self.third.create_source("nested source", "sometype")
         self.array.sources.append(nested)
-        
+
         tag = self.block.create_tag("test tag", "some type", [0.0])
         tag.sources.append(nested)
 
@@ -175,14 +175,36 @@ class TestSources(unittest.TestCase):
 
         self.assertEqual(len(nested.referring_data_arrays), 1)
         self.assertEqual(nested.referring_data_arrays[0], self.array)
-        
+
         self.assertEqual(len(nested.referring_tags), 1)
         self.assertEqual(nested.referring_tags[0], tag)
-        
+
         self.assertEqual(len(nested.referring_multi_tags), 1)
         self.assertEqual(nested.referring_multi_tags[0], mtag)
-        
+
         self.assertEqual(len(nested.referring_objects), 3)
         self.assertTrue(self.array in nested.referring_objects)
         self.assertTrue(tag in nested.referring_objects)
         self.assertTrue(mtag in nested.referring_objects)
+
+    def test_parent_source(self):
+        """
+        root 
+          |--> leaf1
+          |      |--> leaf1a
+          |      |--> leaf1b
+          |--> leaf2
+                 |--> leaf2a
+        """
+        root = self.block.create_source("a root", "test")
+        leaf1 = root.create_source("leaf1", "test")
+        leaf2 = root.create_source("leaf2", "test")
+        leaf1a = leaf1.create_source("leaf1a", "test")
+        leaf1b = leaf1.create_source("leaf1b", "test")
+        leaf2a = leaf2.create_source("leaf2a", "test")
+
+        self.assertIsNone(root.parent_source)
+        self.assertEqual(leaf1.parent_source, root)
+        self.assertEqual(leaf1a.parent_source, leaf1)
+        self.assertEqual(leaf1b.parent_source, leaf1)
+        self.assertEqual(leaf2a.parent_source, leaf2)

--- a/nixio/test/test_source.py
+++ b/nixio/test/test_source.py
@@ -208,3 +208,7 @@ class TestSources(unittest.TestCase):
         self.assertEqual(leaf1a.parent_source, leaf1)
         self.assertEqual(leaf1b.parent_source, leaf1)
         self.assertEqual(leaf2a.parent_source, leaf2)
+
+        with self.assertRaises(ValueError):
+            leaf2._find_parent_recursive(leaf2a.name)
+        self.assertEqual(leaf2._find_parent_recursive(leaf2a.name, False), leaf2)


### PR DESCRIPTION
this pr addresses issue #498. 
* adds a ``parent_block`` property to the source which is needed to finding referring objects
* adds an explicit ``parent_source`` property (which at the moment performs a search on the sources tree)

* it **does not** change the behaviour of the ``referring_objects`` methods. They will still only return those objects that link directly to the source. That is, calling ``referring_data_arrays`` on a parent source will so far not collect the *DataArrays* of the child sources. I would like to leave this open for discussion. Since these are properties, there is no way of overloading with a default argument. For the time being, this needs to be done on the user side. We may want to discuss this at some point.