### PR TITLE
Allow DataViews to become invalid fixes #502

### DIFF
--- a/nixio/data_view.py
+++ b/nixio/data_view.py
@@ -21,14 +21,13 @@ class DataView(DataSet):
     def __init__(self, da, slices):
         self._valid = slices is not None and all(slices)
         self._slices = slices
+        self._error_message = ""
         if not self.valid:
             self._error_message = (
                 "InvalidSlice error!"
                 "Given slice {} is invalid! At least one slice along one dimension"
                 "does not contain data.".format(slices)
             )
-        else:
-            self._error_message = ""
 
         if self.valid and len(slices) != len(da.shape):
             # This is always checked by the calling function, but we repeat

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -436,8 +436,8 @@ class SampledDimension(Dimension):
         try:
             start_index = self.index_of(start_position, mode=IndexMode.GreaterOrEqual)
             end_index = self.index_of(end_position, mode=end_mode)
-        except IndexError as e:
-            raise IndexError("Error using SampledDimension.range_indices: {}".format(e))
+        except IndexError:
+            return None
         if start_index > end_index:
             return None
         return (start_index, end_index)
@@ -694,8 +694,8 @@ class RangeDimension(Dimension):
         try:
             start_index = self.index_of(start_position, mode=IndexMode.GreaterOrEqual, ticks=ticks)
             end_index = self.index_of(end_position, mode=end_mode, ticks=ticks)
-        except IndexError as e:
-            raise IndexError("Error using SampledDimension.range_indices: {}".format(e))
+        except IndexError:
+            return None
         if start_index > end_index:
             return None
         return (start_index, end_index)
@@ -853,8 +853,8 @@ class SetDimension(Dimension):
         try:
             start = self.index_of(start_position, mode=IndexMode.GreaterOrEqual, dim_labels=dim_labels)
             end = self.index_of(end_position, mode=end_mode, dim_labels=dim_labels)
-        except IndexError as e:
-            raise IndexError("Error using SetDimension.range_indices: {}".format(e))
+        except IndexError:
+            return None
         if start > end:
             return None
         return (start, end)

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -803,19 +803,17 @@ class SetDimension(Dimension):
         :param mode: The nixio.RangeMode. Defaults to nixio.RangeMode.Exclusive, i.e. the end position is not part of the range.
         :type mode: nixio.RangeMode
 
-        :returns: The respective start and end indices.
+        :returns: The respective start and end indices. None, if the range is empty
         :rtype: tuple of int
 
         :raises: ValueError if invalid mode is given
         :raises: Index Error if start position is greater than end position.
         """
-
-        dim_labels = self.labels
         if mode is not RangeMode.Exclusive and mode is not RangeMode.Inclusive:
             raise ValueError("Unknown RangeMode: {}".format(mode))
 
+        dim_labels = self.labels
         end_mode = IndexMode.Less if mode == RangeMode.Exclusive else IndexMode.LessOrEqual
-
         if start_position > end_position:
             raise IndexError("Start position {} is greater than end position {}.".format(start_position, end_position))
         try:
@@ -823,4 +821,6 @@ class SetDimension(Dimension):
             end = self.index_of(end_position, mode=end_mode, dim_labels=dim_labels)
         except IndexError as e:
             raise IndexError("Error using SetDimension.range_indices: {}".format(e))
+        if start > end:
+            return None
         return (start, end)

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -422,7 +422,7 @@ class SampledDimension(Dimension):
         :param mode: The nixio.RangeMode. Defaults to nixio.RangeMode.Exclusive, i.e. the end position is not part of the range.
         :type mode: nixio.RangeMode
 
-        :returns: The respective start and end indices.
+        :returns: The respective start and end indices. None, if the range is empty!
         :rtype: tuple of int
 
         :raises: ValueError if invalid mode is given
@@ -438,7 +438,7 @@ class SampledDimension(Dimension):
         except IndexError as e:
             raise IndexError("Error using SampledDimension.range_indices: {}".format(e))
         if start_index > end_index:
-            raise IndexError("Start position {} is greater than end position {}.".format(start_position, end_position))
+            return None
         return (start_index, end_index)
 
     def axis(self, count, start=None, start_position=None):

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -37,6 +37,16 @@ class IndexMode(Enum):
     GEQ = "geq"
 
 
+class RangeMode(Enum):
+    """
+    RangeMode used for slicing along dimensions. 
+    *Inclusive* ranges are defines as [start, end], i.e. start and end are included
+    *Exclusive* ranges are defined as [start, end), i.e. start is included, end is not
+    """
+    Inclusive = "inclusive"
+    Exclusive = "exclusive"
+
+
 class DimensionContainer(Container):
     """
     DimensionContainer extends Container to support returning different types

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -391,7 +391,7 @@ class SampledDimension(Dimension):
             ))
 
         if np.isclose(position, 0) and mode == IndexMode.Less:
-            raise IndexError("Position {} is out of bounds for SetDimension with mode {}".format(position, mode.name))
+            raise IndexError("Position {} is out of bounds for SampledDimension with mode {}".format(position, mode.name))
 
         index = int(np.floor(scaled_position))
         if np.isclose(scaled_position, index):
@@ -410,6 +410,36 @@ class SampledDimension(Dimension):
             return index
 
         raise ValueError("Unknown IndexMode: {}".format(mode))
+
+    def range_indices(self, start_position, end_position, mode=RangeMode.Exclusive):
+        """
+        Returns the start and end indices in this dimension that are matching to the given start and end position.
+
+        :param start_position: the start position of the range.
+        :type start_position: float
+        :param end_position: the end position of the range.
+        :type end_position: fload
+        :param mode: The nixio.RangeMode. Defaults to nixio.RangeMode.Exclusive, i.e. the end position is not part of the range.
+        :type mode: nixio.RangeMode
+        
+        :returns: The respective start and end indices.
+        :rtype: tuple of int
+        
+        :raises: ValueError if invalid mode is given
+        :raises: Index Error if start position is greater than end position.
+        """
+        if mode is not RangeMode.Exclusive and mode is not RangeMode.Inclusive:
+            raise ValueError("Unknown RangeMode: {}".format(mode))
+
+        end_mode = IndexMode.Less if mode == RangeMode.Exclusive else IndexMode.LessOrEqual
+        try:
+            start_index = self.index_of(start_position, mode=IndexMode.GreaterOrEqual)
+            end_index = self.index_of(end_position, mode=end_mode)
+        except IndexError as e:
+            raise e
+        if start_index > end_index:
+            raise IndexError("Start position {} is greater than end position {}.".format(start_position, end_position))
+        return (start_index, end_index)
 
     def axis(self, count, start=None, start_position=None):
         """

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -37,14 +37,15 @@ class IndexMode(Enum):
     GEQ = "geq"
 
 
-class RangeMode(Enum):
-    """
-    RangeMode used for slicing along dimensions. 
-    *Inclusive* ranges are defines as [start, end], i.e. start and end are included
-    *Exclusive* ranges are defined as [start, end), i.e. start is included, end is not
-    """
-    Inclusive = "inclusive"
+class SliceMode(Enum):
     Exclusive = "exclusive"
+    Inclusive = "inclusive"
+
+    def to_index_mode(self):
+        if self == self.Exclusive:
+            return IndexMode.Less
+        if self == self.Inclusive:
+            return IndexMode.LessOrEqual
 
 
 class DimensionContainer(Container):
@@ -411,7 +412,7 @@ class SampledDimension(Dimension):
 
         raise ValueError("Unknown IndexMode: {}".format(mode))
 
-    def range_indices(self, start_position, end_position, mode=RangeMode.Exclusive):
+    def range_indices(self, start_position, end_position, mode=SliceMode.Exclusive):
         """
         Returns the start and end indices in this dimension that are matching to the given start and end position.
 
@@ -419,8 +420,8 @@ class SampledDimension(Dimension):
         :type start_position: float
         :param end_position: the end position of the range.
         :type end_position: float
-        :param mode: The nixio.RangeMode. Defaults to nixio.RangeMode.Exclusive, i.e. the end position is not part of the range.
-        :type mode: nixio.RangeMode
+        :param mode: The nixio.SliceMode. Defaults to nixio.SliceMode.Exclusive, i.e. the end position is not part of the range.
+        :type mode: nixio.SliceMode
 
         :returns: The respective start and end indices. None, if the range is empty!
         :rtype: tuple of int
@@ -428,10 +429,10 @@ class SampledDimension(Dimension):
         :raises: ValueError if invalid mode is given
         :raises: Index Error if start position is greater than end position.
         """
-        if mode is not RangeMode.Exclusive and mode is not RangeMode.Inclusive:
-            raise ValueError("Unknown RangeMode: {}".format(mode))
+        if mode is not SliceMode.Exclusive and mode is not SliceMode.Inclusive:
+            raise ValueError("Unknown SliceMode: {}".format(mode))
 
-        end_mode = IndexMode.Less if mode == RangeMode.Exclusive else IndexMode.LessOrEqual
+        end_mode = IndexMode.Less if mode == SliceMode.Exclusive else IndexMode.LessOrEqual
         try:
             start_index = self.index_of(start_position, mode=IndexMode.GreaterOrEqual)
             end_index = self.index_of(end_position, mode=end_mode)
@@ -667,7 +668,7 @@ class RangeDimension(Dimension):
 
         raise ValueError("Unknown IndexMode: {}".format(mode))
 
-    def range_indices(self, start_position, end_position, mode=RangeMode.Exclusive):
+    def range_indices(self, start_position, end_position, mode=SliceMode.Exclusive):
         """
         Returns the start and end indices in this dimension that are matching to the given start and end position.
 
@@ -675,8 +676,8 @@ class RangeDimension(Dimension):
         :type start_position: float
         :param end_position: the end position of the range.
         :type end_position: float
-        :param mode: The nixio.RangeMode. Defaults to nixio.RangeMode.Exclusive, i.e. the end position is not part of the range.
-        :type mode: nixio.RangeMode
+        :param mode: The nixio.SliceMode. Defaults to nixio.SliceMode.Exclusive, i.e. the end position is not part of the range.
+        :type mode: nixio.SliceMode
 
         :returns: The respective start and end indices. None, if range is empty
         :rtype: tuple of int
@@ -684,12 +685,12 @@ class RangeDimension(Dimension):
         :raises: ValueError if invalid mode is given
         :raises: Index Error if start position is greater than end position.
         """
-        if mode is not RangeMode.Exclusive and mode is not RangeMode.Inclusive:
-            raise ValueError("Unknown RangeMode: {}".format(mode))
+        if mode is not SliceMode.Exclusive and mode is not SliceMode.Inclusive:
+            raise ValueError("Unknown SliceMode: {}".format(mode))
         if start_position > end_position:
             raise IndexError("Start position {} is greater than end position {}.".format(start_position, end_position))
         ticks = self.ticks
-        end_mode = IndexMode.Less if mode == RangeMode.Exclusive else IndexMode.LessOrEqual
+        end_mode = IndexMode.Less if mode == SliceMode.Exclusive else IndexMode.LessOrEqual
         try:
             start_index = self.index_of(start_position, mode=IndexMode.GreaterOrEqual, ticks=ticks)
             end_index = self.index_of(end_position, mode=end_mode, ticks=ticks)
@@ -825,7 +826,7 @@ class SetDimension(Dimension):
 
         raise ValueError("Unknown IndexMode: {}".format(mode))
 
-    def range_indices(self, start_position, end_position, mode=RangeMode.Exclusive):
+    def range_indices(self, start_position, end_position, mode=SliceMode.Exclusive):
         """
         Returns the start and end indices in this dimension that are matching to the given start and end position.
 
@@ -833,8 +834,8 @@ class SetDimension(Dimension):
         :type start_position: float
         :param end_position: the end position of the range.
         :type end_position: float
-        :param mode: The nixio.RangeMode. Defaults to nixio.RangeMode.Exclusive, i.e. the end position is not part of the range.
-        :type mode: nixio.RangeMode
+        :param mode: The nixio.SliceMode. Defaults to nixio.SliceMode.Exclusive, i.e. the end position is not part of the range.
+        :type mode: nixio.SliceMode
 
         :returns: The respective start and end indices. None, if the range is empty
         :rtype: tuple of int
@@ -842,11 +843,11 @@ class SetDimension(Dimension):
         :raises: ValueError if invalid mode is given
         :raises: Index Error if start position is greater than end position.
         """
-        if mode is not RangeMode.Exclusive and mode is not RangeMode.Inclusive:
-            raise ValueError("Unknown RangeMode: {}".format(mode))
+        if mode is not SliceMode.Exclusive and mode is not SliceMode.Inclusive:
+            raise ValueError("Unknown SliceMode: {}".format(mode))
 
         dim_labels = self.labels
-        end_mode = IndexMode.Less if mode == RangeMode.Exclusive else IndexMode.LessOrEqual
+        end_mode = IndexMode.Less if mode == SliceMode.Exclusive else IndexMode.LessOrEqual
         if start_position > end_position:
             raise IndexError("Start position {} is greater than end position {}.".format(start_position, end_position))
         try:

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -557,7 +557,7 @@ class RangeDimension(Dimension):
         elif self.has_link and self.dimension_link._data_object_type == "DataArray":
             return True
         return False
-    
+
     @property
     def _redirgrp(self):
         """
@@ -569,7 +569,7 @@ class RangeDimension(Dimension):
             gname = self._h5group.get_by_pos(0).name
             return self._h5group.open_group(gname)
         return self._h5group
-    
+
     @property
     def ticks(self):
         if self.is_alias and not self.has_link:
@@ -638,6 +638,8 @@ class RangeDimension(Dimension):
                     If the mode is Less, the previous index of the matching tick is always returned.
                     If the mode is GreaterOrEqual and the position does not match a tick exactly, the next index is
                     returned.
+        :param ticks: Optional, the ticks stored in this dimension. If not passed as argument, they are (re)read from file.
+        :type ticks: iterable
 
         :returns: The matching index
         :rtype: int
@@ -786,6 +788,7 @@ class SetDimension(Dimension):
                     rounded down (for LessOrEqual) or rounded up (for GreaterOrEqual).
                     If the mode is Less, the previous integer is always returned.
         :param dim_labels: The labels of this dimension, if None (default) the labels will be read from file.
+        :type dim_labels: iterable
 
         :returns: The matching index
         :rtype: int

--- a/nixio/exceptions/__init__.py
+++ b/nixio/exceptions/__init__.py
@@ -1,6 +1,6 @@
 from .exceptions import (DuplicateName, UninitializedEntity, InvalidUnit,
                          InvalidAttrType, InvalidEntity, OutOfBounds,
-                         IncompatibleDimensions, InvalidFile,
+                         IncompatibleDimensions, InvalidFile, InvalidSlice,
                          DuplicateColumnName, UnsupportedLinkType)
 
 __all__ = (

--- a/nixio/exceptions/exceptions.py
+++ b/nixio/exceptions/exceptions.py
@@ -47,6 +47,13 @@ class InvalidEntity(Exception):
         super(InvalidEntity, self).__init__(self.message, *args, **kwargs)
 
 
+class InvalidSlice(Exception):
+
+    def __init__(self, *args, **kwargs):
+        self.message = "Trying to access data with an invalid slice."
+        super(InvalidSlice, self).__init__(self.message, *args, **kwargs)
+
+
 class OutOfBounds(IndexError):
 
     def __init__(self, message, index=None):

--- a/nixio/multi_tag.py
+++ b/nixio/multi_tag.py
@@ -139,8 +139,6 @@ class MultiTag(BaseTag):
         ref = references[refidx]
 
         slices = self._calc_data_slices_mtag(ref, posidx, stop_rule)
-        if not self._slices_in_data(ref, slices):
-            raise OutOfBounds("References data slice out of the extent of the DataArray!")
         return DataView(ref, slices)
 
     def retrieve_feature_data(self, posidx, featidx):

--- a/nixio/tag.py
+++ b/nixio/tag.py
@@ -122,7 +122,6 @@ class BaseTag(Entity):
             units = self.units
 
         for idx, dim in enumerate(data.dimensions):
-            scaling = 1.0
             if idx < len(position):
                 start_pos = position[idx]
                 start_pos, scaling = self._scale_position(start_pos, units[idx], dim)

--- a/nixio/tag.py
+++ b/nixio/tag.py
@@ -151,6 +151,37 @@ class BaseTag(Entity):
         return np.all(np.less_equal(stops, dasize))
 
     @staticmethod
+    def _scale_position(pos, unit, dim):
+        dimtype = dim.dimension_type
+        if dimtype == DimensionType.Set:
+            dimunit = None
+        else:
+            dimunit = dim.unit
+        scaling = 1.0
+        if dimtype == DimensionType.Set:
+            if unit and unit != "none":
+                raise IncompatibleDimensions(
+                    "Cannot apply a position with unit to a SetDimension",
+                    "Tag._pos_to_idx"
+                )
+        else:
+            if dimunit is None and unit is not None:
+                raise IncompatibleDimensions(
+                    "Units of position and SampledDimension "
+                    "must both be given!",
+                    "Tag._pos_to_idx"
+                )
+            elif dimunit is not None and unit is not None:
+                try:
+                    scaling = util.units.scaling(unit, dimunit)
+                except InvalidUnit:
+                    raise IncompatibleDimensions(
+                        "Cannot scale Tag unit {} to match dimension unit {}".format(unit, dimunit),
+                        "Tag._pos_to_idx"
+                    )
+        return pos * scaling, scaling
+
+    @staticmethod
     def _pos_to_idx(pos, unit, dim, mode):
         dimtype = dim.dimension_type
         if dimtype == DimensionType.Set:

--- a/nixio/tag.py
+++ b/nixio/tag.py
@@ -25,19 +25,7 @@ from .dimension_type import DimensionType
 from .link_type import LinkType
 from . import util
 from .section import Section
-from enum import Enum
-from .dimensions import IndexMode
-
-
-class SliceMode(Enum):
-    Exclusive = "exclusive"
-    Inclusive = "inclusive"
-
-    def to_index_mode(self):
-        if self == self.Exclusive:
-            return IndexMode.Less
-        if self == self.Inclusive:
-            return IndexMode.LessOrEqual
+from .dimensions import SliceMode
 
 
 class FeatureContainer(Container):

--- a/nixio/tag.py
+++ b/nixio/tag.py
@@ -167,8 +167,7 @@ class BaseTag(Entity):
         else:
             if dimunit is None and unit is not None:
                 raise IncompatibleDimensions(
-                    "Units of position and SampledDimension "
-                    "must both be given!",
+                    "If a unit if given for the position the dimension must not be without a unit!",
                     "Tag._pos_to_idx"
                 )
             elif dimunit is not None and unit is not None:

--- a/nixio/test/test_data_view.py
+++ b/nixio/test/test_data_view.py
@@ -123,7 +123,6 @@ class TestDataView(unittest.TestCase):
 
     def test_data_view_oob(self):
         da = self.file.blocks[0].data_arrays[0]
-        from IPython import embed
 
         dv = da.get_slice((41, 81), extents=(1, 1))
         assert not dv.valid

--- a/nixio/test/test_data_view.py
+++ b/nixio/test/test_data_view.py
@@ -123,17 +123,21 @@ class TestDataView(unittest.TestCase):
 
     def test_data_view_oob(self):
         da = self.file.blocks[0].data_arrays[0]
+        from IPython import embed
 
-        with self.assertRaises(nix.exceptions.OutOfBounds):
-            da.get_slice((41, 81), extents=(1, 1))
+        dv = da.get_slice((41, 81), extents=(1, 1))
+        assert not dv.valid
+        assert "OutOfBounds error" in dv.debug_message
 
-        with self.assertRaises(nix.exceptions.OutOfBounds):
-            da.get_slice((0, 0), extents=(100, 5))
+        dv = da.get_slice((0, 0), extents=(100, 5))
+        assert not dv.valid
+        assert "OutOfBounds error" in dv.debug_message
 
         with self.assertRaises(nix.exceptions.IncompatibleDimensions):
             da.get_slice((0, 0, 0), extents=(5, 5, 5))
 
         dv = da.get_slice((5, 8), extents=(10, 20))
+        assert dv.valid
 
         with self.assertRaises(nix.exceptions.OutOfBounds):
             _ = dv[12, :]

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -6,7 +6,7 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
-from nixio.dimensions import RangeMode
+from nixio.dimensions import SliceMode
 from nixio.exceptions.exceptions import IncompatibleDimensions
 import os
 import unittest
@@ -114,28 +114,30 @@ class TestDimension(unittest.TestCase):
         with self.assertRaises(IndexError):
             self.sample_dim.range_indices(10, -10, mode=RangeMode.Inclusive)
         range_indices = self.sample_dim.range_indices(2, 11, mode=RangeMode.Inclusive)
+        self.assertIsNone(self.sample_dim.range_indices(10, -10, mode=SliceMode.Inclusive))
+        range_indices = self.sample_dim.range_indices(2, 11, mode=SliceMode.Inclusive)
         assert range_indices[0] == 0
         assert range_indices[-1] == 4
 
-        range_indices = self.sample_dim.range_indices(2, 11, mode=RangeMode.Exclusive)
+        range_indices = self.sample_dim.range_indices(2, 11, mode=SliceMode.Exclusive)
         assert range_indices[0] == 0
         assert range_indices[-1] == 3
 
-        range_indices = self.sample_dim.range_indices(3., 3.1, mode=RangeMode.Inclusive)
+        range_indices = self.sample_dim.range_indices(3., 3.1, mode=SliceMode.Inclusive)
         assert range_indices[0] == 0
         assert range_indices[-1] == 0
-        range_indices = self.sample_dim.range_indices(3., 3.1, mode=RangeMode.Exclusive)
+        range_indices = self.sample_dim.range_indices(3., 3.1, mode=SliceMode.Exclusive)
         assert range_indices[0] == 0
         assert range_indices[-1] == 0
 
-        range_indices = self.sample_dim.range_indices(3.1, 3.2, mode=RangeMode.Inclusive)
+        range_indices = self.sample_dim.range_indices(3.1, 3.2, mode=SliceMode.Inclusive)
         self.assertIsNone(range_indices)
-        range_indices = self.sample_dim.range_indices(3.1, 3.2, mode=RangeMode.Exclusive)
+        range_indices = self.sample_dim.range_indices(3.1, 3.2, mode=SliceMode.Exclusive)
         self.assertIsNone(range_indices)
 
-        range_indices = self.sample_dim.range_indices(3.1, 5.0, mode=RangeMode.Inclusive)
+        range_indices = self.sample_dim.range_indices(3.1, 5.0, mode=SliceMode.Inclusive)
         self.assertIsNotNone(range_indices)
-        range_indices = self.sample_dim.range_indices(3.1, 5.0, mode=RangeMode.Exclusive)
+        range_indices = self.sample_dim.range_indices(3.1, 5.0, mode=SliceMode.Exclusive)
         self.assertIsNone(range_indices)
 
     def test_range_dimension(self):
@@ -185,20 +187,20 @@ class TestDimension(unittest.TestCase):
         with self.assertRaises(IndexError):
             self.range_dim.range_indices(10, -10)
 
-        self.assertIsNone(self.range_dim.range_indices(3.15, 3.16, mode=RangeMode.Inclusive))
-        self.assertIsNone(self.range_dim.range_indices(3.15, 3.16, mode=RangeMode.Exclusive))
+        self.assertIsNone(self.range_dim.range_indices(3.15, 3.16, mode=SliceMode.Inclusive))
+        self.assertIsNone(self.range_dim.range_indices(3.15, 3.16, mode=SliceMode.Exclusive))
 
-        range_indices = self.range_dim.range_indices(3.14, 4.0, mode=RangeMode.Inclusive)
+        range_indices = self.range_dim.range_indices(3.14, 4.0, mode=SliceMode.Inclusive)
         assert range_indices[0] == 1
         assert range_indices[1] == 1
-        range_indices = self.range_dim.range_indices(3.14, 4.0, mode=RangeMode.Exclusive)
+        range_indices = self.range_dim.range_indices(3.14, 4.0, mode=SliceMode.Exclusive)
         assert range_indices[0] == 1
         assert range_indices[1] == 1
 
-        range_indices = self.range_dim.range_indices(6.2, 25.12, mode=RangeMode.Inclusive)
+        range_indices = self.range_dim.range_indices(6.2, 25.12, mode=SliceMode.Inclusive)
         assert range_indices[0] == 2
         assert range_indices[1] == 8
-        range_indices = self.range_dim.range_indices(6.2, 25.12, mode=RangeMode.Exclusive)
+        range_indices = self.range_dim.range_indices(6.2, 25.12, mode=SliceMode.Exclusive)
         assert range_indices[0] == 2
         assert range_indices[1] == 7
 
@@ -309,25 +311,25 @@ class TestDimension(unittest.TestCase):
         with self.assertRaises(IndexError):
             self.set_dim.range_indices(10, -10)
 
-        range_indices = self.set_dim.range_indices(0.1, 0.4, mode=RangeMode.Inclusive)
+        range_indices = self.set_dim.range_indices(0.1, 0.4, mode=SliceMode.Inclusive)
         self.assertIsNone(range_indices)
-        range_indices = self.set_dim.range_indices(0.1, 0.4, mode=RangeMode.Exclusive)
+        range_indices = self.set_dim.range_indices(0.1, 0.4, mode=SliceMode.Exclusive)
         self.assertIsNone(range_indices)
 
-        range_indices = self.set_dim.range_indices(0.1, 1.0, mode=RangeMode.Inclusive)
+        range_indices = self.set_dim.range_indices(0.1, 1.0, mode=SliceMode.Inclusive)
         self.assertIsNotNone(range_indices)
         assert range_indices[0] == 1
         assert range_indices[1] == 1
-        range_indices = self.set_dim.range_indices(0.1, 1.0, mode=RangeMode.Exclusive)
+        range_indices = self.set_dim.range_indices(0.1, 1.0, mode=SliceMode.Exclusive)
         self.assertIsNone(range_indices)
-        range_indices = self.set_dim.range_indices(0.1, 1.1, mode=RangeMode.Exclusive)
+        range_indices = self.set_dim.range_indices(0.1, 1.1, mode=SliceMode.Exclusive)
         self.assertIsNotNone(range_indices)
         assert range_indices[0] == 1
         assert range_indices[1] == 1
-        range_indices = self.set_dim.range_indices(0, 9, mode=RangeMode.Exclusive)
+        range_indices = self.set_dim.range_indices(0, 9, mode=SliceMode.Exclusive)
         assert range_indices[0] == 0
         assert range_indices[-1] == 8
-        range_indices = self.set_dim.range_indices(0, 9, mode=RangeMode.Inclusive)
+        range_indices = self.set_dim.range_indices(0, 9, mode=SliceMode.Inclusive)
         assert range_indices[0] == 0
         assert range_indices[-1] == 9
 

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -285,10 +285,28 @@ class TestDimension(unittest.TestCase):
             self.set_dim.range_indices(0, 10, mode="invalid")
         with self.assertRaises(IndexError):
             self.set_dim.range_indices(10, -10)
-        assert self.set_dim.range_indices(0, 9, mode=RangeMode.Exclusive)[0] == 0
-        assert self.set_dim.range_indices(0, 9, mode=RangeMode.Exclusive)[-1] == 8
-        assert self.set_dim.range_indices(0, 9, mode=RangeMode.Inclusive)[0] == 0
-        assert self.set_dim.range_indices(0, 9, mode=RangeMode.Inclusive)[-1] == 9
+
+        range_indices = self.set_dim.range_indices(0.1, 0.4, mode=RangeMode.Inclusive)
+        self.assertIsNone(range_indices)
+        range_indices = self.set_dim.range_indices(0.1, 0.4, mode=RangeMode.Exclusive)
+        self.assertIsNone(range_indices)
+
+        range_indices = self.set_dim.range_indices(0.1, 1.0, mode=RangeMode.Inclusive)
+        self.assertIsNotNone(range_indices)
+        assert range_indices[0] == 1
+        assert range_indices[1] == 1
+        range_indices = self.set_dim.range_indices(0.1, 1.0, mode=RangeMode.Exclusive)
+        self.assertIsNone(range_indices)
+        range_indices = self.set_dim.range_indices(0.1, 1.1, mode=RangeMode.Exclusive)
+        self.assertIsNotNone(range_indices)
+        assert range_indices[0] == 1
+        assert range_indices[1] == 1
+        range_indices = self.set_dim.range_indices(0, 9, mode=RangeMode.Exclusive)
+        assert range_indices[0] == 0
+        assert range_indices[-1] == 8
+        range_indices = self.set_dim.range_indices(0, 9, mode=RangeMode.Inclusive)
+        assert range_indices[0] == 0
+        assert range_indices[-1] == 9
 
     def test_sampled_dimension_modes(self):
         # exact

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -6,6 +6,7 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
+from nixio.dimensions import RangeMode
 from nixio.exceptions.exceptions import IncompatibleDimensions
 import os
 import unittest
@@ -107,6 +108,16 @@ class TestDimension(unittest.TestCase):
         assert self.sample_dim.axis(10, 0, 5.0)[0] == 3
         assert self.sample_dim.axis(10, start_position=5.0)[0] == 5.0
         assert self.sample_dim.axis(10, start_position=5.0)[-1] == 5.0 + 9 * 2
+
+        with self.assertRaises(ValueError):
+            self.sample_dim.range_indices(0, 1, mode="invalid")
+        with self.assertRaises(IndexError):
+            self.sample_dim.range_indices(10, -10, mode=RangeMode.Inclusive)
+        assert self.sample_dim.range_indices(2, 11, mode=RangeMode.Inclusive)[0] == 0
+        assert self.sample_dim.range_indices(2, 11, mode=RangeMode.Inclusive)[-1] == 4
+
+        assert self.sample_dim.range_indices(2, 11, mode=RangeMode.Exclusive)[0] == 0
+        assert self.sample_dim.range_indices(2, 11, mode=RangeMode.Exclusive)[-1] == 3
 
     def test_range_dimension(self):
         assert self.range_dim.index == 3

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -156,12 +156,12 @@ class TestDimension(unittest.TestCase):
         assert self.range_dim.unit is None
 
         assert self.range_dim.ticks == test_range
-        other = tuple([i*3.14 for i in range(10)])
+        other = tuple([i * 3.14 for i in range(10)])
         self.range_dim.ticks = other
         assert self.range_dim.ticks == other
 
         assert self.range_dim.index_of(0.) == 0
-        assert self.range_dim.index_of(10.) == (np.floor(10./3.14))
+        assert self.range_dim.index_of(10.) == (np.floor(10. / 3.14))
         assert self.range_dim.index_of(18.84) == 6
         assert self.range_dim.index_of(28.26) == 9
         assert self.range_dim.index_of(100.) == 9
@@ -178,6 +178,29 @@ class TestDimension(unittest.TestCase):
         with self.assertRaises(IndexError):
             self.range_dim.axis(10, 2)
             self.range_dim.axis(100)
+
+        #  ticks = (0.0, 3.14, 6.28, 9.42, 12.56, 15.7, 18.84, 21.98, 25.12, 28.26)
+        with self.assertRaises(ValueError):
+            self.range_dim.range_indices(0, 10, mode="invalid")
+        with self.assertRaises(IndexError):
+            self.range_dim.range_indices(10, -10)
+
+        self.assertIsNone(self.range_dim.range_indices(3.15, 3.16, mode=RangeMode.Inclusive))
+        self.assertIsNone(self.range_dim.range_indices(3.15, 3.16, mode=RangeMode.Exclusive))
+
+        range_indices = self.range_dim.range_indices(3.14, 4.0, mode=RangeMode.Inclusive)
+        assert range_indices[0] == 1
+        assert range_indices[1] == 1
+        range_indices = self.range_dim.range_indices(3.14, 4.0, mode=RangeMode.Exclusive)
+        assert range_indices[0] == 1
+        assert range_indices[1] == 1
+
+        range_indices = self.range_dim.range_indices(6.2, 25.12, mode=RangeMode.Inclusive)
+        assert range_indices[0] == 2
+        assert range_indices[1] == 8
+        range_indices = self.range_dim.range_indices(6.2, 25.12, mode=RangeMode.Exclusive)
+        assert range_indices[0] == 2
+        assert range_indices[1] == 7
 
     def test_set_dim_label_resize(self):
         setdim = self.array.append_set_dimension()
@@ -347,17 +370,17 @@ class TestDimension(unittest.TestCase):
 
         # valid oob below
         assert self.sample_dim.index_of(-30, nix.IndexMode.GreaterOrEqual) == 0
-        assert self.sample_dim.index_of(offset-0.3, nix.IndexMode.GreaterOrEqual) == 0
+        assert self.sample_dim.index_of(offset - 0.3, nix.IndexMode.GreaterOrEqual) == 0
 
         # invalid oob
         with self.assertRaises(IndexError):
-            self.sample_dim.index_of(offset-0.2, nix.IndexMode.Less)
+            self.sample_dim.index_of(offset - 0.2, nix.IndexMode.Less)
         with self.assertRaises(IndexError):
             self.sample_dim.index_of(0, nix.IndexMode.Less)
         with self.assertRaises(IndexError):
-            self.sample_dim.index_of(offset-0.01, nix.IndexMode.LessOrEqual)
+            self.sample_dim.index_of(offset - 0.01, nix.IndexMode.LessOrEqual)
         with self.assertRaises(IndexError):
-            self.sample_dim.index_of(offset-0.5)
+            self.sample_dim.index_of(offset - 0.5)
 
     def test_range_dimension_modes(self):
         # exact

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -111,9 +111,6 @@ class TestDimension(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             self.sample_dim.range_indices(0, 1, mode="invalid")
-        with self.assertRaises(IndexError):
-            self.sample_dim.range_indices(10, -10, mode=RangeMode.Inclusive)
-        range_indices = self.sample_dim.range_indices(2, 11, mode=RangeMode.Inclusive)
         self.assertIsNone(self.sample_dim.range_indices(10, -10, mode=SliceMode.Inclusive))
         range_indices = self.sample_dim.range_indices(2, 11, mode=SliceMode.Inclusive)
         assert range_indices[0] == 0

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -260,7 +260,16 @@ class TestDimension(unittest.TestCase):
         with self.assertRaises(IndexError):
             self.set_dim.index_of(12398, nix.IndexMode.GreaterOrEqual)
         with self.assertRaises(IndexError):
-            self.set_dim.index_of(len(test_labels)-0.5, nix.IndexMode.GreaterOrEqual)
+            self.set_dim.index_of(len(test_labels) - 0.5, nix.IndexMode.GreaterOrEqual)
+
+        with self.assertRaises(ValueError):
+            self.set_dim.range_indices(0, 10, mode="invalid")
+        with self.assertRaises(IndexError):
+            self.set_dim.range_indices(10, -10)
+        assert self.set_dim.range_indices(0, 9, mode=RangeMode.Exclusive)[0] == 0
+        assert self.set_dim.range_indices(0, 9, mode=RangeMode.Exclusive)[-1] == 8
+        assert self.set_dim.range_indices(0, 9, mode=RangeMode.Inclusive)[0] == 0
+        assert self.set_dim.range_indices(0, 9, mode=RangeMode.Inclusive)[-1] == 9
 
     def test_sampled_dimension_modes(self):
         # exact

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -113,11 +113,30 @@ class TestDimension(unittest.TestCase):
             self.sample_dim.range_indices(0, 1, mode="invalid")
         with self.assertRaises(IndexError):
             self.sample_dim.range_indices(10, -10, mode=RangeMode.Inclusive)
-        assert self.sample_dim.range_indices(2, 11, mode=RangeMode.Inclusive)[0] == 0
-        assert self.sample_dim.range_indices(2, 11, mode=RangeMode.Inclusive)[-1] == 4
+        range_indices = self.sample_dim.range_indices(2, 11, mode=RangeMode.Inclusive)
+        assert range_indices[0] == 0
+        assert range_indices[-1] == 4
 
-        assert self.sample_dim.range_indices(2, 11, mode=RangeMode.Exclusive)[0] == 0
-        assert self.sample_dim.range_indices(2, 11, mode=RangeMode.Exclusive)[-1] == 3
+        range_indices = self.sample_dim.range_indices(2, 11, mode=RangeMode.Exclusive)
+        assert range_indices[0] == 0
+        assert range_indices[-1] == 3
+
+        range_indices = self.sample_dim.range_indices(3., 3.1, mode=RangeMode.Inclusive)
+        assert range_indices[0] == 0
+        assert range_indices[-1] == 0
+        range_indices = self.sample_dim.range_indices(3., 3.1, mode=RangeMode.Exclusive)
+        assert range_indices[0] == 0
+        assert range_indices[-1] == 0
+
+        range_indices = self.sample_dim.range_indices(3.1, 3.2, mode=RangeMode.Inclusive)
+        self.assertIsNone(range_indices)
+        range_indices = self.sample_dim.range_indices(3.1, 3.2, mode=RangeMode.Exclusive)
+        self.assertIsNone(range_indices)
+
+        range_indices = self.sample_dim.range_indices(3.1, 5.0, mode=RangeMode.Inclusive)
+        self.assertIsNotNone(range_indices)
+        range_indices = self.sample_dim.range_indices(3.1, 5.0, mode=RangeMode.Exclusive)
+        self.assertIsNone(range_indices)
 
     def test_range_dimension(self):
         assert self.range_dim.index == 3

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ def get_wheel_data():
 classifiers = [
     'Development Status :: 5 - Production/Stable',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Topic :: Scientific/Engineering'


### PR DESCRIPTION
This PR changes the way ranges along a dimension are calculated. 
* allows DataView to be invalid and reading access will return an empty array
* range calculation is delegated to the dimensions respecting the SliceMode.
* allows for some simplification of the BaseTag._calc_data_slice method
* We do not necessarily return at minimum a single value along a given dimension. If there are no data points between start and end position the range is invalid and the DataView will become invalid and return an empty array. Just like slicing a numpy array that does not return a result. 
* Invalid DataViews return no data extent, write access will raise an exception. They offer a "debug message" containing the reason of their invalidity.

* I might be that I went a little far with removing the OOB and IncompatibleDimensions exceptions from DataView, happy to have your opinions..