### PR TITLE
remove Python2 crumbs

### DIFF
--- a/docs/source/examples/lif.py
+++ b/docs/source/examples/lif.py
@@ -13,7 +13,7 @@
 import numpy as np
 
 
-class LIF(object):
+class LIF:
 
     def __init__(self, stepsize=0.0001, offset=1.6, tau_m=0.025, tau_a=0.02, da=0.0, D=3.5):
         self.stepsize = stepsize  # simulation stepsize [s]

--- a/nixio/block.py
+++ b/nixio/block.py
@@ -15,7 +15,6 @@ try:
     from collections.abc import OrderedDict
 except ImportError:
     from collections import OrderedDict
-import sys
 
 from .util import find as finders
 from .compression import Compression
@@ -299,13 +298,6 @@ class Block(Entity):
             return self.data_frames[objid]
 
         util.check_entity_name_and_type(name, type_)
-        if (isinstance(col_dict, dict)
-                and not isinstance(col_dict, OrderedDict)
-                and sys.version_info[0] < 3):
-            raise TypeError("Cannot create a DataFrame from a dictionary "
-                            "in Python 2 as the order of keys is not "
-                            "preserved. Please use the OrderedDict class "
-                            "from the collections module instead.")
 
         if data is not None:
             shape = len(data)

--- a/nixio/block.py
+++ b/nixio/block.py
@@ -7,10 +7,8 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 
-try:
-    from sys import maxint
-except ImportError:
-    from sys import maxsize as maxint
+from sys import maxsize
+
 import numpy as np
 from inspect import isclass
 try:
@@ -396,7 +394,7 @@ class Block(Entity):
         :rtype: list of nixio.Source
         """
         if limit is None:
-            limit = maxint
+            limit = maxsize
         return finders._find_sources(self, filtr, limit)
 
     def pprint(self, indent=2, max_length=120, extra=True, start_depth=0):

--- a/nixio/block.py
+++ b/nixio/block.py
@@ -13,7 +13,6 @@ except ImportError:
     from sys import maxsize as maxint
 import numpy as np
 from inspect import isclass
-from six import string_types
 try:
     from collections.abc import OrderedDict
 except ImportError:
@@ -358,8 +357,7 @@ class Block(Entity):
         if col_dict is not None:
             for nam, dt in col_dict.items():
                 if isclass(dt):
-                    if any(issubclass(dt, st) for st in string_types) \
-                            or issubclass(dt, np.string_):
+                    if issubclass(dt, str) or issubclass(dt, np.string_):
                         col_dict[nam] = util.vlen_str_dtype
                 if 'U' in str(dt) or dt == np.string_:
                     col_dict[nam] = util.vlen_str_dtype

--- a/nixio/container.py
+++ b/nixio/container.py
@@ -6,7 +6,7 @@ except ImportError:
 from . import util
 
 
-class Container(object):
+class Container:
     """
     Container acts as an interface to container groups in the backend. In the
     case of HDF5, this is a group that is used as a container for other groups.

--- a/nixio/data_frame.py
+++ b/nixio/data_frame.py
@@ -6,7 +6,6 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
-from __future__ import (absolute_import, division, print_function)
 try:
     from collections.abc import Iterable
 except ImportError:

--- a/nixio/data_frame.py
+++ b/nixio/data_frame.py
@@ -19,7 +19,6 @@ from . import util
 from .data_set import DataSet
 from .datatype import DataType
 from .section import Section
-from six import string_types
 import csv
 
 
@@ -55,8 +54,7 @@ class DataFrame(Entity, DataSet):
             raise ValueError("Too much entries for column in this dataframe")
         if datatype is None:
             datatype = DataType.get_dtype(column[0])
-        if isclass(datatype) and any(issubclass(datatype, st)
-                                     for st in string_types):
+        if isclass(datatype) and issubclass(datatype, str):
             datatype = util.vlen_str_dtype
         dt_arr = [(n, dty) for n, dty in zip(self.column_names, self.dtype)]
         dt_arr.append((name, datatype))

--- a/nixio/data_set.py
+++ b/nixio/data_set.py
@@ -9,7 +9,7 @@
 import numpy as np
 
 
-class DataSet(object):
+class DataSet:
     """
     Data IO object for DataArray.
     """

--- a/nixio/datatype.py
+++ b/nixio/datatype.py
@@ -7,7 +7,6 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 from numbers import Integral, Real
-from six import string_types
 
 import numpy as np
 
@@ -41,7 +40,7 @@ class DataType:
             return cls.Int64
         elif isinstance(value, Real):
             return cls.Double
-        elif isinstance(value, string_types):
+        elif isinstance(value, str):
             return cls.String
         else:
             raise ValueError("Unknown type for value {}".format(value))

--- a/nixio/datatype.py
+++ b/nixio/datatype.py
@@ -7,7 +7,6 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 from numbers import Integral, Real
-from six import string_types
 from packaging import version
 
 import numpy as np

--- a/nixio/datatype.py
+++ b/nixio/datatype.py
@@ -15,7 +15,7 @@ import numpy as np
 BOOLS = (bool, np.bool_)
 
 
-class DataType(object):
+class DataType:
     UInt8 = np.uint8
     UInt16 = np.uint16
     UInt32 = np.uint32

--- a/nixio/dimensions.py
+++ b/nixio/dimensions.py
@@ -64,7 +64,7 @@ class DimensionContainer(Container):
         return cls(self._parent, idx)
 
 
-class DimensionLink(object):
+class DimensionLink:
     """
     Links a Dimension to a data object (DataArray or DataFrame).
 
@@ -223,7 +223,7 @@ class DimensionLink(object):
         return self._h5group.get_attr("data_object_type")
 
 
-class Dimension(object):
+class Dimension:
 
     def __init__(self, nixfile, data_array, index):
         dimgroup = data_array._h5group.open_group("dimensions")

--- a/nixio/entity.py
+++ b/nixio/entity.py
@@ -10,7 +10,7 @@
 from . import util
 
 
-class Entity(object):
+class Entity:
 
     def __init__(self, nixfile, nixparent, h5group):
         util.check_entity_id(h5group.get_attr("entity_id"))

--- a/nixio/feature.py
+++ b/nixio/feature.py
@@ -14,7 +14,7 @@ from six import string_types
 from .util import util
 
 
-class Feature(object):
+class Feature:
 
     def __init__(self, nixfile, nixparent, h5group):
         util.check_entity_id(h5group.get_attr("entity_id"))

--- a/nixio/feature.py
+++ b/nixio/feature.py
@@ -10,7 +10,6 @@ from .data_array import DataArray
 from .data_frame import DataFrame
 from .link_type import LinkType
 from .exceptions import UnsupportedLinkType
-from six import string_types
 from .util import util
 
 
@@ -53,7 +52,7 @@ class Feature:
 
     @link_type.setter
     def link_type(self, link_type):
-        if isinstance(link_type, string_types):
+        if isinstance(link_type, str):
             link_type = link_type.lower()
         link_type = LinkType(link_type)
         self._h5group.set_attr("link_type", link_type.value)

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -54,7 +54,7 @@ def can_read(nixfile):
         return False
 
 
-class FileMode(object):
+class FileMode:
     ReadOnly = 'r'
     ReadWrite = 'a'
     Overwrite = 'w'
@@ -82,7 +82,7 @@ def make_fcpl():
     return fcpl
 
 
-class File(object):
+class File:
 
     def __init__(self, path, mode=FileMode.ReadWrite,
                  compression=Compression.Auto,

--- a/nixio/file.py
+++ b/nixio/file.py
@@ -9,12 +9,9 @@
 import os
 import gc
 import numpy as np
+from sys import maxsize
 from warnings import warn
 
-try:
-    from sys import maxint
-except ImportError:
-    from sys import maxsize as maxint
 import h5py
 
 from .hdf5.h5group import H5Group
@@ -478,7 +475,7 @@ class File:
         :rtype: list of nixio.Section
         """
         if limit is None:
-            limit = maxint
+            limit = maxsize
         return finders._find_sections(self, filtr, limit)
 
     @property

--- a/nixio/hdf5/h5dataset.py
+++ b/nixio/hdf5/h5dataset.py
@@ -12,7 +12,7 @@ from ..datatype import DataType
 from .. import util
 
 
-class H5DataSet(object):
+class H5DataSet:
 
     def __init__(self, parent, name, dtype=None, shape=None,
                  compression=False):

--- a/nixio/hdf5/h5group.py
+++ b/nixio/hdf5/h5group.py
@@ -16,7 +16,7 @@ from ..datatype import DataType
 from .. import util
 
 
-class H5Group(object):
+class H5Group:
 
     def __init__(self, parent, name, create=False):
         self._parent = parent

--- a/nixio/property.py
+++ b/nixio/property.py
@@ -13,7 +13,7 @@ except ImportError:
     from collections import Sequence, Iterable
 from enum import Enum
 from numbers import Number
-from six import string_types, ensure_str, ensure_text
+from six import ensure_str, ensure_text
 import numpy as np
 
 from .datatype import DataType
@@ -268,7 +268,7 @@ class Property(Entity):
             self.delete_values()
             return
 
-        if not isinstance(vals, (Sequence, Iterable)) or isinstance(vals, string_types):
+        if not isinstance(vals, (Sequence, Iterable)) or isinstance(vals, str):
             vals = [vals]
 
         # Make sure all values are of the same data type
@@ -294,7 +294,7 @@ class Property(Entity):
         dataset.write_data(arr, slc=np.s_[src_len: src_len + dlen])
 
     def _check_new_value_types(self, data):
-        if isinstance(data, (Sequence, Iterable)) and not isinstance(data, string_types):
+        if isinstance(data, (Sequence, Iterable)) and not isinstance(data, str):
             single_val = data[0]
         else:
             single_val = data

--- a/nixio/section.py
+++ b/nixio/section.py
@@ -14,7 +14,6 @@ try:
     from collections.abc import Sequence, Iterable
 except ImportError:
     from collections import Sequence, Iterable
-from six import string_types
 import numpy as np
 from .container import Container, SectionContainer
 from .datatype import DataType
@@ -147,7 +146,7 @@ class Section(Entity):
             # Make sure all values are of the same data type
             single_val = vals
             if (isinstance(vals, (Sequence, Iterable)) and
-                    not isinstance(vals, string_types)):
+                    not isinstance(vals, str)):
                 single_val = vals[0]
             else:
                 # Make sure the data will always be created with an array.

--- a/nixio/section.py
+++ b/nixio/section.py
@@ -25,7 +25,7 @@ from . import util
 from . import exceptions
 
 
-class S(object):  # pylint: disable=invalid-name
+class S:  # pylint: disable=invalid-name
     def __init__(self, section_type, section=None):
         self.section_type = section_type
         self.section = section

--- a/nixio/section.py
+++ b/nixio/section.py
@@ -6,15 +6,14 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
-try:
-    from sys import maxint
-except ImportError:
-    from sys import maxsize as maxint
+from sys import maxsize
 try:
     from collections.abc import Sequence, Iterable
 except ImportError:
     from collections import Sequence, Iterable
+
 import numpy as np
+
 from .container import Container, SectionContainer
 from .datatype import DataType
 from .entity import Entity
@@ -386,7 +385,7 @@ class Section(Entity):
         :rtype: list of nixio.Section
         """
         if limit is None:
-            limit = maxint
+            limit = maxsize
         return finders._find_sections(self, filtr, limit)
 
     def find_related(self, filtr=lambda _: True):

--- a/nixio/source.py
+++ b/nixio/source.py
@@ -6,7 +6,7 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
-from sys import maxsize as maxint
+from sys import maxsize
 
 from .import exceptions
 from .entity import Entity
@@ -173,7 +173,7 @@ class Source(Entity):
         :rtype: list of nixio.Source
         """
         if limit is None:
-            limit = maxint
+            limit = maxsize
         return finders._find_sources(self, filtr, limit)
 
     @property

--- a/nixio/tag.py
+++ b/nixio/tag.py
@@ -9,7 +9,6 @@
 import warnings
 
 import numpy as np
-from six import string_types
 
 from .entity import Entity
 from .source_link_container import SourceLinkContainer
@@ -107,7 +106,7 @@ class BaseTag(Entity):
         :returns: The created feature object.
         :rtype: nixio.Feature
         """
-        if isinstance(link_type, string_types):
+        if isinstance(link_type, str):
             link_type = link_type.lower()
         link_type = LinkType(link_type)
         features = self._h5group.open_group("features")

--- a/nixio/test/test_data_array.py
+++ b/nixio/test/test_data_array.py
@@ -8,7 +8,6 @@
 # LICENSE file in the root of the Project.
 import os
 import time
-import sys
 import unittest
 import numpy as np
 import nixio as nix
@@ -277,8 +276,7 @@ class TestDataArray(unittest.TestCase):
         assert da.dtype == test_data.dtype
 
         bdata = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0']
-        if sys.version_info[0] == 3:
-            bdata = [bytes(x, 'UTF-8') for x in bdata]
+        bdata = [bytes(x, 'UTF-8') for x in bdata]
 
         void_data = np.array(bdata, dtype='V1')
         da = self.block.create_data_array('dtype_opaque', 'b', data=void_data)

--- a/nixio/test/test_data_array.py
+++ b/nixio/test/test_data_array.py
@@ -8,7 +8,6 @@
 # LICENSE file in the root of the Project.
 import os
 import time
-from six import string_types
 import sys
 import unittest
 import numpy as np
@@ -307,8 +306,8 @@ class TestDataArray(unittest.TestCase):
         self.assertRaises(IndexError, lambda: self.array.dimensions[-4])
         self.assertRaises(IndexError, lambda: self.array.dimensions[3])
 
-        assert isinstance(str(self.array.dimensions), string_types)
-        assert isinstance(repr(self.array.dimensions), string_types)
+        assert isinstance(str(self.array.dimensions), str)
+        assert isinstance(repr(self.array.dimensions), str)
 
         dims = list(self.array.dimensions)
         for i in range(3):

--- a/nixio/test/test_data_frame.py
+++ b/nixio/test/test_data_frame.py
@@ -9,7 +9,6 @@ try:
     from collections.abc import OrderedDict
 except ImportError:
     from collections import OrderedDict
-import sys
 
 
 class TestDataFrame(unittest.TestCase):
@@ -219,11 +218,10 @@ class TestDataFrame(unittest.TestCase):
         assert tuple(self.df1.df_shape) == (10, 5)
         # create df with incorrect dimension to see if Error is raised
         arr = np.arange(1000).reshape(10, 10, 10)
-        if sys.version_info[0] == 3:
-            with self.assertRaises(ValueError):
-                self.block.create_data_frame('err', 'err',
-                                             {'name': np.int64},
-                                             data=arr)
+        with self.assertRaises(ValueError):
+            self.block.create_data_frame('err', 'err',
+                                         {'name': np.int64},
+                                         data=arr)
 
     def test_data_type(self):
         assert self.df1.dtype[4] == np.int32

--- a/nixio/test/test_data_frame.py
+++ b/nixio/test/test_data_frame.py
@@ -5,7 +5,6 @@ from .tmp import TempDir
 import os
 import time
 import numpy as np
-from six import string_types
 try:
     from collections.abc import OrderedDict
 except ImportError:
@@ -65,7 +64,7 @@ class TestDataFrame(unittest.TestCase):
         assert df_li.column_names == self.df1.column_names
         assert df_li.dtype == self.df1.dtype
         for i in df_li[:]:
-            self.assertIsInstance(i['id'], string_types)
+            self.assertIsInstance(i['id'], str)
             self.assertIsInstance(i['sig2'], np.int32)
 
     def test_column_name_collision(self):

--- a/nixio/test/test_nix_compatibility.py
+++ b/nixio/test/test_nix_compatibility.py
@@ -12,7 +12,6 @@ try:
 except ImportError:
     from collections import Iterable
 from collections import OrderedDict
-from six import string_types
 from subprocess import Popen, PIPE
 import numpy as np
 import pytest
@@ -725,7 +724,7 @@ def check_group_children_counts(group, nda, ntg, nmt):
 def compare(expected, actual):
     if (isinstance(expected, Iterable) and
             isinstance(actual, Iterable) and not
-            isinstance(expected, string_types)):
+            isinstance(expected, str)):
         assert len(expected) == len(actual), "Expected {}, got {}".format(expected, actual)
         for exp, act in zip(expected, actual):
             compare(exp, act)

--- a/nixio/test/test_validator.py
+++ b/nixio/test/test_validator.py
@@ -1,4 +1,3 @@
-from __future__ import (absolute_import, division, print_function)
 import nixio as nix
 import numpy as np
 import os

--- a/nixio/test/tmp.py
+++ b/nixio/test/tmp.py
@@ -3,7 +3,7 @@ import shutil
 from tempfile import mkdtemp
 
 
-class TempDir(object):
+class TempDir:
 
     def __init__(self, prefix=None):
         self.path = mkdtemp(prefix=prefix)

--- a/nixio/util/find.py
+++ b/nixio/util/find.py
@@ -10,7 +10,7 @@
 import nixio
 
 
-class Cont(object):
+class Cont:
     """
     Simple container for an element an a level
     """

--- a/nixio/util/units.py
+++ b/nixio/util/units.py
@@ -7,7 +7,6 @@
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
 
-from six import string_types
 import re
 try:
     from collections.abc import Sequence
@@ -125,8 +124,8 @@ def scalable(units_a, units_b):
     :rtype: bool
     """
     if (isinstance(units_a, Sequence) and isinstance(units_b, Sequence) and
-            not isinstance(units_a, string_types) and
-            not isinstance(units_b, string_types)):
+            not isinstance(units_a, str) and
+            not isinstance(units_b, str)):
         if len(units_a) != len(units_b):
             return False
         for unit_a, unit_b in zip(units_a, units_b):

--- a/nixio/util/util.py
+++ b/nixio/util/util.py
@@ -6,7 +6,6 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
-from six import string_types
 import numpy as np
 
 import h5py
@@ -129,8 +128,6 @@ def check_attr_type(value, type_):
     :param value: the value to check
     :param type_: the type to check against
     """
-    if type_ is str:
-        type_ = string_types
     if value is not None and not isinstance(value, type_):
         raise exceptions.InvalidAttrType(type_, value)
 

--- a/nixio/validator.py
+++ b/nixio/validator.py
@@ -10,7 +10,7 @@ from .util import units
 from .dimension_type import DimensionType
 
 
-class ValidationError(object):
+class ValidationError:
     """
     Static class for defining validation error messages
     """
@@ -77,7 +77,7 @@ class ValidationError(object):
     NoLinkType = "link_type is not set"
 
 
-class ValidationWarning(object):
+class ValidationWarning:
     NoVersion = "version is not set"
     NoFormat = "format is not set"
     NoFileID = "file ID is not set"

--- a/nixio/validator.py
+++ b/nixio/validator.py
@@ -6,7 +6,6 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted under the terms of the BSD License. See
 # LICENSE file in the root of the Project.
-from __future__ import (absolute_import, division, print_function)
 from .util import units
 from .dimension_type import DimensionType
 


### PR DESCRIPTION
Hi !

I saw this new package in Debian today popping up in my QA list.

Here's a cleanup of Python2 code.


@emollier : please remove python3-six dependency when a new release is published, or I'll do if I notice first

https://tracker.debian.org/pkg/python-nixio

https://salsa.debian.org/detiste-guest/python3-six-removal/-/commit/b3218f61adb31c09cac2de735fd83997abe9b707