### PR TITLE
Keep string data as python str

### DIFF
--- a/nixio/hdf5/h5dataset.py
+++ b/nixio/hdf5/h5dataset.py
@@ -61,7 +61,7 @@ class H5DataSet(object):
             # Let's change it to IndexError
             raise IndexError(te_exc)
         if data.dtype == util.vlen_str_dtype:
-            data = np.reshape(np.array(list(map(ensure_str, data.ravel()))), data.shape)
+            data = np.reshape(np.array(list(map(ensure_str, data.ravel())), dtype=object), data.shape)
         elif data.dtype.fields:
             data = self._convert_string_cols(data)
         return data

--- a/nixio/hdf5/h5group.py
+++ b/nixio/hdf5/h5group.py
@@ -250,6 +250,8 @@ class H5Group(object):
             if name in self.group.attrs:
                 del self.group.attrs[name]
         else:
+            if isinstance(value, np.str_):
+                value = str(value)
             self.group.attrs[name] = value
 
     def get_attr(self, name):

--- a/nixio/test/test_data_view.py
+++ b/nixio/test/test_data_view.py
@@ -42,11 +42,13 @@ class TestDataView(unittest.TestCase):
         da = self.file.blocks[0].create_data_array("str_2d_array", "test", dtype=nix.DataType.String, data=data)
         da.append_set_dimension()
         da.append_set_dimension()
-        
+
         dv = da.get_slice((0, 0), extents=(10, 4))
         npeq = np.testing.assert_equal
         npeq(dv.shape, da.shape)
         npeq(dv[:], data)
+        for d in dv[:]:
+            assert("numpy.str_" not in str(type(d)))
 
     def test_data_view_fancy_slicing(self):
         da = self.file.blocks[0].data_arrays[0]


### PR DESCRIPTION
With https://github.com/G-Node/nixpy/commit/b3c21c3efdb48de853a49ad8f0f930457283f280 we fixed the reading of 2D string data. Unfortunately, this implicitly converted python strings to np.str_. With this pr, we keep them as python strings.

fixes #534 