### PR TITLE
Remove deprecated pytest-runner dependency

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -29,7 +29,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Run install
       run: |
-        pip install setuptools
         pip install .
     - name: Lint with Pylint
       run: |
@@ -38,7 +37,7 @@ jobs:
         pylint --rcfile=.pylintrc nixio
     - name: Test with pytest
       run: |
-        pip install pytest scipy pillow matplotlib
+        pip install .[test]
         # pytest will skip cross-compatibility tests since NIX isn't installed
         pytest
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,7 +64,8 @@ build_script:
 test_script:
   # TODO: Force cross-compatibility tests
   # - python setup.py test --addopts "--force-compat"
-  - python setup.py test --addopts "-nauto"
+  # - python setup.py test --addopts "-nauto"
+  - pytest -nauto
 
 after_test:
   - ps: mkdir "$env:DEPLOY_DIR"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,9 +17,12 @@ environment:
 
 
   matrix:
-    - PYTHON: "C:/Python38-x64"
-    - PYTHON: "C:/Python311-x64"
-    
+    # - PYTHON: "C:/Python38-x64"
+    # - PYTHON: "C:/Python311-x64"
+    - TOXENV: py39    # https://devguide.python.org/versions
+    - TOXENV: py311
+    - TOXENV: py313
+  
 init:
   - "ECHO %PYTHON% %vcvars% (%bits%)"
   - ps: $env:PATH = "$env:PYTHON;$env:PATH;C:\Program Files\7-Zip;$env:NIX_DIR\bin"
@@ -54,6 +57,7 @@ install:
   - python -m pip install certifi
   - python -m pip install -U pip wheel
   - python -m pip install numpy h5py pytest pytest-xdist scipy pillow matplotlib
+  - python -m pip install tox
   - ps: cd "$env:APPVEYOR_BUILD_FOLDER"
   - set DISTUTILS_USE_SDK="1"
   - set MSSdk="1"
@@ -65,7 +69,7 @@ test_script:
   # TODO: Force cross-compatibility tests
   # - python setup.py test --addopts "--force-compat"
   # - python setup.py test --addopts "-nauto"
-  - pytest -nauto
+  - py -m tox
 
 after_test:
   - ps: mkdir "$env:DEPLOY_DIR"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,7 +53,7 @@ install:
   # - cd ..
   - python -m pip install certifi
   - python -m pip install -U pip wheel
-  - python -m pip install numpy h5py pytest-xdist scipy pillow matplotlib
+  - python -m pip install numpy h5py pytest pytest-xdist scipy pillow matplotlib
   - ps: cd "$env:APPVEYOR_BUILD_FOLDER"
   - set DISTUTILS_USE_SDK="1"
   - set MSSdk="1"

--- a/setup.py
+++ b/setup.py
@@ -80,9 +80,9 @@ setup(
     packages=packages,
     scripts=[],
     python_requires=">=3.6",
-    tests_require=['pytest', 'scipy', 'pillow', 'matplotlib'],
-    test_suite='pytest',
-    setup_requires=['pytest-runner'],
+    extras_require={
+        "test": ['pytest', 'scipy', 'pillow', 'matplotlib', 'setuptools'],
+    },
     install_requires=['numpy', 'h5py'],
     package_data={'nixio': [license_text, description_text]},
     include_package_data=True,

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+# tox.ini
+
+[tox]
+envlist = py3{9,11,13}
+
+[testenv]
+description = Unit tests
+deps = pytest
+commands = pytest


### PR DESCRIPTION
The `pytest-runner` project has been deprecated since 2019 and has been
archived on git hub in December 2024.

This removes the dependency on the deprecated package and also removes
deprecated keywords from `setup.py` related to it.

Use the new extra to install test dependencies in CI workflow.
