### PR TITLE
Allow for list-like labels of SetDimension

### DIFF
--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -91,7 +91,7 @@ class DataArray(Entity, DataSet):
         index = len(self.dimensions) + 1
         setdim = SetDimension.create_new(self, index)
         if labels is not None:
-            if not isinstance(labels, list):
+            if not isinstance(labels, (list, str)):
                 labels = list(labels)
             setdim.labels = labels
         if self.file.auto_update_timestamps:

--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -91,10 +91,11 @@ class DataArray(Entity, DataSet):
         index = len(self.dimensions) + 1
         setdim = SetDimension.create_new(self, index)
         if labels is not None:
-            if not hasattr(labels, '__iter__'):
-                labels = str(labels)
-            if isinstance(labels, str):
-                labels = [labels]
+            if not hasattr(labels, '__iter__') or isinstance(labels, str):
+                raise ValueError('`labels` has to be a list-like object.')
+            for label in labels:
+                if not isinstance(label, str):
+                    raise ValueError(f'`labels` has to contain string objects, not {type(label)}')
             if not isinstance(labels, list):
                 labels = list(labels)
             setdim.labels = labels

--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -82,6 +82,9 @@ class DataArray(Entity, DataSet):
         Append a new SetDimension to the list of existing dimension
         descriptors.
 
+        :param labels: The set of sample labels
+        :type labels: list or convertible to list
+
         :returns: The newly created SetDimension.
         :rtype: nixio.SetDimension
         """
@@ -103,6 +106,12 @@ class DataArray(Entity, DataSet):
 
         :param sampling_interval: The sampling interval of the SetDimension to create.
         :type sampling_interval: float
+        :param label: The label of the dimension
+        :type label: str
+        :param unit: The physical unit of the dimension
+        :type unit: str
+        :param offset: The offset between 0 and the first sample
+        :type offset: float
 
         :returns: The newly created SampledDimension.
         :rtype: nixio.SampledDimension
@@ -126,6 +135,10 @@ class DataArray(Entity, DataSet):
 
         :param ticks: The ticks of the RangeDimension to create.
         :type ticks: list of float
+        :param label: The label of the dimension
+        :type label: str
+        :param unit: The physical unit of the dimension
+        :type unit: str
 
         :returns: The newly created RangeDimension.
         :rtype: nixio.RangeDimension

--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -91,13 +91,6 @@ class DataArray(Entity, DataSet):
         index = len(self.dimensions) + 1
         setdim = SetDimension.create_new(self, index)
         if labels is not None:
-            if not hasattr(labels, '__iter__') or isinstance(labels, str):
-                raise ValueError('`labels` has to be a list-like object.')
-            for label in labels:
-                if not isinstance(label, str):
-                    raise ValueError(f'`labels` has to contain string objects, not {type(label)}')
-            if not isinstance(labels, list):
-                labels = list(labels)
             setdim.labels = labels
         if self.file.auto_update_timestamps:
             self.force_updated_at()

--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -91,7 +91,11 @@ class DataArray(Entity, DataSet):
         index = len(self.dimensions) + 1
         setdim = SetDimension.create_new(self, index)
         if labels is not None:
-            if not isinstance(labels, (list, str)):
+            if not hasattr(labels, '__iter__'):
+                labels = str(labels)
+            if isinstance(labels, str):
+                labels = [labels]
+            if not isinstance(labels, list):
                 labels = list(labels)
             setdim.labels = labels
         if self.file.auto_update_timestamps:

--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -87,7 +87,9 @@ class DataArray(Entity, DataSet):
         """
         index = len(self.dimensions) + 1
         setdim = SetDimension.create_new(self, index)
-        if labels:
+        if labels is not None:
+            if not isinstance(labels, list):
+                labels = list(labels)
             setdim.labels = labels
         if self.file.auto_update_timestamps:
             self.force_updated_at()

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -684,6 +684,13 @@ class SetDimension(Dimension):
             raise RuntimeError("The labels of a SetDimension linked to a "
                                "data object cannot be modified")
         dt = util.vlen_str_dtype
+        if not hasattr(labels, '__iter__') or isinstance(labels, str):
+            raise ValueError('`labels` has to be a list-like object.')
+        for label in labels:
+            if not isinstance(label, str):
+                raise ValueError(f'`labels` has to contain string objects, not {type(label)}')
+        if not isinstance(labels, list):
+            labels = list(labels)
         self._h5group.write_data("labels", labels, dtype=dt)
 
     def index_of(self, position, mode=IndexMode.LessOrEqual):

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -158,15 +158,16 @@ class TestDimension(unittest.TestCase):
         setdim = self.array.append_set_dimension(labels)
         assert tuple(labels) == setdim.labels
 
-    def test_set_dim_labels_single_string(self):
-        labels = 'Sample 1'
-        setdim = self.array.append_set_dimension(labels)
-        assert tuple([labels]) == setdim.labels
+    def test_set_dim_invalid_labels(self):
+        # don't accept non list-like labels
+        with self.assertRaises(ValueError):
+            self.array.append_set_dimension('Sample 1')
+        with self.assertRaises(ValueError):
+            self.array.append_set_dimension(1000)
 
-    def test_set_dim_labels_single_float(self):
-        labels = 1000
-        setdim = self.array.append_set_dimension(labels)
-        assert tuple([str(labels)]) == setdim.labels
+        # don't accept list of non-string objects
+        with self.assertRaises(ValueError):
+            self.array.append_set_dimension([1, 2, 3])
 
     def test_range_dim_ticks_resize(self):
         rangedim = self.array.append_range_dimension([1, 2, 100])

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -153,10 +153,20 @@ class TestDimension(unittest.TestCase):
         setdim.labels = newlabels
         assert tuple(newlabels) == setdim.labels
 
-    def test_set_dim_label_array(self):
+    def test_set_dim_labels_array(self):
         labels = np.array(["A", "B"])
         setdim = self.array.append_set_dimension(labels)
         assert tuple(labels) == setdim.labels
+
+    def test_set_dim_labels_single_string(self):
+        labels = 'Sample 1'
+        setdim = self.array.append_set_dimension(labels)
+        assert tuple([labels]) == setdim.labels
+
+    def test_set_dim_labels_single_float(self):
+        labels = 1000
+        setdim = self.array.append_set_dimension(labels)
+        assert tuple([str(labels)]) == setdim.labels
 
     def test_range_dim_ticks_resize(self):
         rangedim = self.array.append_range_dimension([1, 2, 100])

--- a/nixio/test/test_dimensions.py
+++ b/nixio/test/test_dimensions.py
@@ -153,6 +153,11 @@ class TestDimension(unittest.TestCase):
         setdim.labels = newlabels
         assert tuple(newlabels) == setdim.labels
 
+    def test_set_dim_label_array(self):
+        labels = np.array(["A", "B"])
+        setdim = self.array.append_set_dimension(labels)
+        assert tuple(labels) == setdim.labels
+
     def test_range_dim_ticks_resize(self):
         rangedim = self.array.append_range_dimension([1, 2, 100])
         ticks = [1, 1, 30]


### PR DESCRIPTION
Currently `append_set_dimension` fails if a non-list object, e.g. numpy array, is provided as labels. For convenience it would be nice to accept any object that can be converted to a list. The same is in principle true for Dimension ticks, but here no check on the input type is currently performed.


