### PR TITLE
Invalid event slices

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -2,8 +2,8 @@ name: NIXPy tests and linting
 
 on:
   # Run one build a month at 01:00
-  schedule:
-  - cron:  '0 1 1 * *'
+  # schedule:
+  # - cron:  '0 1 1 * *'
   push:
     branches:
       - master

--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -316,6 +316,8 @@ class DataArray(Entity, DataSet):
         ```
 
         Note: The extents are *not* the end positions but the extent of the slice!
+        In the case of regularly sampled dimensions, reaching beyond the start of end of the respective dimension will cause an exception. For irregularly sampled data no 
+        exception will be raised but the returned DataView might be invalid and empty.
 
         :param positions: Specifies the start of the data slice. List of either indices or data positions depending on the DataSliceMode.
         :type positions: list length must match dimensionality of the data.

--- a/nixio/data_array.py
+++ b/nixio/data_array.py
@@ -11,8 +11,6 @@ from numbers import Number
 from enum import Enum
 import numpy as np
 
-from nixio.exceptions.exceptions import OutOfBounds
-
 from .data_view import DataView
 from .data_set import DataSet
 from .entity import Entity
@@ -378,7 +376,8 @@ class DataArray(Entity, DataSet):
                 start_pos = int(pos)
                 extent = int(ext)
             else:
-                raise IncompatibleDimensions(f"Unknown dimension type: {dim.dimension_type}")
+                raise IncompatibleDimensions(f"Unknown dimension type: {dim.dimension_type}",
+                                             "data_array._get_slice_by_dim")
 
             if extent < 0:
                 return DataView(self, None)

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -693,7 +693,7 @@ class RangeDimension(Dimension):
         :raises: ValueError if invalid mode is given
         :raises: Index Error if start position is greater than end position.
         """
-        if mode is not SliceMode.Exclusive and mode is not SliceMode.Inclusive:
+        if mode not in (SliceMode.Exclusive, SliceMode.Inclusive):
             raise ValueError("Unknown SliceMode: {}".format(mode))
         if start_position > end_position:
             raise IndexError("Start position {} is greater than end position {}.".format(start_position, end_position))

--- a/nixio/tag.py
+++ b/nixio/tag.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright © 2014, German Neuroinformatics Node (G-Node)
+# Copyright © 2014 - 2022, German Neuroinformatics Node (G-Node)
 #
 # All rights reserved.
 #
@@ -260,6 +260,8 @@ class Tag(BaseTag):
 
     @position.setter
     def position(self, pos):
+        if pos is not None and not hasattr(pos, "__getitem__"):
+            pos = [pos]
         if pos is None or len(pos) == 0:
             if self._h5group.has_data("position"):
                 del self._h5group["position"]
@@ -281,6 +283,8 @@ class Tag(BaseTag):
 
     @extent.setter
     def extent(self, ext):
+        if ext is not None and not hasattr(ext, "__getitem__"):
+            ext = [ext]
         if ext is None or len(ext) == 0:
             if self._h5group.has_data("extent"):
                 del self._h5group["extent"]
@@ -313,6 +317,8 @@ class Tag(BaseTag):
                 "do not match ", extent)
 
         slices = self._calc_data_slices(ref, self.position, self.extent, stop_rule)
+        if not all(slices):
+            return DataView(ref, slices)
         if not self._slices_in_data(ref, slices):
             raise OutOfBounds("References data slice out of the extent of the "
                               "DataArray!")

--- a/nixio/test/test_data_array.py
+++ b/nixio/test/test_data_array.py
@@ -13,6 +13,7 @@ import sys
 import unittest
 import numpy as np
 import nixio as nix
+from nixio.data_array import DataSliceMode
 from nixio.exceptions import IncompatibleDimensions
 from .tmp import TempDir
 
@@ -443,6 +444,21 @@ class TestDataArray(unittest.TestCase):
 
         with self.assertRaises(IncompatibleDimensions):
             da3d.get_slice((0, 0, 0), (3, 9, 40, 1))
+
+        dslice = da2d.get_slice([20, 1], [10, 1], DataSliceMode.Data)
+        self.assertFalse(dslice.valid)
+
+        time_vector = np.arange(0.0, 10., 0.001)
+        indices = np.random.rand(len(time_vector))
+
+        event_data = time_vector[(indices < 0.1)]
+        event_data = event_data[(event_data < 4) | (event_data > 7)]
+
+        event_da = self.block.create_data_array("event_data", "nix.events", data=event_data, unit="s")
+        event_da.append_range_dimension_using_self()
+        selection = event_da.get_slice([4.5], [1.0], nix.DataSliceMode.Data)
+        self.assertFalse(selection.valid)
+        np.testing.assert_almost_equal(np.array([]), selection[:])
 
     def test_dim_one_based(self):
         self.array.append_set_dimension()

--- a/nixio/test/test_tag.py
+++ b/nixio/test/test_tag.py
@@ -606,7 +606,6 @@ class TestTags(unittest.TestCase):
 
         event_da = self.block.create_data_array("event_data", "nix.events", data=event_data, unit="s")
         event_da.append_range_dimension_using_self()
-        selection = event_da.get_slice([4.5], [1.0], nix.DataSliceMode.Data)[:]
 
         tt = self.block.create_tag("no_event_segment", "nix.segment", 4.5)
         tt.extent = 1.0

--- a/nixio/test/test_tag.py
+++ b/nixio/test/test_tag.py
@@ -610,20 +610,20 @@ class TestTags(unittest.TestCase):
         tt = self.block.create_tag("no_event_segment", "nix.segment", 4.5)
         tt.extent = 1.0
         tt.references.append(event_da)
-        slice = tt.tagged_data(0)
-        self.assertFalse(slice.valid)
+        sl = tt.tagged_data(0)
+        self.assertFalse(sl.valid)
 
         tt2 = self.block.create_tag("beyond data", "nix.segment", 12.0)
         tt2.extent = 3.0
         tt2.references.append(event_da)
-        slice = tt2.tagged_data(0)
-        self.assertFalse(slice.valid)
+        sl = tt2.tagged_data(0)
+        self.assertFalse(sl.valid)
 
         tt3 = self.block.create_tag("reachingbeyonddata", "nix.segment", 8.5)
         tt3.extent = [3.0]
         tt3.references.append(event_da)
-        slice = tt3.tagged_data(0)
-        self.assertTrue(slice.valid)
+        sl = tt3.tagged_data(0)
+        self.assertTrue(sl.valid)
 
     def test_tagged_sampled_dim(self):
         """


### PR DESCRIPTION
With event data (RangeDim DataArrays) it can easily happen, that there are no events in a certain time frame. In the current version trying to read such a slice will lead to a ``ValueError: length should not be negative``. 

This pull request catches such situations and returns an empty slice. 