### PR TITLE
Fix setup.cfg metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ all_files  = 1
 upload-dir = build/docs
 
 [metadata]
-description-file = README.rst
+description_file = README.rst
 
 [aliases]
 test=pytest


### PR DESCRIPTION
Hey guys, specifying metadata with dashes is deprecated on the last version of setuptools:

https://setuptools.pypa.io/en/stable/history.html?utm_source=chatgpt.com#bugfixes

This is causing people that want to build your package using the latest version of setuptools to fail:

https://github.com/NeuralEnsemble/python-neo/pull/1660#issuecomment-2749208250

This PR should fix it.