### PR TITLE
Numpy

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -58,6 +58,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
         with:
+          miniconda-version: "latest"
           activate-environment: deptest-${{ matrix.python-version }}
           python-version: ${{ matrix.python-version }}
           channels: conda-forge

--- a/docs/source/examples/multiple_regions.py
+++ b/docs/source/examples/multiple_regions.py
@@ -70,8 +70,9 @@ def plot(nixfile):
         rect = patches.Rectangle((interval, 1.05), extent, -2.1, alpha=0.5,
                                  facecolor="silver", edgecolor='k', lw=0.75, ls='--')
         ax.add_patch(rect)
+        stim_freq = mtag.feature_data(i, "stimulus frequency")[:]  # should be scalar, we will use item() to read it
         ax.text(interval + extent / 2, -1.25,
-                "%.1f %s" % (mtag.feature_data(i, "stimulus frequency")[:],
+                "%.1f %s" % (stim_freq.item(),
                              mtag.features["stimulus frequency"].data.unit), fontsize=8, ha="center")
     ax.legend((l, rect), (signal_da.name, mtag.name), loc=1, frameon=False, ncol=2)
 

--- a/docs/source/examples/spikeFeatures.py
+++ b/docs/source/examples/spikeFeatures.py
@@ -15,8 +15,8 @@
 
 """
 
-import nixio
 import lif
+import nixio
 import numpy as np
 import scipy.signal as signal
 import matplotlib.pylab as plt
@@ -68,7 +68,7 @@ def plot_data(tag):
     average_snippet_axis = plt.subplot2grid((2, 2), (1, 1), rowspan=1, colspan=1)
 
     response_axis.plot(time, voltage, color='dodgerblue', label=data_array.name)
-    response_axis.scatter(spike_times, np.ones(spike_times.shape)*np.max(voltage), color='red', label=tag.name)
+    response_axis.scatter(spike_times, np.ones(spike_times.shape) * np.max(voltage), color='red', label=tag.name)
     response_axis.set_xlabel(x_axis.label + ((" [" + x_axis.unit + "]") if x_axis.unit else ""))
     response_axis.set_ylabel(data_array.label + ((" [" + data_array.unit + "]") if data_array.unit else ""))
     response_axis.set_title(data_array.name)
@@ -81,7 +81,7 @@ def plot_data(tag):
     single_snippet_axis.set_ylabel(feature_data_array.label + ((" [" + feature_data_array.unit + "]") if feature_data_array.unit else ""))
     single_snippet_axis.set_title("single stimulus snippet")
     single_snippet_axis.set_xlim(np.min(snippet_time), np.max(snippet_time))
-    single_snippet_axis.set_ylim((1.2 * np.min(snippets[3,:]), 1.2 * np.max(snippets[3,:])))
+    single_snippet_axis.set_ylim((1.2 * np.min(snippets[3, :]), 1.2 * np.max(snippets[3, :])))
     single_snippet_axis.legend()
 
     mean_snippet = np.mean(snippets, axis=0)
@@ -129,7 +129,7 @@ def main():
     # save stimulus snippets in a DataArray
     snippets = block.create_data_array("spike triggered stimulus", "nix.regular_sampled.multiple_series", data=sts, label="stimulus", unit="nA")
     snippets.append_set_dimension()
-    snippets.append_sampled_dimension(stepsize, offset= -sta_offset * stepsize, label="time", unit="s")
+    snippets.append_sampled_dimension(stepsize, offset=-sta_offset * stepsize, label="time", unit="s")
 
     # set snippets as an indexed feature of the multi_tag
     multi_tag.create_feature(snippets, nixio.LinkType.Indexed)

--- a/docs/source/examples/taggedFeature.py
+++ b/docs/source/examples/taggedFeature.py
@@ -33,7 +33,7 @@ def fake_neuron(stepsize=0.001, offset=.8):
 
 
 def main():
-    stepsize = 0.0001 # s
+    stepsize = 0.0001  # s
     time, voltage, stimulus, spike_times = fake_neuron(stepsize=0.0001)
 
     # create a new file overwriting any existing content
@@ -90,7 +90,7 @@ def plot_data(tag):
     stim_at_spike_time = np.zeros(len(tag.positions[:]))
 
     for i in range(len(tag.positions)):
-        stim_at_spike_time[i] = tag.feature_data(i, 0)[:]
+        stim_at_spike_time[i] = tag.feature_data(i, 0)[:].item()
 
     response_axis = plt.subplot2grid((2, 3), (0, 0), rowspan=1, colspan=2)
     stimulus_axis = plt.subplot2grid((2, 3), (1, 0), rowspan=1, colspan=2, sharex=response_axis)
@@ -109,7 +109,7 @@ def plot_data(tag):
     response_axis.legend(loc="lower center", ncol=2, fontsize=8)
 
     stimulus_axis.plot(stimulus_time, stimulus, color="darkgray", label="stimulus", lw=1)
-    stimulus_axis.scatter(spike_times, np.ones(spike_times.shape)*np.max(stimulus), color='red', label=tag.name)
+    stimulus_axis.scatter(spike_times, np.ones(spike_times.shape) * np.max(stimulus), color='red', label=tag.name)
     stimulus_axis.set_xlabel(stim_time_dim.label + ((" [" + stim_time_dim.unit + "]") if stim_time_dim.unit else ""))
     stimulus_axis.set_ylabel(feature_data_array.label + ((" [" + feature_data_array.unit + "]") if feature_data_array.unit else ""))
     stimulus_axis.set_xlim(np.min(stimulus_time), np.max(stimulus_time))
@@ -121,6 +121,6 @@ def plot_data(tag):
     # plt.savefig('../images/tagged_feature.png')
     plt.show()
 
+
 if __name__ == '__main__':
     main()
-

--- a/docs/source/examples/untaggedFeature.py
+++ b/docs/source/examples/untaggedFeature.py
@@ -15,8 +15,8 @@
 
 """
 
-import nixio
 import lif
+import nixio
 import numpy as np
 import scipy.signal as signal
 import matplotlib.pylab as plt
@@ -25,15 +25,15 @@ import matplotlib.pylab as plt
 def fake_neuron(stepsize=0.001, offset=.8):
     stimulus = np.random.randn(82000) * 2.5
 
-    b, a = signal.butter(2, 12.5, fs=1/stepsize, btype="low")
+    b, a = signal.butter(2, 12.5, fs=1 / stepsize, btype="low")
     stimulus = signal.filtfilt(b, a, stimulus[:])
     stimulus = stimulus[1000:-1000]
     s = np.hstack((np.zeros(10000), stimulus, np.zeros(10000)))
     lif_model = lif.LIF(stepsize=stepsize, offset=offset)
     time, v, spike_times = lif_model.run_stimulus(s)
 
-    stimulus_onset = 10000*stepsize
-    stimulus_duration = len(stimulus)*stepsize
+    stimulus_onset = 10000 * stepsize
+    stimulus_duration = len(stimulus) * stepsize
 
     return time, v, stimulus, stimulus_onset, stimulus_duration
 
@@ -73,7 +73,7 @@ def plot_data(tag):
     response_axis.set_ylabel(data_array.label + ((" [" + data_array.unit + "]") if data_array.unit else ""))
     response_axis.set_xlim(0, np.max(time))
     response_axis.set_ylim((1.2 * np.min(voltage), 1.2 * np.max(voltage)))
-    response_axis.barh((np.max(voltage) - np.min(voltage))/2, stimulus_duration, np.min(voltage) - np.max(voltage),
+    response_axis.barh((np.max(voltage) - np.min(voltage)) / 2, stimulus_duration, np.min(voltage) - np.max(voltage),
                        stimulus_onset, color='silver', alpha=0.5, zorder=0, label="stimulus epoch")
     response_axis.legend(fontsize=9, ncol=2, loc=9)
 

--- a/nixio/datatype.py
+++ b/nixio/datatype.py
@@ -8,6 +8,7 @@
 # LICENSE file in the root of the Project.
 from numbers import Integral, Real
 from six import string_types
+from packaging import version
 
 import numpy as np
 
@@ -26,7 +27,10 @@ class DataType(object):
     Int64 = np.int64
     Float = np.float32
     Double = np.double
-    String = np.unicode_
+    if version.parse(np.__version__) < version.parse("2.0"):
+        String = np.unicode_
+    else:
+        String = np.str_
     Bool = np.bool_
 
     # type groups

--- a/nixio/test/test_doc_examples.py
+++ b/nixio/test/test_doc_examples.py
@@ -1,14 +1,12 @@
-import importlib.util as getmod
-import os
-import runpy
 import sys
+import runpy
 import unittest
+import importlib.util
+import importlib.machinery
+import matplotlib.pyplot as plt
 
 from pathlib import Path
 from shutil import copyfile
-
-import matplotlib.pyplot as plt
-
 
 TEST_IMAGE = "lenna.png"
 
@@ -23,22 +21,25 @@ class TestDocumentationExamples(unittest.TestCase):
 
     def handle_lif(self):
         lif_path = Path.joinpath(self.examples_path, "lif.py")
-        spec = getmod.spec_from_file_location("lif", str(lif_path))
-        spec.loader.load_module("lif")
+        print(lif_path)
+        spec = importlib.util.spec_from_file_location("lif", lif_path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules["lif"] = module
+        spec.loader.exec_module(module)
 
     def handle_image(self):
         image_path = Path.joinpath(self.examples_path, TEST_IMAGE)
-        copyfile(str(image_path), str(Path.joinpath(Path(os.getcwd()), TEST_IMAGE)))
+        copyfile(str(image_path), str(Path.joinpath(Path(Path.cwd()), TEST_IMAGE)))
 
     def setUp(self):
-        curr_path = os.getcwd()
-        if os.path.basename(curr_path) == "nixpy":
+        curr_path = Path.cwd()
+        if curr_path.stem == "nixpy":
             self.examples_path = Path.joinpath(Path(curr_path),
                                                "docs", "source", "examples")
-        elif os.path.basename(curr_path) == "nixio":
+        elif curr_path.stem == "nixio":
             self.examples_path = Path.joinpath(Path(curr_path).parent,
                                                "docs", "source", "examples")
-        elif os.path.basename(curr_path) == "test":
+        elif curr_path.stem == "test":
             self.examples_path = Path.joinpath(Path(curr_path).parent.parent,
                                                "docs", "source", "examples")
 
@@ -48,28 +49,28 @@ class TestDocumentationExamples(unittest.TestCase):
     def tearDown(self):
         plt.close("all")
         plt.ioff()
-        if os.path.exists(TEST_IMAGE):
-            os.remove(TEST_IMAGE)
+        if Path.exists(Path("TEST_IMAGE")):
+            Path.unlink(Path(TEST_IMAGE))
 
     def test_annotations(self):
         self.run_script("annotations.py")
         # cleanup
-        os.remove("annotations.nix")
+        Path.unlink(Path("annotations.nix"))
 
     def test_category_data(self):
         self.run_script("categoryData.py")
         # cleanup
-        os.remove("categoryData.nix")
+        Path.unlink(Path("categoryData.nix"))
 
     def test_continuous_recording(self):
         self.run_script("continuousRecording.py")
         # cleanup
-        os.remove("continuous_recording.nix")
+        Path.unlink(Path("continuous_recording.nix"))
 
     def test_file_create(self):
         self.run_script("fileCreate.py")
         # cleanup
-        os.remove("file_create_example.nix")
+        Path.unlink(Path("file_create_example.nix"))
 
     def test_image_data(self):
         # test will open image with an external program; does not work on windows
@@ -78,20 +79,20 @@ class TestDocumentationExamples(unittest.TestCase):
             self.handle_image()
             self.run_script("imageData.py")
             # cleanup
-            os.remove("image_example.nix")
+            Path.unlink(Path("image_example.nix"))
 
     def test_image_with_metadata(self):
         # Requires PIL package and the "Lenna" image.
         self.handle_image()
         self.run_script("imageWithMetadata.py")
         # cleanup
-        os.remove("image_with_source_example.h5")
-        os.remove("image_with_metadata.png")
+        Path.unlink(Path("image_with_source_example.h5"))
+        Path.unlink(Path("image_with_metadata.png"))
 
     def test_irregularly_sampled_data(self):
         self.run_script("irregularlySampledData.py")
         # cleanup
-        os.remove("irregular_data_example.nix")
+        Path.unlink(Path("irregular_data_example.nix"))
 
     def test_lif(self):
         self.run_script("lif.py")
@@ -99,29 +100,29 @@ class TestDocumentationExamples(unittest.TestCase):
     def test_multiple_points(self):
         self.run_script("multiple_points.py")
         # cleanup
-        os.remove("multiple_points.nix")
+        Path.unlink(Path("multiple_points.nix"))
 
     def test_multiple_regions(self):
         self.run_script("multiple_regions.py")
         # cleanup
-        os.remove("multiple_regions.nix")
+        Path.unlink(Path("multiple_regions.nix"))
 
     def test_multiple_rois(self):
         # Requires PIL package and the "Lenna" image.
         self.handle_image()
         self.run_script("multipleROIs.py")
         # cleanup
-        os.remove("multiple_roi.nix")
+        Path.unlink(Path("multiple_roi.nix"))
 
     def test_range_dimension_link(self):
         self.run_script("rangeDimensionLink.py")
         # cleanup
-        os.remove("range_link.nix")
+        Path.unlink(Path("range_link.nix"))
 
     def test_regularly_sampled_data(self):
         self.run_script("regularlySampledData.py")
         # cleanup
-        os.remove("regular_data_example.nix")
+        Path.unlink(Path("regular_data_example.nix"))
 
     def test_single_roi(self):
         # test will open image with an external program; does not work on windows
@@ -130,44 +131,44 @@ class TestDocumentationExamples(unittest.TestCase):
             self.handle_image()
             self.run_script("singleROI.py")
             # cleanup
-            os.remove("single_roi.nix")
+            Path.unlink(Path("single_roi.nix"))
 
     def test_sources(self):
         self.run_script("sources.py")
         # cleanup
-        os.remove("sources.nix")
+        Path.unlink(Path("sources.nix"))
 
     def test_spike_features(self):
         # Requires scipy package and "lif.py"
         self.handle_lif()
         self.run_script("spikeFeatures.py")
         # cleanup
-        os.remove("spike_features.h5")
+        Path.unlink(Path("spike_features.h5"))
 
     def test_spike_tagging(self):
         # Requires "lif.py"
         self.handle_lif()
         self.run_script("spikeTagging.py")
         # cleanup
-        os.remove("spike_tagging.nix")
+        Path.unlink(Path("spike_tagging.nix"))
 
     def test_tabular_data(self):
         self.run_script("tabulardata.py")
         # cleanup
-        os.remove("dataframe.nix")
+        Path.unlink(Path("dataframe.nix"))
 
     def test_tagged_feature(self):
         # Requires scipy package and "lif.py"
         self.handle_lif()
         self.run_script("taggedFeature.py")
         # cleanup
-        os.remove("spike_features.nix")
+        Path.unlink(Path("spike_features.nix"))
 
     def test_tagging_example(self):
         # Requires scipy package
         self.run_script("tagging_example.py")
         # cleanup
-        os.remove("tagging1.nix")
+        Path.unlink(Path("tagging1.nix"))
 
     def test_tagging_nd(self):
         # not testing any nix feature
@@ -179,4 +180,4 @@ class TestDocumentationExamples(unittest.TestCase):
         self.handle_lif()
         self.run_script("untaggedFeature.py")
         # cleanup
-        os.remove("untagged_feature.h5")
+        Path.unlink(Path("untagged_feature.h5"))

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
     tests_require=['pytest', 'scipy', 'pillow', 'matplotlib'],
     test_suite='pytest',
     setup_requires=['pytest-runner'],
-    install_requires=['numpy', 'h5py', 'six', 'enum34;python_version<"3.4"'],
+    install_requires=['numpy<2.0', 'h5py', 'six', 'enum34;python_version<"3.4"'],
     package_data={'nixio': [license_text, description_text]},
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
With numpy 2.0 we run into several issues. One is solved here, but there are more changes regarding string/unicode handling that kill the continuous integration at the moment. Most of them I could not reproduce locally. As an intermediate solution I limited numpy to versions less than 2.0.

This pr fixes:
* miniconda action by specifying the version to "latest"
* switches to ``pathlib`` instead of ``os`` in test_docs
* load_module deprecation

@achilleas-k if you could spare a quick look ;)