### PR TITLE
d/s/conf.py: move to modern intersphinx_mapping.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,5 +35,5 @@ except ImportError:
     html_theme = 'default'
 
 # intersphinx configuration
-intersphinx_mapping = {'http://docs.python.org/': None,
-                       'http://docs.scipy.org/doc/numpy': None}
+intersphinx_mapping = {'python': ['http://docs.python.org/', None],
+                       'scipy': ['http://docs.scipy.org/doc/numpy', None] }


### PR DESCRIPTION
Since Sphinx 8.0, support for the old intersphinx_mapping format has been removed.  Attempts to build the documentation result in the following errors:

	Running Sphinx v8.1.3
	loading translations [en]... done
	making output directory... done
	Converting `source_suffix = '.rst'` to `source_suffix = {'.rst': 'restructuredtext'}`.
	ERROR: Invalid value `None` in intersphinx_mapping['http://docs.python.org/']. Expected a two-element tuple or list.
	ERROR: Invalid value `None` in intersphinx_mapping['http://docs.scipy.org/doc/numpy']. Expected a two-element tuple or list.

This change migrates intersphinx_mapping to the new format.

This has been initially reported as [Debian bug #1090153].

[Debian bug #1090153]: https://bugs.debian.org/1090153