### PR TITLE
Add documentation examples tests

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -37,7 +37,7 @@ jobs:
         pylint --rcfile=.pylintrc nixio
     - name: Test with pytest
       run: |
-        pip install pytest
+        pip install pytest scipy pillow
         # pytest will skip cross-compatibility tests since NIX isn't installed
         pytest
 
@@ -69,7 +69,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python setup.py install
-          pip install pytest
+          pip install pytest scipy pillow
       - name: Run tests
         run: |
           pytest
@@ -86,7 +86,7 @@ jobs:
       - name: Install dependencies
         run: |
           python setup.py install
-          pip install pytest coveralls
+          pip install pytest coveralls scipy pillow
       - name: Create coverage
         run: |
           coverage run --source=nixio -m pytest nixio/test/
@@ -107,7 +107,7 @@ jobs:
       - name: Install dependencies
         run: |
           python setup.py install
-          pip install pytest pytest-cov
+          pip install pytest pytest-cov scipy pillow
       - name: Create coverage
         run: |
           pytest --cov=./ --cov-report=xml

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -37,7 +37,7 @@ jobs:
         pylint --rcfile=.pylintrc nixio
     - name: Test with pytest
       run: |
-        pip install pytest scipy pillow
+        pip install pytest scipy pillow matplotlib
         # pytest will skip cross-compatibility tests since NIX isn't installed
         pytest
 
@@ -69,7 +69,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python setup.py install
-          pip install pytest scipy pillow
+          pip install pytest scipy pillow matplotlib
       - name: Run tests
         run: |
           pytest
@@ -86,7 +86,7 @@ jobs:
       - name: Install dependencies
         run: |
           python setup.py install
-          pip install pytest coveralls scipy pillow
+          pip install pytest coveralls scipy pillow matplotlib
       - name: Create coverage
         run: |
           coverage run --source=nixio -m pytest nixio/test/
@@ -107,7 +107,7 @@ jobs:
       - name: Install dependencies
         run: |
           python setup.py install
-          pip install pytest pytest-cov scipy pillow
+          pip install pytest pytest-cov scipy pillow matplotlib
       - name: Create coverage
         run: |
           pytest --cov=./ --cov-report=xml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,7 @@ install:
   # - cd ..
   - python -m pip install certifi
   - python -m pip install -U pip wheel
-  - python -m pip install numpy h5py pytest-xdist scipy pillow
+  - python -m pip install numpy h5py pytest-xdist scipy pillow matplotlib
   - ps: cd "$env:APPVEYOR_BUILD_FOLDER"
   - set DISTUTILS_USE_SDK="1"
   - set MSSdk="1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,7 @@ install:
   # - cd ..
   - python -m pip install certifi
   - python -m pip install -U pip wheel
-  - python -m pip install numpy h5py pytest-xdist
+  - python -m pip install numpy h5py pytest-xdist scipy pillow
   - ps: cd "$env:APPVEYOR_BUILD_FOLDER"
   - set DISTUTILS_USE_SDK="1"
   - set MSSdk="1"

--- a/docs/source/examples/imageData.py
+++ b/docs/source/examples/imageData.py
@@ -38,8 +38,8 @@ def load_image():
 
 
 def plot_data(data_array):
-    img_data = np.zeros(data_array.data.shape)
-    data_array.data.read_direct(img_data)
+    img_data = np.zeros(data_array.shape)
+    data_array.read_direct(img_data)
     img_data = np.array(img_data, dtype='uint8')
     new_img = img.fromarray(img_data)
     new_img.show()

--- a/docs/source/examples/imageWithMetadata.py
+++ b/docs/source/examples/imageWithMetadata.py
@@ -63,8 +63,8 @@ def load_image():
 
 
 def plot_data(data_array):
-    img_data = np.zeros(data_array.data.shape)
-    data_array.data.read_direct(img_data)
+    img_data = np.zeros(data_array.shape)
+    data_array.read_direct(img_data)
     img_data = np.array(img_data, dtype='uint8')
     new_img = img.fromarray(img_data)
 

--- a/docs/source/examples/imageWithMetadata.py
+++ b/docs/source/examples/imageWithMetadata.py
@@ -35,7 +35,7 @@ def print_metadata_table(section, ax):
     cell_text = []
     for p in section.items():
         for i, v in enumerate(p[1].values):
-            value = str(v.value)
+            value = str(v)
             if len(value) > 30:
                 value = value[:30] + '...'
             if i == 0:

--- a/docs/source/examples/multipleTimeSeries.py
+++ b/docs/source/examples/multipleTimeSeries.py
@@ -29,10 +29,10 @@ def create_data(duration=1, freq=10, stepsize=0.01):
 def plot_data(data_array):
     set_dim = data_array.dimensions[0]
     x_axis = data_array.dimensions[1]
-    x = np.arange(0, data_array.data.shape[1])
+    x = np.arange(0, data_array.shape[1])
     x = x * x_axis.sampling_interval + x_axis.offset
-    y = np.zeros(data_array.data.shape)
-    data_array.data.read_direct(y)
+    y = np.zeros(data_array.shape)
+    data_array.read_direct(y)
     for i, label in enumerate(set_dim.labels):
         plt.plot(x, y[i, :], label=label)
 

--- a/docs/source/examples/regularlySampledData.py
+++ b/docs/source/examples/regularlySampledData.py
@@ -27,8 +27,8 @@ def create_sinewave(duration=1, freq=10, stepsize=0.01):
 
 def plot_data(data_array):
     x_axis = data_array.dimensions[0]
-    x = x_axis.axis(data_array.data.shape[0])
-    y = data_array.data[:]
+    x = x_axis.axis(data_array.shape[0])
+    y = data_array[:]
 
     plt.plot(x, y, marker=".", markersize=5, label=data_array.name)
     plt.xlabel(x_axis.label + " [" + x_axis.unit + "]")

--- a/docs/source/examples/singleROI.py
+++ b/docs/source/examples/singleROI.py
@@ -52,7 +52,7 @@ def plot_data(tag):
     draw_rect(img_data, pos, ext)
     new_img = img.fromarray(img_data)
 
-    new_img.save("../images/single_roi.png")
+    # new_img.save("../images/single_roi.png")
     new_img.show()
 
 

--- a/docs/source/examples/singleROI.py
+++ b/docs/source/examples/singleROI.py
@@ -43,8 +43,8 @@ def draw_rect(img_data, position, extent):
 
 def plot_data(tag):
     data_array = tag.references[0]
-    img_data = np.zeros(data_array.data.shape)
-    data_array.data.read_direct(img_data)
+    img_data = np.zeros(data_array.shape)
+    data_array.read_direct(img_data)
     img_data = np.array(img_data, dtype='uint8')
     # positions and extents are double by default, need to convert to int
     pos = tuple(map(int, tag.position))

--- a/docs/source/examples/spikeFeatures.py
+++ b/docs/source/examples/spikeFeatures.py
@@ -47,8 +47,8 @@ def fake_neuron(stepsize=0.001, offset=.8, sta_offset=1000):
 
 def plot_data(tag):
     data_array = tag.references[0]
-    voltage = np.zeros(data_array.data.shape)
-    data_array.data.read_direct(voltage)
+    voltage = np.zeros(data_array.shape)
+    data_array.read_direct(voltage)
 
     x_axis = data_array.dimensions[0]
     time = x_axis.axis(data_array.data_extent[0])

--- a/docs/source/examples/spikeTagging.py
+++ b/docs/source/examples/spikeTagging.py
@@ -48,7 +48,7 @@ def plot_data(tag):
     ax.set_ylim((1.5 * np.min(voltage), 1.5 * np.max(voltage)))
     ax.legend()
     fig.subplots_adjust(bottom=0.175, top=0.975, right=0.975)
-    fig.savefig("../images/spike_tagging.png")
+    # fig.savefig("../images/spike_tagging.png")
     plt.show()
 
 

--- a/docs/source/examples/spikeTagging.py
+++ b/docs/source/examples/spikeTagging.py
@@ -29,14 +29,14 @@ def fake_neuron():
 
 def plot_data(tag):
     data_array = tag.references[0]
-    voltage = np.zeros(data_array.data.shape)
-    data_array.data.read_direct(voltage)
+    voltage = np.zeros(data_array.shape)
+    data_array.read_direct(voltage)
 
     x_axis = data_array.dimensions[0]
-    time = x_axis.axis(data_array.data.shape[0])
+    time = x_axis.axis(data_array.shape[0])
 
     spike_times = np.zeros(tag.positions.data_extent)
-    tag.positions.data.read_direct(spike_times)
+    tag.positions.read_direct(spike_times)
 
     fig = plt.figure(figsize=(5.5, 2.5))
     ax = fig.add_subplot(111)

--- a/nixio/test/test_doc_examples.py
+++ b/nixio/test/test_doc_examples.py
@@ -1,6 +1,7 @@
 import importlib.util as getmod
 import os
 import runpy
+import sys
 import unittest
 
 from pathlib import Path
@@ -69,11 +70,13 @@ class TestDocumentationExamples(unittest.TestCase):
         os.remove("file_create_example.nix")
 
     def test_image_data(self):
-        # Requires PIL package and the "Lenna" image.
-        self.handle_image()
-        self.run_script("imageData.py")
-        # cleanup
-        os.remove("image_example.nix")
+        # test will open image with an external program; does not work on windows
+        if sys.platform == 'linux':
+            # Requires PIL package and the "Lenna" image.
+            self.handle_image()
+            self.run_script("imageData.py")
+            # cleanup
+            os.remove("image_example.nix")
 
     def test_image_with_metadata(self):
         # Requires PIL package and the "Lenna" image.
@@ -119,11 +122,13 @@ class TestDocumentationExamples(unittest.TestCase):
         os.remove("regular_data_example.nix")
 
     def test_single_roi(self):
-        # Requires PIL package and the "Lenna" image.
-        self.handle_image()
-        self.run_script("singleROI.py")
-        # cleanup
-        os.remove("single_roi.nix")
+        # test will open image with an external program; does not work on windows
+        if sys.platform == 'linux':
+            # Requires PIL package and the "Lenna" image.
+            self.handle_image()
+            self.run_script("singleROI.py")
+            # cleanup
+            os.remove("single_roi.nix")
 
     def test_sources(self):
         self.run_script("sources.py")

--- a/nixio/test/test_doc_examples.py
+++ b/nixio/test/test_doc_examples.py
@@ -1,0 +1,211 @@
+import importlib.util as getmod
+import matplotlib.pyplot as plt
+import os
+import runpy
+import unittest
+
+from pathlib import Path
+from shutil import copyfile
+
+
+class TestDocumentationExamples(unittest.TestCase):
+
+    def setUp(self):
+        curr_path = os.getcwd()
+        if os.path.basename(curr_path) == "nixpy":
+            self.examples_path = Path.joinpath(Path(curr_path),
+                                               "docs", "source", "examples")
+        elif os.path.basename(curr_path) == "nixio":
+            self.examples_path = Path.joinpath(Path(curr_path).parent,
+                                               "docs", "source", "examples")
+        elif os.path.basename(curr_path) == "test":
+            self.examples_path = Path.joinpath(Path(curr_path).parent.parent,
+                                               "docs", "source", "examples")
+
+        # Render matplotlib plots non-blocking
+        plt.ion()
+
+    def tearDown(self):
+        plt.close("all")
+        plt.ioff()
+
+    def test_annotations(self):
+        file_path = Path.joinpath(self.examples_path, "annotations.py")
+        runpy.run_path(path_name=str(file_path), run_name="__main__")
+        # cleanup
+        os.remove("annotations.nix")
+
+    def test_category_data(self):
+        file_path = Path.joinpath(self.examples_path, "categoryData.py")
+        runpy.run_path(path_name=str(file_path), run_name="__main__")
+        # cleanup
+        os.remove("categoryData.nix")
+
+    def test_continuous_recording(self):
+        file_path = Path.joinpath(self.examples_path, "continuousRecording.py")
+        runpy.run_path(path_name=str(file_path), run_name="__main__")
+        # cleanup
+        os.remove("continuous_recording.nix")
+
+    def test_file_create(self):
+        file_path = Path.joinpath(self.examples_path, "fileCreate.py")
+        runpy.run_path(path_name=str(file_path), run_name="__main__")
+        # cleanup
+        os.remove("file_create_example.nix")
+
+    def test_image_data(self):
+        # Requires PIL package and the "Lenna" image.
+        image_path = Path.joinpath(self.examples_path, "lenna.png")
+        copyfile(str(image_path), str(Path.joinpath(Path(os.getcwd()), "lenna.png")))
+
+        file_path = Path.joinpath(self.examples_path, "imageData.py")
+        runpy.run_path(path_name=str(file_path), run_name="__main__")
+
+        # cleanup
+        os.remove("image_example.nix")
+        os.remove("lenna.png")
+
+    def test_image_with_metadata(self):
+        # Requires PIL package and the "Lenna" image.
+        image_path = Path.joinpath(self.examples_path, "lenna.png")
+        copyfile(str(image_path), str(Path.joinpath(Path(os.getcwd()), "lenna.png")))
+
+        file_path = Path.joinpath(self.examples_path, "imageWithMetadata.py")
+        runpy.run_path(path_name=str(file_path), run_name="__main__")
+
+        # cleanup
+        os.remove("image_with_source_example.h5")
+        os.remove("image_with_metadata.png")
+        os.remove("lenna.png")
+
+    def test_irregularly_sampled_data(self):
+        file_path = Path.joinpath(self.examples_path, "irregularlySampledData.py")
+        runpy.run_path(path_name=str(file_path), run_name="__main__")
+        # cleanup
+        os.remove("irregular_data_example.nix")
+
+    def test_lif(self):
+        file_path = Path.joinpath(self.examples_path, "lif.py")
+        runpy.run_path(path_name=str(file_path), run_name="__main__")
+
+    def test_multiple_points(self):
+        file_path = Path.joinpath(self.examples_path, "multiple_points.py")
+        runpy.run_path(path_name=str(file_path), run_name="__main__")
+        # cleanup
+        os.remove("multiple_points.nix")
+
+    def test_multiple_regions(self):
+        file_path = Path.joinpath(self.examples_path, "multiple_regions.py")
+        runpy.run_path(path_name=str(file_path), run_name="__main__")
+        # cleanup
+        os.remove("multiple_regions.nix")
+
+    def test_multiple_rois(self):
+        # Requires PIL package and the "Lenna" image.
+        image_path = Path.joinpath(self.examples_path, "lenna.png")
+        copyfile(str(image_path), str(Path.joinpath(Path(os.getcwd()), "lenna.png")))
+
+        file_path = Path.joinpath(self.examples_path, "multipleROIs.py")
+        runpy.run_path(path_name=str(file_path), run_name="__main__")
+
+        # cleanup
+        os.remove("lenna.png")
+        os.remove("multiple_roi.nix")
+
+    def test_range_dimension_link(self):
+        file_path = Path.joinpath(self.examples_path, "rangeDimensionLink.py")
+        runpy.run_path(path_name=str(file_path), run_name="__main__")
+        # cleanup
+        os.remove("range_link.nix")
+
+    def test_regularly_sampled_data(self):
+        file_path = Path.joinpath(self.examples_path, "regularlySampledData.py")
+        runpy.run_path(path_name=str(file_path), run_name="__main__")
+        # cleanup
+        os.remove("regular_data_example.nix")
+
+    def test_single_roi(self):
+        # Requires PIL package and the "Lenna" image.
+        image_path = Path.joinpath(self.examples_path, "lenna.png")
+        copyfile(str(image_path), str(Path.joinpath(Path(os.getcwd()), "lenna.png")))
+
+        file_path = Path.joinpath(self.examples_path, "singleROI.py")
+        runpy.run_path(path_name=str(file_path), run_name="__main__")
+
+        # cleanup
+        os.remove("lenna.png")
+        os.remove("single_roi.nix")
+
+    def test_sources(self):
+        file_path = Path.joinpath(self.examples_path, "sources.py")
+        runpy.run_path(path_name=str(file_path), run_name="__main__")
+        # cleanup
+        os.remove("sources.nix")
+
+    def test_spike_features(self):
+        # Requires scipy package and "lif.py"
+        lif_path = Path.joinpath(self.examples_path, "lif.py")
+        spec = getmod.spec_from_file_location("lif", str(lif_path))
+        spec.loader.load_module("lif")
+
+        file_path = Path.joinpath(self.examples_path, "spikeFeatures.py")
+        runpy.run_path(path_name=str(file_path), run_name="__main__")
+
+        # cleanup
+        os.remove("spike_features.h5")
+
+    def test_spike_tagging(self):
+        # Requires "lif.py"
+        lif_path = Path.joinpath(self.examples_path, "lif.py")
+        spec = getmod.spec_from_file_location("lif", str(lif_path))
+        spec.loader.load_module("lif")
+
+        file_path = Path.joinpath(self.examples_path, "spikeTagging.py")
+        runpy.run_path(path_name=str(file_path), run_name="__main__")
+
+        # cleanup
+        os.remove("spike_tagging.nix")
+
+    def test_tabular_data(self):
+        file_path = Path.joinpath(self.examples_path, "tabulardata.py")
+        runpy.run_path(path_name=str(file_path), run_name="__main__")
+        # cleanup
+        os.remove("dataframe.nix")
+
+    def test_tagged_feature(self):
+        # Requires scipy package and "lif.py"
+        lif_path = Path.joinpath(self.examples_path, "lif.py")
+        spec = getmod.spec_from_file_location("lif", str(lif_path))
+        spec.loader.load_module("lif")
+
+        file_path = Path.joinpath(self.examples_path, "taggedFeature.py")
+        runpy.run_path(path_name=str(file_path), run_name="__main__")
+
+        # cleanup
+        os.remove("spike_features.nix")
+
+    def test_tagging_example(self):
+        # Requires scipy package
+        file_path = Path.joinpath(self.examples_path, "tagging_example.py")
+        runpy.run_path(path_name=str(file_path), run_name="__main__")
+
+        # cleanup
+        os.remove("tagging1.nix")
+
+    def test_tagging_nd(self):
+        # not testing any nix feature
+        # file_path = Path.joinpath(self.examples_path, "tagging_nd.py")
+        # runpy.run_path(path_name=str(file_path), run_name="__main__")
+        pass
+
+    def test_untagged_feature(self):
+        # Requires scipy package and "lif.py"
+        lif_path = Path.joinpath(self.examples_path, "lif.py")
+        spec = getmod.spec_from_file_location("lif", str(lif_path))
+        spec.loader.load_module("lif")
+
+        file_path = Path.joinpath(self.examples_path, "untaggedFeature.py")
+        runpy.run_path(path_name=str(file_path), run_name="__main__")
+
+        # cleanup
+        os.remove("untagged_feature.h5")

--- a/nixio/test/test_doc_examples.py
+++ b/nixio/test/test_doc_examples.py
@@ -1,5 +1,4 @@
 import importlib.util as getmod
-import matplotlib.pyplot as plt
 import os
 import runpy
 import unittest
@@ -7,8 +6,26 @@ import unittest
 from pathlib import Path
 from shutil import copyfile
 
+import matplotlib.pyplot as plt
+
+
+TEST_IMAGE = "lenna.png"
+
 
 class TestDocumentationExamples(unittest.TestCase):
+
+    def run_script(self, script_name):
+        file_path = Path.joinpath(self.examples_path, script_name)
+        runpy.run_path(path_name=str(file_path), run_name="__main__")
+
+    def handle_lif(self):
+        lif_path = Path.joinpath(self.examples_path, "lif.py")
+        spec = getmod.spec_from_file_location("lif", str(lif_path))
+        spec.loader.load_module("lif")
+
+    def handle_image(self):
+        image_path = Path.joinpath(self.examples_path, TEST_IMAGE)
+        copyfile(str(image_path), str(Path.joinpath(Path(os.getcwd()), TEST_IMAGE)))
 
     def setUp(self):
         curr_path = os.getcwd()
@@ -28,184 +45,131 @@ class TestDocumentationExamples(unittest.TestCase):
     def tearDown(self):
         plt.close("all")
         plt.ioff()
+        if os.path.exists(TEST_IMAGE):
+            os.remove(TEST_IMAGE)
 
     def test_annotations(self):
-        file_path = Path.joinpath(self.examples_path, "annotations.py")
-        runpy.run_path(path_name=str(file_path), run_name="__main__")
+        self.run_script("annotations.py")
         # cleanup
         os.remove("annotations.nix")
 
     def test_category_data(self):
-        file_path = Path.joinpath(self.examples_path, "categoryData.py")
-        runpy.run_path(path_name=str(file_path), run_name="__main__")
+        self.run_script("categoryData.py")
         # cleanup
         os.remove("categoryData.nix")
 
     def test_continuous_recording(self):
-        file_path = Path.joinpath(self.examples_path, "continuousRecording.py")
-        runpy.run_path(path_name=str(file_path), run_name="__main__")
+        self.run_script("continuousRecording.py")
         # cleanup
         os.remove("continuous_recording.nix")
 
     def test_file_create(self):
-        file_path = Path.joinpath(self.examples_path, "fileCreate.py")
-        runpy.run_path(path_name=str(file_path), run_name="__main__")
+        self.run_script("fileCreate.py")
         # cleanup
         os.remove("file_create_example.nix")
 
     def test_image_data(self):
         # Requires PIL package and the "Lenna" image.
-        image_path = Path.joinpath(self.examples_path, "lenna.png")
-        copyfile(str(image_path), str(Path.joinpath(Path(os.getcwd()), "lenna.png")))
-
-        file_path = Path.joinpath(self.examples_path, "imageData.py")
-        runpy.run_path(path_name=str(file_path), run_name="__main__")
-
+        self.handle_image()
+        self.run_script("imageData.py")
         # cleanup
         os.remove("image_example.nix")
-        os.remove("lenna.png")
 
     def test_image_with_metadata(self):
         # Requires PIL package and the "Lenna" image.
-        image_path = Path.joinpath(self.examples_path, "lenna.png")
-        copyfile(str(image_path), str(Path.joinpath(Path(os.getcwd()), "lenna.png")))
-
-        file_path = Path.joinpath(self.examples_path, "imageWithMetadata.py")
-        runpy.run_path(path_name=str(file_path), run_name="__main__")
-
+        self.handle_image()
+        self.run_script("imageWithMetadata.py")
         # cleanup
         os.remove("image_with_source_example.h5")
         os.remove("image_with_metadata.png")
-        os.remove("lenna.png")
 
     def test_irregularly_sampled_data(self):
-        file_path = Path.joinpath(self.examples_path, "irregularlySampledData.py")
-        runpy.run_path(path_name=str(file_path), run_name="__main__")
+        self.run_script("irregularlySampledData.py")
         # cleanup
         os.remove("irregular_data_example.nix")
 
     def test_lif(self):
-        file_path = Path.joinpath(self.examples_path, "lif.py")
-        runpy.run_path(path_name=str(file_path), run_name="__main__")
+        self.run_script("lif.py")
 
     def test_multiple_points(self):
-        file_path = Path.joinpath(self.examples_path, "multiple_points.py")
-        runpy.run_path(path_name=str(file_path), run_name="__main__")
+        self.run_script("multiple_points.py")
         # cleanup
         os.remove("multiple_points.nix")
 
     def test_multiple_regions(self):
-        file_path = Path.joinpath(self.examples_path, "multiple_regions.py")
-        runpy.run_path(path_name=str(file_path), run_name="__main__")
+        self.run_script("multiple_regions.py")
         # cleanup
         os.remove("multiple_regions.nix")
 
     def test_multiple_rois(self):
         # Requires PIL package and the "Lenna" image.
-        image_path = Path.joinpath(self.examples_path, "lenna.png")
-        copyfile(str(image_path), str(Path.joinpath(Path(os.getcwd()), "lenna.png")))
-
-        file_path = Path.joinpath(self.examples_path, "multipleROIs.py")
-        runpy.run_path(path_name=str(file_path), run_name="__main__")
-
+        self.handle_image()
+        self.run_script("multipleROIs.py")
         # cleanup
-        os.remove("lenna.png")
         os.remove("multiple_roi.nix")
 
     def test_range_dimension_link(self):
-        file_path = Path.joinpath(self.examples_path, "rangeDimensionLink.py")
-        runpy.run_path(path_name=str(file_path), run_name="__main__")
+        self.run_script("rangeDimensionLink.py")
         # cleanup
         os.remove("range_link.nix")
 
     def test_regularly_sampled_data(self):
-        file_path = Path.joinpath(self.examples_path, "regularlySampledData.py")
-        runpy.run_path(path_name=str(file_path), run_name="__main__")
+        self.run_script("regularlySampledData.py")
         # cleanup
         os.remove("regular_data_example.nix")
 
     def test_single_roi(self):
         # Requires PIL package and the "Lenna" image.
-        image_path = Path.joinpath(self.examples_path, "lenna.png")
-        copyfile(str(image_path), str(Path.joinpath(Path(os.getcwd()), "lenna.png")))
-
-        file_path = Path.joinpath(self.examples_path, "singleROI.py")
-        runpy.run_path(path_name=str(file_path), run_name="__main__")
-
+        self.handle_image()
+        self.run_script("singleROI.py")
         # cleanup
-        os.remove("lenna.png")
         os.remove("single_roi.nix")
 
     def test_sources(self):
-        file_path = Path.joinpath(self.examples_path, "sources.py")
-        runpy.run_path(path_name=str(file_path), run_name="__main__")
+        self.run_script("sources.py")
         # cleanup
         os.remove("sources.nix")
 
     def test_spike_features(self):
         # Requires scipy package and "lif.py"
-        lif_path = Path.joinpath(self.examples_path, "lif.py")
-        spec = getmod.spec_from_file_location("lif", str(lif_path))
-        spec.loader.load_module("lif")
-
-        file_path = Path.joinpath(self.examples_path, "spikeFeatures.py")
-        runpy.run_path(path_name=str(file_path), run_name="__main__")
-
+        self.handle_lif()
+        self.run_script("spikeFeatures.py")
         # cleanup
         os.remove("spike_features.h5")
 
     def test_spike_tagging(self):
         # Requires "lif.py"
-        lif_path = Path.joinpath(self.examples_path, "lif.py")
-        spec = getmod.spec_from_file_location("lif", str(lif_path))
-        spec.loader.load_module("lif")
-
-        file_path = Path.joinpath(self.examples_path, "spikeTagging.py")
-        runpy.run_path(path_name=str(file_path), run_name="__main__")
-
+        self.handle_lif()
+        self.run_script("spikeTagging.py")
         # cleanup
         os.remove("spike_tagging.nix")
 
     def test_tabular_data(self):
-        file_path = Path.joinpath(self.examples_path, "tabulardata.py")
-        runpy.run_path(path_name=str(file_path), run_name="__main__")
+        self.run_script("tabulardata.py")
         # cleanup
         os.remove("dataframe.nix")
 
     def test_tagged_feature(self):
         # Requires scipy package and "lif.py"
-        lif_path = Path.joinpath(self.examples_path, "lif.py")
-        spec = getmod.spec_from_file_location("lif", str(lif_path))
-        spec.loader.load_module("lif")
-
-        file_path = Path.joinpath(self.examples_path, "taggedFeature.py")
-        runpy.run_path(path_name=str(file_path), run_name="__main__")
-
+        self.handle_lif()
+        self.run_script("taggedFeature.py")
         # cleanup
         os.remove("spike_features.nix")
 
     def test_tagging_example(self):
         # Requires scipy package
-        file_path = Path.joinpath(self.examples_path, "tagging_example.py")
-        runpy.run_path(path_name=str(file_path), run_name="__main__")
-
+        self.run_script("tagging_example.py")
         # cleanup
         os.remove("tagging1.nix")
 
     def test_tagging_nd(self):
         # not testing any nix feature
-        # file_path = Path.joinpath(self.examples_path, "tagging_nd.py")
-        # runpy.run_path(path_name=str(file_path), run_name="__main__")
+        # self.run_script("tagging_nd.py")
         pass
 
     def test_untagged_feature(self):
         # Requires scipy package and "lif.py"
-        lif_path = Path.joinpath(self.examples_path, "lif.py")
-        spec = getmod.spec_from_file_location("lif", str(lif_path))
-        spec.loader.load_module("lif")
-
-        file_path = Path.joinpath(self.examples_path, "untaggedFeature.py")
-        runpy.run_path(path_name=str(file_path), run_name="__main__")
-
+        self.handle_lif()
+        self.run_script("untaggedFeature.py")
         # cleanup
         os.remove("untagged_feature.h5")

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     license='BSD',
     packages=packages,
     scripts=[],
-    tests_require=['pytest'],
+    tests_require=['pytest', 'scipy', 'pillow'],
     test_suite='pytest',
     setup_requires=['pytest-runner'],
     install_requires=['numpy', 'h5py', 'six', 'enum34;python_version<"3.4"'],

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     license='BSD',
     packages=packages,
     scripts=[],
-    tests_require=['pytest', 'scipy', 'pillow'],
+    tests_require=['pytest', 'scipy', 'pillow', 'matplotlib'],
     test_suite='pytest',
     setup_requires=['pytest-runner'],
     install_requires=['numpy', 'h5py', 'six', 'enum34;python_version<"3.4"'],


### PR DESCRIPTION
This PR introduces tests for the documentation examples in the `docs` folder. Since `docs` resides outside the nixio package, the testing requires executing the example files directly, copying the required 'lenna.png' image from the docs folder and cleaning up created test nix files once the tests are done. Running and cleanup works, please comment if there are any reservations to the way these tests are run or if individual tests should not be excluded.

Running tests for these examples requires the additional packages `matplotlib, scipy, pillow` to be installed. These packages have been added to the `setup.py: tests_requires` and the CI config files.

All plots are rendered non-blocking and are closed after the tests are done. The examples "imageData.py" and "singleROI.py" will open an image via `pillow image.show()` which cannot be closed automatically. These tests block on Windows and are only run on Linux OS.

The PR also fixes
- invalid old style property values usage in the `imageWithMetadata` example.
- all usages of the deprecated `DataArray.data` method.
