### PR TITLE
test_doc_examples.py: initialize examples_path.

### DIFF
--- a/nixio/test/test_doc_examples.py
+++ b/nixio/test/test_doc_examples.py
@@ -15,6 +15,8 @@ TEST_IMAGE = "lenna.png"
 
 class TestDocumentationExamples(unittest.TestCase):
 
+    examples_path = Path("docs/source/examples")
+
     def run_script(self, script_name):
         file_path = Path.joinpath(self.examples_path, script_name)
         runpy.run_path(path_name=str(file_path), run_name="__main__")


### PR DESCRIPTION
While trying to package the Python nixio module in Debian, most tests from test_doc_examples.py are failing with the following error:

	    def handle_lif(self):
	>       lif_path = Path.joinpath(self.examples_path, "lif.py")
	E       AttributeError: 'TestDocumentationExamples' object has no attribute 'examples_path'

This looks to be caused by missing initialisation of the examples_path attribute of the TestDocumentationExamples class.  Initialising the attribute with the path to the documentation from the root of the sources corrects the issue.