### PR TITLE
Range dim

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.4.{build}
+version: 1.5.{build}
 
 image: Visual Studio 2017
 

--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -140,24 +140,25 @@ class DataArray(Entity, DataSet):
             rdim.ticks = ticks
         return rdim
 
-    def append_range_dimension_using_self(self, index=[-1]):
+    def append_range_dimension_using_self(self, index=None):
         """
         Convenience function to append a new RangeDimension to the list of
         existing dimensions that uses the DataArray itself as provider for the ticks.
         This is a replacement for
         rdim = array.append_range_dimension()
         rdim.link_data_array(self, index)
-        
+
         :param index: The slice of the DataArray that contains the tick
-        values. This must be a vector of the data. Defaults to [-1], i.e. the full first dimension. 
+        values. This must be a vector of the data. Defaults to None, which will be replaced by [-1], i.e. the full first dimension.
         :type: list of int
-        
+
         :returns: the newly created RangeDimension
         :rtype: RangeDimension
         """
-        index = len(self.dimensions) + 1
-
-        rdim = RangeDimension.create_new(self, index, None)
+        dim_index = len(self.dimensions) + 1
+        rdim = RangeDimension.create_new(self, dim_index, None)
+        if index is None:
+            index = [-1]
         rdim.link_data_array(self, index)
         return rdim
 
@@ -168,7 +169,7 @@ class DataArray(Entity, DataSet):
         dimgroup = self._h5group.open_group("dimensions")
         ndims = len(dimgroup)
         for idx in range(ndims):
-            del dimgroup[str(idx+1)]
+            del dimgroup[str(idx + 1)]
         return True
 
     def _dimension_count(self):
@@ -192,7 +193,7 @@ class DataArray(Entity, DataSet):
         which returns the index starting from one and the dimensions.
         """
         for idx, dim in enumerate(self.dimensions):
-            yield idx+1, dim
+            yield idx + 1, dim
 
     @property
     def dtype(self):
@@ -302,7 +303,7 @@ class DataArray(Entity, DataSet):
                 "DataArray.get_slice"
             )
         if mode == DataSliceMode.Index:
-            slices = tuple(slice(p, p+e) for p, e in zip(positions, extents))
+            slices = tuple(slice(p, p + e) for p, e in zip(positions, extents))
             return DataView(self, slices)
         elif mode == DataSliceMode.Data:
             return self._get_slice_bydim(positions, extents)
@@ -317,11 +318,11 @@ class DataArray(Entity, DataSet):
             if dim.dimension_type in (DimensionType.Sample,
                                       DimensionType.Range):
                 dpos.append(dim.index_of(pos))
-                dext.append(dim.index_of(pos+ext)-dpos[-1])
+                dext.append(dim.index_of(pos + ext) - dpos[-1])
             elif dim.dimension_type == DimensionType.Set:
                 dpos.append(int(pos))
                 dext.append(int(ext))
-        slices = tuple(slice(p, p+e) for p, e in zip(dpos, dext))
+        slices = tuple(slice(p, p + e) for p, e in zip(dpos, dext))
         return DataView(self, slices)
 
     @property

--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -155,11 +155,19 @@ class DataArray(Entity, DataSet):
         :returns: the newly created RangeDimension
         :rtype: RangeDimension
         """
-        dim_index = len(self.dimensions) + 1
-        rdim = RangeDimension.create_new(self, dim_index, None)
         if index is None:
             index = [0] * len(self.shape)
             index[0] = -1
+        msg = RangeDimension._check_index(index)
+        if msg is not None:
+            raise ValueError(msg)
+
+        msg = RangeDimension._check_link_dimensionality(self, index)
+        if msg is not None:
+            raise IncompatibleDimensions(msg, "RangeDimension.append_range_dimension_using_self")
+
+        dim_index = len(self.dimensions) + 1
+        rdim = RangeDimension.create_new(self, dim_index, None)
         rdim.link_data_array(self, index)
         return rdim
 

--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -140,6 +140,27 @@ class DataArray(Entity, DataSet):
             rdim.ticks = ticks
         return rdim
 
+    def append_range_dimension_using_self(self, index=[-1]):
+        """
+        Convenience function to append a new RangeDimension to the list of
+        existing dimensions that uses the DataArray itself as provider for the ticks.
+        This is a replacement for
+        rdim = array.append_range_dimension()
+        rdim.link_data_array(self, index)
+        
+        :param index: The slice of the DataArray that contains the tick
+        values. This must be a vector of the data. Defaults to [-1], i.e. the full first dimension. 
+        :type: list of int
+        
+        :returns: the newly created RangeDimension
+        :rtype: RangeDimension
+        """
+        index = len(self.dimensions) + 1
+
+        rdim = RangeDimension.create_new(self, index, None)
+        rdim.link_data_array(self, index)
+        return rdim
+
     def delete_dimensions(self):
         """
         Delete all the dimension descriptors for this DataArray.

--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -149,7 +149,7 @@ class DataArray(Entity, DataSet):
         rdim.link_data_array(self, index)
 
         :param index: The slice of the DataArray that contains the tick
-        values. This must be a vector of the data. Defaults to None, which will be replaced by [-1], i.e. the full first dimension.
+        values. This must be a vector of the data. Defaults to None, which will be replaced by an index referring to the full first dimension.
         :type: list of int
 
         :returns: the newly created RangeDimension
@@ -158,7 +158,8 @@ class DataArray(Entity, DataSet):
         dim_index = len(self.dimensions) + 1
         rdim = RangeDimension.create_new(self, dim_index, None)
         if index is None:
-            index = [-1]
+            index = [0] * len(self.shape)
+            index[0] = -1
         rdim.link_data_array(self, index)
         return rdim
 

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -86,7 +86,7 @@ class DimensionLink(object):
 
     @property
     def id(self):
-        self._h5group.get_attr("entity_id")
+        return self._h5group.get_attr("entity_id")
 
     @property
     def file(self):

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -486,12 +486,15 @@ class RangeDimension(Dimension):
         to any DataArray or DataFrame.
         For downward compatibility this method has been re-introduced in 1.5.1.
 
-        :returns: True, if this dimension links to an DataArray, False otherwise
+        :returns: True, if this dimension links to a DataArray, False otherwise
         :rtype: bool
         """
-        if self.has_link:
-            if self.dimension_link._data_object_type == "DataArray":
-                return True
+        if self._h5group.has_data("ticks"):
+            return False
+        elif not self.has_link and len(self._h5group) > 0:
+            return True
+        elif self.has_link and self.dimension_link._data_object_type == "DataArray":
+            return True
         return False
 
     @property

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -467,6 +467,18 @@ class RangeDimension(Dimension):
         return newdim
 
     @property
+    def is_alias(self):
+        """[summary]
+
+        Returns:
+            [type]: [description]
+        """
+        if self.has_link:
+            if self.dimension_link._data_object_type == "DataArray":
+                return True
+        return False
+
+    @property
     def ticks(self):
         if self.has_link:
             ticks = self.dimension_link.values

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -496,9 +496,26 @@ class RangeDimension(Dimension):
         elif self.has_link and self.dimension_link._data_object_type == "DataArray":
             return True
         return False
-
+    
+    @property
+    def _redirgrp(self):
+        """
+        If the dimension is an Alias Range dimension, this property returns
+        the H5Group of the linked DataArray. Otherwise, it returns the H5Group
+        representing the dimension.
+        """
+        if self.is_alias:
+            gname = self._h5group.get_by_pos(0).name
+            return self._h5group.open_group(gname)
+        return self._h5group
+    
     @property
     def ticks(self):
+        if self.is_alias and not self.has_link:
+            g = self._redirgrp
+            if g.has_data("data"):
+                ticks = g.get_data("data")
+                return tuple(ticks)
         if self.has_link:
             ticks = self.dimension_link.values
         else:

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -468,10 +468,14 @@ class RangeDimension(Dimension):
 
     @property
     def is_alias(self):
-        """[summary]
+        """
+        In versions < 1.5 a RangeDimension that was referring to the DataArray it describes
+        was called an AliasRangeDimension. This has been made more flexible by allowing to link
+        to any DataArray or DataFrame.
+        For downward compatibility this method has been re-introduced in 1.5.1.
 
-        Returns:
-            [type]: [description]
+        :returns: True, if this dimension links to an DataArray, False otherwise
+        :rtype: bool
         """
         if self.has_link:
             if self.dimension_link._data_object_type == "DataArray":

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -389,13 +389,12 @@ class SampledDimension(Dimension):
         :param start: positive integer, indicates the starting sample.
 
         :returns: The created axis
-        :rtype: list
+        :rtype: tuple
         """
         offset = self.offset if self.offset else 0.0
         sample = self.sampling_interval
         start_val = start * sample + offset
-        end_val = (start + count) * sample + offset
-        return tuple(np.arange(start_val, end_val, sample))
+        return tuple(np.arange(count) * sample + start_val)
 
     @property
     def label(self):

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -390,14 +390,18 @@ class TestLinkDimension(unittest.TestCase):
         assert da.dimensions[0].unit == da.unit
         assert np.all(da.dimensions[0].ticks == da[:])
         assert rdim.is_alias
-        
+
         da.delete_dimensions()
         da.append_range_dimension_using_self()
         assert len(da.dimensions) == 1
         assert da.dimensions[0].is_alias
-        
+
         da.delete_dimensions()
-        self.assertRaises(IncompatibleDimensions, da.append_range_dimension_using_self([0, -1]))
+        with self.assertRaises(IncompatibleDimensions):
+            da.append_range_dimension_using_self([0, -1])
+        with self.assertRaises(ValueError):
+            da.append_range_dimension_using_self([-2])
+
         da.append_range_dimension_using_self([-1])
         assert len(da.dimensions) == 1
         assert da.dimensions[0].is_alias

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -388,7 +388,7 @@ class TestLinkDimension(unittest.TestCase):
         assert da.dimensions[0].label == da.label
         assert da.dimensions[0].unit == da.unit
         assert np.all(da.dimensions[0].ticks == da[:])
-        assert rdim.is_alias == True
+        assert rdim.is_alias
 
     def test_data_array_self_link_set_dimension(self):
         # The new way of making alias range dimension
@@ -433,7 +433,7 @@ class TestLinkDimension(unittest.TestCase):
                                        tuple(v[2] for v in values))
         assert self.range_dim.unit == df.units[2]
         assert self.range_dim.label == df.column_names[2]
-        assert self.range_dim.is_alias == False
+        assert not self.range_dim.is_alias
 
     def test_data_frame_set_link_dimension(self):
         column_descriptions = OrderedDict([("name", nix.DataType.String),

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -388,6 +388,7 @@ class TestLinkDimension(unittest.TestCase):
         assert da.dimensions[0].label == da.label
         assert da.dimensions[0].unit == da.unit
         assert np.all(da.dimensions[0].ticks == da[:])
+        assert rdim.is_alias == True
 
     def test_data_array_self_link_set_dimension(self):
         # The new way of making alias range dimension
@@ -432,6 +433,7 @@ class TestLinkDimension(unittest.TestCase):
                                        tuple(v[2] for v in values))
         assert self.range_dim.unit == df.units[2]
         assert self.range_dim.label == df.column_names[2]
+        assert self.range_dim.is_alias == False
 
     def test_data_frame_set_link_dimension(self):
         column_descriptions = OrderedDict([("name", nix.DataType.String),

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -392,6 +392,10 @@ class TestLinkDimension(unittest.TestCase):
         assert rdim.is_alias
 
         da.delete_dimensions()
+        da.append_range_dimension()
+        assert not da.dimensions[0].is_alias
+        
+        da.delete_dimensions()
         da.append_range_dimension_using_self()
         assert len(da.dimensions) == 1
         assert da.dimensions[0].is_alias

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -6,6 +6,7 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
+from nixio.exceptions.exceptions import IncompatibleDimensions
 import os
 import unittest
 import numpy as np
@@ -389,6 +390,17 @@ class TestLinkDimension(unittest.TestCase):
         assert da.dimensions[0].unit == da.unit
         assert np.all(da.dimensions[0].ticks == da[:])
         assert rdim.is_alias
+        
+        da.delete_dimensions()
+        da.append_range_dimension_using_self()
+        assert len(da.dimensions) == 1
+        assert da.dimensions[0].is_alias
+        
+        da.delete_dimensions()
+        self.assertRaises(IncompatibleDimensions, da.append_range_dimension_using_self([0, -1]))
+        da.append_range_dimension_using_self([-1])
+        assert len(da.dimensions) == 1
+        assert da.dimensions[0].is_alias
 
     def test_data_array_self_link_set_dimension(self):
         # The new way of making alias range dimension


### PR DESCRIPTION
fixes
* missing return in ``DimensionLink.id``
* a few docstrings
* the version number in appveyor.yml
* ``SampledDimension.axis`` returned the wrong number of data points (off by 1 due to rounding issues under certain conditions)

adds
* ``RangeDimension.is_alias`` method for downward compatibility
* ``DataArray.append_range_dimension_using_self`` as a convenience method
