### PR TITLE
d/s/examples/*.py: use python3 in shebang.

### DIFF
--- a/docs/source/examples/imageWithMetadata.py
+++ b/docs/source/examples/imageWithMetadata.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """Copyright © 2014 German Neuroinformatics Node (G-Node)

--- a/docs/source/examples/multipleTimeSeries.py
+++ b/docs/source/examples/multipleTimeSeries.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Copyright © 2014 German Neuroinformatics Node (G-Node)
 

--- a/docs/source/examples/singleROI.py
+++ b/docs/source/examples/singleROI.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """Copyright © 2014 German Neuroinformatics Node (G-Node)

--- a/docs/source/examples/taggedFeature.py
+++ b/docs/source/examples/taggedFeature.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """Copyright © 2014 German Neuroinformatics Node (G-Node)


### PR DESCRIPTION
With python2 deprecation, it should be safe to enforce use of the python3 shebang everywhere.  Besides, there can be inconsistencies between distributions, and even system configuration within a single distribution, on whether to ship python as python2, as python3, or not at all.